### PR TITLE
Add the Stremio vertical slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ pnpm install
 pnpm dev
 ```
 
+The browser checkpoint browses, searches, and resolves sources through the real Stremio Core. Torrent playback currently requires a locally running Stremio Service; native macOS playback and service packaging are the next delivery step.
+
 Run the complete local validation suite with:
 
 ```sh

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -14,8 +14,10 @@
     "@fontsource-variable/geist": "5.3.0",
     "@kino/design-tokens": "workspace:*",
     "@phosphor-icons/react": "2.1.10",
+    "@stremio/stremio-core-web": "0.61.0",
     "react": "19.2.8",
-    "react-dom": "19.2.8"
+    "react-dom": "19.2.8",
+    "theintrodb": "3.2.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "7.0.1",

--- a/apps/desktop/src/App.module.css
+++ b/apps/desktop/src/App.module.css
@@ -19,7 +19,8 @@
 }
 
 .logoButton,
-.navButton {
+.navButton,
+.profileButton {
   display: grid;
   width: 42px;
   height: 42px;
@@ -34,6 +35,17 @@
     color var(--kino-duration-fast) ease,
     background-color var(--kino-duration-fast) ease,
     transform var(--kino-duration-fast) var(--kino-ease-out);
+}
+
+.profileButton {
+  width: 30px;
+  height: 30px;
+  margin-top: auto;
+  border-radius: 50%;
+  color: var(--kino-text-muted);
+  background: var(--kino-border);
+  font-size: 11px;
+  font-weight: 650;
 }
 
 .logoButton {
@@ -84,6 +96,751 @@
   width: min(100%, 1500px);
   min-height: 100%;
   padding: 44px var(--kino-page-gutter) 64px;
+}
+
+.homePage {
+  width: min(100%, 1600px);
+  min-height: 100%;
+  padding: 36px var(--kino-page-gutter) 64px;
+}
+
+.homeSection {
+  margin-top: 28px;
+}
+
+.homeSection:first-of-type {
+  margin-top: 0;
+}
+
+.homeSection h2,
+.detailSection h2 {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.sectionHeading,
+.detailSectionHeading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 8px;
+}
+
+.sectionHeading span,
+.detailSectionHeading > span {
+  color: var(--kino-text-faint);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.mediaRow,
+.continueRow {
+  display: flex;
+  gap: 16px;
+  padding: 8px 2px 12px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x proximity;
+}
+
+.mediaCard {
+  display: flex;
+  width: 152px;
+  flex: 0 0 auto;
+  flex-direction: column;
+  padding: 0;
+  border: 0;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
+  scroll-snap-align: start;
+}
+
+.posterFrame {
+  position: relative;
+  display: grid;
+  width: 100%;
+  aspect-ratio: 2 / 3;
+  overflow: hidden;
+  place-items: center;
+  border-radius: var(--kino-media-radius);
+  background: var(--kino-surface);
+  transition:
+    transform 220ms var(--kino-ease-out),
+    box-shadow 220ms ease;
+}
+
+.mediaCard:hover .posterFrame,
+.mediaCard:focus-visible .posterFrame {
+  transform: scale(1.025);
+  box-shadow: inset 0 0 0 1.5px rgb(255 255 255 / 50%);
+}
+
+.poster {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.posterFallback {
+  color: var(--kino-text-faint);
+  font-size: 40px;
+  font-weight: 300;
+}
+
+.watchedBadge {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  padding: 4px 7px;
+  border: 1px solid rgb(255 255 255 / 14%);
+  border-radius: var(--kino-pill-radius);
+  color: var(--kino-text);
+  background: rgb(10 10 11 / 76%);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.mediaTitle,
+.mediaMeta {
+  width: 100%;
+  text-align: center;
+}
+
+.mediaTitle {
+  margin-top: 10px;
+  overflow: hidden;
+  color: rgb(255 255 255 / 92%);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mediaMeta {
+  margin-top: 3px;
+  color: var(--kino-text-faint);
+  font-size: 12px;
+  text-transform: capitalize;
+}
+
+.mediaSkeleton {
+  width: 152px;
+  flex: 0 0 auto;
+  aspect-ratio: 2 / 3;
+  border-radius: var(--kino-media-radius);
+  background: var(--kino-surface);
+  animation: pulse 1.4s ease-in-out infinite alternate;
+}
+
+.inlineEmpty,
+.loadError {
+  margin: 14px 0 0;
+  color: var(--kino-text-faint);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.loadError {
+  color: var(--kino-danger);
+}
+
+.continueCard {
+  width: 264px;
+  flex: 0 0 auto;
+  padding: 0;
+  border: 0;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
+}
+
+.continueArtwork {
+  position: relative;
+  display: flex;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  align-items: flex-end;
+  border-radius: var(--kino-media-radius);
+  background: var(--kino-surface);
+}
+
+.continueArtwork::after {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgb(0 0 0 / 70%), transparent 70%);
+  content: '';
+}
+
+.continueArtwork img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.continueLabel {
+  position: relative;
+  z-index: 1;
+  padding: 14px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.progressTrack {
+  position: absolute;
+  z-index: 2;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  background: rgb(255 255 255 / 16%);
+}
+
+.progressTrack span {
+  display: block;
+  height: 100%;
+  background: var(--kino-accent);
+}
+
+.mediaGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 24px 16px;
+  margin-top: 28px;
+}
+
+.mediaGrid .mediaCard {
+  width: 100%;
+}
+
+.detailPage {
+  min-height: 100%;
+}
+
+.detailHero {
+  position: relative;
+  display: flex;
+  height: 400px;
+  overflow: hidden;
+  align-items: flex-end;
+  background: var(--kino-surface);
+}
+
+.detailBackdrop,
+.detailShade {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.detailBackdrop {
+  object-fit: cover;
+}
+
+.detailShade {
+  background: linear-gradient(
+    to top,
+    var(--kino-bg) 0%,
+    rgb(10 10 11 / 24%) 54%,
+    rgb(10 10 11 / 60%) 100%
+  );
+}
+
+.backButton {
+  position: absolute;
+  top: 28px;
+  left: var(--kino-page-gutter);
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 0;
+  border: 0;
+  color: var(--kino-text-muted);
+  background: transparent;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.detailCopy {
+  position: relative;
+  width: min(740px, 100%);
+  padding: 0 var(--kino-page-gutter) 38px;
+}
+
+.detailCopy h1 {
+  margin: 0;
+  font-size: clamp(34px, 5vw, 48px);
+  font-weight: 700;
+  line-height: 1.04;
+  letter-spacing: -0.035em;
+}
+
+.detailMetadata,
+.detailDescription {
+  margin: 10px 0 0;
+}
+
+.detailMetadata {
+  color: var(--kino-text-muted);
+  font-size: 13px;
+  font-weight: 500;
+  text-transform: capitalize;
+}
+
+.detailDescription {
+  display: -webkit-box;
+  overflow: hidden;
+  color: #c9c9ce;
+  font-size: 14px;
+  line-height: 1.55;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.detailBody {
+  width: min(100%, 1160px);
+  padding: 6px var(--kino-page-gutter) 72px;
+}
+
+.detailSection {
+  margin-top: 34px;
+}
+
+.seasonTabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.seasonButton,
+.seasonActive {
+  min-height: 32px;
+  padding: 0 14px;
+  border: 1px solid var(--kino-border);
+  border-radius: var(--kino-pill-radius);
+  color: var(--kino-text-muted);
+  background: transparent;
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.seasonActive {
+  border-color: var(--kino-accent);
+  color: var(--kino-on-accent);
+  background: var(--kino-accent);
+}
+
+.episodeList,
+.sourceList {
+  border-top: 1px solid var(--kino-border-subtle);
+}
+
+.episodeButton,
+.episodeActive,
+.sourceButton {
+  display: grid;
+  width: 100%;
+  min-height: 64px;
+  align-items: center;
+  padding: 10px 12px;
+  border: 0;
+  border-bottom: 1px solid var(--kino-border-subtle);
+  color: var(--kino-text);
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.episodeButton,
+.episodeActive {
+  grid-template-columns: 38px minmax(0, 1fr) auto;
+  gap: 14px;
+}
+
+.episodeButton:hover,
+.episodeActive,
+.sourceButton:hover:not(:disabled) {
+  background: var(--kino-surface-hover);
+}
+
+.episodeNumber {
+  color: var(--kino-text-faint);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.episodeButton strong,
+.episodeActive strong,
+.episodeButton small,
+.episodeActive small,
+.sourcePrimary strong,
+.sourcePrimary small {
+  display: block;
+}
+
+.episodeButton strong,
+.episodeActive strong,
+.sourcePrimary strong {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.episodeButton small,
+.episodeActive small {
+  display: -webkit-box;
+  margin-top: 4px;
+  overflow: hidden;
+  color: var(--kino-text-faint);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.4;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+}
+
+.sourceButton {
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
+}
+
+.sourceButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.sourcePrimary small {
+  max-width: 74ch;
+  margin-top: 5px;
+  overflow: hidden;
+  color: var(--kino-text-faint);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sourceMeta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--kino-text-faint);
+  font-size: 11px;
+}
+
+.sourceMeta em {
+  color: var(--kino-danger);
+  font-style: normal;
+}
+
+.player {
+  position: fixed;
+  z-index: var(--kino-layer-dialog);
+  inset: 0;
+  overflow: hidden;
+  color: var(--kino-text);
+  background: #000;
+}
+
+.player video {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.playerTopbar {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  padding: 24px 30px 70px;
+  background: linear-gradient(to bottom, rgb(0 0 0 / 78%), transparent);
+}
+
+.playerTopbar button,
+.controlRow button,
+.skipNotice button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 38px;
+  padding: 0 12px;
+  border: 0;
+  border-radius: var(--kino-control-radius);
+  color: var(--kino-text);
+  background: rgb(20 20 23 / 76%);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.playerTopbar > div {
+  display: grid;
+  gap: 3px;
+}
+
+.playerTopbar strong {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.playerTopbar span {
+  color: var(--kino-text-muted);
+  font-size: 12px;
+}
+
+.playerStatus {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: grid;
+  gap: 6px;
+  color: var(--kino-text-muted);
+  font-size: 13px;
+  text-align: center;
+  transform: translate(-50%, -50%);
+}
+
+.playerStatus strong {
+  color: var(--kino-text);
+  font-size: 16px;
+}
+
+.skipIntro {
+  position: absolute;
+  right: 36px;
+  bottom: 120px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 11px 22px;
+  border: 0;
+  border-radius: 6px;
+  color: var(--kino-on-accent);
+  background: var(--kino-accent);
+  font: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  animation: enter var(--kino-duration-standard) var(--kino-ease-out);
+}
+
+.skipNotice {
+  position: absolute;
+  right: 36px;
+  bottom: 120px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 8px 8px 8px 16px;
+  border: 1px solid rgb(255 255 255 / 14%);
+  border-radius: var(--kino-control-radius);
+  background: rgb(10 10 11 / 88%);
+  font-size: 13px;
+}
+
+.skipNotice button {
+  min-height: 30px;
+  color: var(--kino-on-accent);
+  background: var(--kino-accent);
+}
+
+.playerControls {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  padding: 68px 30px 24px;
+  background: linear-gradient(to top, rgb(0 0 0 / 86%), transparent);
+}
+
+.timeline {
+  position: relative;
+  height: 18px;
+}
+
+.timeline input {
+  position: relative;
+  z-index: 2;
+  width: 100%;
+  margin: 0;
+  accent-color: var(--kino-accent);
+  cursor: pointer;
+}
+
+.introRange {
+  position: absolute;
+  z-index: 1;
+  top: 7px;
+  height: 4px;
+  border-radius: var(--kino-pill-radius);
+  background: #c9a96b;
+}
+
+.controlRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.controlRow button {
+  width: 40px;
+  padding: 0;
+  background: transparent;
+}
+
+.controlRow button:last-child {
+  margin-left: auto;
+}
+
+.timeLabel {
+  color: var(--kino-text-muted);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.dialogBackdrop {
+  position: fixed;
+  z-index: calc(var(--kino-layer-dialog) + 1);
+  inset: 0;
+  display: grid;
+  padding: 24px;
+  place-items: center;
+  background: rgb(0 0 0 / 72%);
+  backdrop-filter: blur(12px);
+}
+
+.accountDialog {
+  position: relative;
+  width: min(100%, 420px);
+  padding: 34px;
+  border: 1px solid var(--kino-border);
+  border-radius: var(--kino-panel-radius);
+  background: var(--kino-surface);
+  box-shadow: 0 24px 80px rgb(0 0 0 / 48%);
+  animation: enter var(--kino-duration-standard) var(--kino-ease-out);
+}
+
+.accountDialog > img {
+  width: 24px;
+  height: 24px;
+  margin-bottom: 24px;
+}
+
+.accountDialog h1 {
+  margin: 0;
+  font-size: 24px;
+  letter-spacing: -0.025em;
+}
+
+.accountDialog p {
+  margin: 10px 0 24px;
+  color: var(--kino-text-muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.accountDialog form {
+  display: grid;
+}
+
+.accountDialog label {
+  margin: 14px 0 7px;
+  color: var(--kino-text-muted);
+  font-size: 12px;
+  font-weight: 550;
+}
+
+.accountDialog input {
+  width: 100%;
+  height: 42px;
+  padding: 0 12px;
+  border: 1px solid var(--kino-border);
+  border-radius: var(--kino-control-radius);
+  outline: 0;
+  color: var(--kino-text);
+  background: var(--kino-bg);
+  font: inherit;
+  font-size: 14px;
+}
+
+.accountDialog input:focus {
+  border-color: var(--kino-text-muted);
+}
+
+.dialogClose {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  display: grid;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  place-items: center;
+  border: 0;
+  border-radius: var(--kino-control-radius);
+  color: var(--kino-text-muted);
+  background: transparent;
+  cursor: pointer;
+}
+
+.primaryAction,
+.secondaryAction {
+  min-height: 42px;
+  margin-top: 22px;
+  padding: 0 18px;
+  border: 1px solid var(--kino-accent);
+  border-radius: var(--kino-control-radius);
+  color: var(--kino-on-accent);
+  background: var(--kino-accent);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.secondaryAction {
+  color: var(--kino-text);
+  background: transparent;
+}
+
+.primaryAction:disabled,
+.dialogClose:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+.accountDialog .formError {
+  margin: 12px 0 0;
+  color: var(--kino-danger);
+}
+
+@keyframes pulse {
+  from {
+    opacity: 0.55;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 .narrowPage {
@@ -329,6 +1086,10 @@
     display: none;
   }
 
+  .profileButton {
+    display: none;
+  }
+
   .navGroup {
     flex-direction: row;
     gap: 4px;
@@ -341,6 +1102,43 @@
   .page {
     padding: 32px 22px 48px;
   }
+
+  .homePage {
+    padding: 28px 22px 48px;
+  }
+
+  .mediaCard,
+  .mediaSkeleton {
+    width: 132px;
+  }
+
+  .detailHero {
+    height: 360px;
+  }
+
+  .detailCopy,
+  .detailBody {
+    padding-right: 22px;
+    padding-left: 22px;
+  }
+
+  .backButton {
+    left: 22px;
+  }
+
+  .detailSectionHeading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .sourceButton {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 8px;
+  }
+
+  .sourceMeta {
+    flex-wrap: wrap;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -352,6 +1150,10 @@
   .navButton,
   .switch,
   .switch span {
+    transition: none;
+  }
+
+  .mediaCard .posterFrame {
     transition: none;
   }
 }

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -46,4 +46,18 @@ describe('App', () => {
       automaticIntroSkipping: true,
     });
   });
+
+  it('opens and dismisses Stremio sign-in without leaving the current screen', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(screen.getByRole('button', { name: 'Sign in to Stremio' }));
+
+    expect(screen.getByRole('dialog', { name: 'Sign in to Stremio' })).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByRole('dialog', { name: 'Sign in to Stremio' })).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Home' })).toBeInTheDocument();
+  });
 });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -11,10 +11,18 @@ import { useEffect, useState } from 'react';
 
 import logo from './assets/kino.svg';
 import styles from './App.module.css';
+import { AccountDialog } from './components/AccountDialog';
+import type { PlaybackSelection } from './core/actions';
+import type { CoreMetaPreview, ProfileState } from './core/types';
+import { useCoreModel } from './core/useCoreModel';
 import { enUS } from './locales/en-US';
+import { HomeScreen } from './screens/HomeScreen';
+import { MetaDetailsScreen } from './screens/MetaDetailsScreen';
+import { PlayerScreen } from './screens/PlayerScreen';
+import { SearchScreen } from './screens/SearchScreen';
 import { defaultSettings, loadSettings, saveSettings, type KinoSettings } from './settings';
 
-type Screen = 'home' | 'search' | 'discover' | 'library' | 'addons' | 'settings';
+type Screen = 'home' | 'search' | 'discover' | 'library' | 'addons' | 'settings' | 'detail';
 
 interface NavigationItem {
   icon: Icon;
@@ -39,47 +47,6 @@ function EmptyState({ children }: { children: string }) {
     <div className={styles.emptyState}>
       <span>{enUS.status.unavailable}</span>
       <p>{children}</p>
-    </div>
-  );
-}
-
-function HomeScreen() {
-  return (
-    <div className={styles.page}>
-      <h1>{enUS.home.title}</h1>
-      <section className={styles.section} aria-labelledby="continue-watching-title">
-        <h2 id="continue-watching-title">{enUS.home.continueWatching}</h2>
-        <EmptyState>{enUS.home.continueEmpty}</EmptyState>
-      </section>
-      <section className={styles.section} aria-labelledby="catalogs-title">
-        <h2 id="catalogs-title">{enUS.home.catalogs}</h2>
-        <EmptyState>{enUS.home.catalogsEmpty}</EmptyState>
-      </section>
-    </div>
-  );
-}
-
-function SearchScreen() {
-  const [query, setQuery] = useState('');
-
-  return (
-    <div className={styles.page}>
-      <h1 className={styles.visuallyHidden}>{enUS.search.title}</h1>
-      <label className={styles.visuallyHidden} htmlFor="catalog-search">
-        {enUS.search.placeholder}
-      </label>
-      <input
-        autoFocus
-        className={styles.searchInput}
-        id="catalog-search"
-        onChange={(event) => setQuery(event.target.value)}
-        placeholder={enUS.search.placeholder}
-        type="search"
-        value={query}
-      />
-      <p className={styles.searchHelp} role="status">
-        {query.trim() ? enUS.search.disconnected : enUS.search.idle}
-      </p>
     </div>
   );
 }
@@ -260,6 +227,11 @@ function NavigationButton({
 
 export function App() {
   const [screen, setScreen] = useState<Screen>('home');
+  const [previousScreen, setPreviousScreen] = useState<Exclude<Screen, 'detail'>>('home');
+  const [detail, setDetail] = useState<CoreMetaPreview | null>(null);
+  const [playback, setPlayback] = useState<PlaybackSelection | null>(null);
+  const [accountOpen, setAccountOpen] = useState(false);
+  const profile = useCoreModel<ProfileState>('ctx', null, 'app-profile');
   const [settings, setSettings] = useState<KinoSettings>(() =>
     typeof window === 'undefined' ? defaultSettings : loadSettings(window.localStorage),
   );
@@ -268,12 +240,24 @@ export function App() {
     saveSettings(window.localStorage, settings);
   }, [settings]);
 
+  const openDetail = (item: CoreMetaPreview) => {
+    if (screen !== 'detail') setPreviousScreen(screen);
+    setDetail(item);
+    setScreen('detail');
+  };
+
+  if (playback) {
+    return (
+      <PlayerScreen onBack={() => setPlayback(null)} selection={playback} settings={settings} />
+    );
+  }
+
   const content = (() => {
     switch (screen) {
       case 'home':
-        return <HomeScreen />;
+        return <HomeScreen onOpen={openDetail} />;
       case 'search':
-        return <SearchScreen />;
+        return <SearchScreen onOpen={openDetail} />;
       case 'discover':
         return <DiscoverScreen />;
       case 'library':
@@ -282,6 +266,16 @@ export function App() {
         return <AddonsScreen />;
       case 'settings':
         return <SettingsScreen onChange={setSettings} settings={settings} />;
+      case 'detail':
+        return detail ? (
+          <MetaDetailsScreen
+            item={detail}
+            onBack={() => setScreen(previousScreen)}
+            onPlay={setPlayback}
+          />
+        ) : (
+          <HomeScreen onOpen={openDetail} />
+        );
     }
   })();
 
@@ -317,10 +311,20 @@ export function App() {
             />
           ))}
         </nav>
+        <button
+          aria-label={profile.state?.profile.auth ? 'Stremio account' : 'Sign in to Stremio'}
+          className={styles.profileButton}
+          onClick={() => setAccountOpen(true)}
+          title={profile.state?.profile.auth ? 'Stremio account' : 'Sign in to Stremio'}
+          type="button"
+        >
+          {profile.state?.profile.auth?.user.name?.slice(0, 1).toUpperCase() || 'G'}
+        </button>
       </aside>
       <main className={styles.content} id="main-content" key={screen}>
         {content}
       </main>
+      {accountOpen ? <AccountDialog onClose={() => setAccountOpen(false)} /> : null}
     </div>
   );
 }

--- a/apps/desktop/src/components/AccountDialog.tsx
+++ b/apps/desktop/src/components/AccountDialog.tsx
@@ -1,0 +1,163 @@
+import { X } from '@phosphor-icons/react';
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
+
+import logo from '../assets/kino.svg';
+import styles from '../App.module.css';
+import { useCore } from '../core/context';
+import type { CoreRuntimeEvent, ProfileState } from '../core/types';
+import { useCoreModel } from '../core/useCoreModel';
+
+function authError(event: CoreRuntimeEvent) {
+  return event.name === 'CoreEvent' && event.args.event === 'Error';
+}
+
+export function AccountDialog({ onClose }: { onClose: () => void }) {
+  const { selectSession, session, status, transport } = useCore();
+  const profile = useCoreModel<ProfileState>('ctx', null, `account:${session}`);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const user = profile.state?.profile.auth?.user;
+
+  const close = useCallback(() => {
+    if (!user) selectSession('guest');
+    onClose();
+  }, [onClose, selectSession, user]);
+
+  useEffect(() => {
+    if (session === 'guest') selectSession('account');
+  }, [selectSession, session]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !submitting) close();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [close, submitting]);
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!transport || status !== 'ready') return;
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        let unsubscribe: () => void = () => undefined;
+        const timeout = window.setTimeout(() => {
+          unsubscribe();
+          reject(new Error('Sign-in timed out.'));
+        }, 20_000);
+        unsubscribe = transport.subscribe((coreEvent) => {
+          if (coreEvent.name === 'CoreEvent' && coreEvent.args.event === 'UserAuthenticated') {
+            window.clearTimeout(timeout);
+            unsubscribe();
+            resolve();
+          } else if (authError(coreEvent)) {
+            window.clearTimeout(timeout);
+            unsubscribe();
+            reject(new Error('Stremio did not accept those credentials.'));
+          }
+        });
+        void transport
+          .dispatch({
+            action: 'Ctx',
+            args: {
+              action: 'Authenticate',
+              args: { type: 'Login', email, password },
+            },
+          })
+          .catch((dispatchError: unknown) => {
+            window.clearTimeout(timeout);
+            unsubscribe();
+            reject(dispatchError instanceof Error ? dispatchError : new Error('Sign-in failed.'));
+          });
+      });
+      setPassword('');
+      onClose();
+    } catch (signInError) {
+      setError(signInError instanceof Error ? signInError.message : 'Sign-in failed.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className={styles.dialogBackdrop} role="presentation">
+      <section
+        aria-labelledby="account-title"
+        aria-modal="true"
+        className={styles.accountDialog}
+        role="dialog"
+      >
+        <button
+          aria-label="Close"
+          className={styles.dialogClose}
+          disabled={submitting}
+          onClick={close}
+          type="button"
+        >
+          <X aria-hidden size={18} />
+        </button>
+        <img alt="" src={logo} />
+        {user ? (
+          <>
+            <h1 id="account-title">Stremio account</h1>
+            <p>{user.email || user.name || 'Signed in'}</p>
+            <button
+              className={styles.secondaryAction}
+              onClick={() => {
+                if (!transport) return;
+                void transport
+                  .dispatch({ action: 'Ctx', args: { action: 'Logout' } })
+                  .finally(() => {
+                    selectSession('guest');
+                    onClose();
+                  });
+              }}
+              type="button"
+            >
+              Sign out
+            </button>
+          </>
+        ) : (
+          <form onSubmit={submit}>
+            <h1 id="account-title">Sign in to Stremio</h1>
+            <p>Your credentials go directly to Stremio. Kino keeps guest activity separate.</p>
+            <label htmlFor="stremio-email">Email</label>
+            <input
+              autoComplete="username"
+              autoFocus
+              disabled={status !== 'ready' || submitting}
+              id="stremio-email"
+              onChange={(event) => setEmail(event.target.value)}
+              required
+              type="email"
+              value={email}
+            />
+            <label htmlFor="stremio-password">Password</label>
+            <input
+              autoComplete="current-password"
+              disabled={status !== 'ready' || submitting}
+              id="stremio-password"
+              onChange={(event) => setPassword(event.target.value)}
+              required
+              type="password"
+              value={password}
+            />
+            {error ? <p className={styles.formError}>{error}</p> : null}
+            <button
+              className={styles.primaryAction}
+              disabled={status !== 'ready' || submitting}
+              type="submit"
+            >
+              {status !== 'ready' ? 'Preparing account…' : submitting ? 'Signing in…' : 'Sign in'}
+            </button>
+          </form>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/MediaCard.tsx
+++ b/apps/desktop/src/components/MediaCard.tsx
@@ -1,0 +1,23 @@
+import type { CoreMetaPreview } from '../core/types';
+import styles from '../App.module.css';
+
+function year(item: CoreMetaPreview) {
+  return item.releaseInfo?.split(/[–-]/)[0] || item.released?.slice(0, 4) || item.type;
+}
+
+export function MediaCard({ item, onOpen }: { item: CoreMetaPreview; onOpen: () => void }) {
+  return (
+    <button className={styles.mediaCard} onClick={onOpen} type="button">
+      <span className={styles.posterFrame}>
+        {item.poster ? (
+          <img alt="" className={styles.poster} loading="lazy" src={item.poster} />
+        ) : (
+          <span className={styles.posterFallback}>{item.name.slice(0, 1)}</span>
+        )}
+        {item.watched ? <span className={styles.watchedBadge}>Watched</span> : null}
+      </span>
+      <span className={styles.mediaTitle}>{item.name}</span>
+      <span className={styles.mediaMeta}>{year(item)}</span>
+    </button>
+  );
+}

--- a/apps/desktop/src/core/CoreProvider.tsx
+++ b/apps/desktop/src/core/CoreProvider.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+
+import { ensureGuestCatalog } from './bootstrap';
+import { CoreContext, type CoreContextValue } from './context';
+import type { CoreSession } from './storage';
+import { createCoreTransport, type CoreTransport } from './transport';
+
+interface RuntimeState {
+  error: string | null;
+  session: CoreSession | null;
+  status: 'error' | 'ready' | 'unavailable';
+  transport: CoreTransport | null;
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : 'Stremio Core could not start.';
+}
+
+export function CoreProvider({ children }: { children: ReactNode }) {
+  const [session, setSession] = useState<CoreSession>('guest');
+  const [runtime, setRuntime] = useState<RuntimeState>({
+    error: null,
+    session: null,
+    status: 'unavailable',
+    transport: null,
+  });
+
+  useEffect(() => {
+    if (typeof Worker === 'undefined') return;
+
+    let disposed = false;
+    const transport = createCoreTransport(session);
+    void transport
+      .init()
+      .then(async () => {
+        if (session === 'guest') await ensureGuestCatalog(transport);
+      })
+      .then(() => {
+        if (!disposed) setRuntime({ error: null, session, status: 'ready', transport });
+      })
+      .catch((error: unknown) => {
+        console.error('[kino:core] initialization failed', errorMessage(error));
+        if (!disposed) {
+          setRuntime({ error: errorMessage(error), session, status: 'error', transport: null });
+        }
+      });
+
+    return () => {
+      disposed = true;
+      transport.destroy();
+    };
+  }, [session]);
+
+  const context = useMemo<CoreContextValue>(() => {
+    if (typeof Worker === 'undefined') {
+      return {
+        error: null,
+        selectSession: setSession,
+        session,
+        status: 'unavailable',
+        transport: null,
+      };
+    }
+    if (runtime.session !== session) {
+      return {
+        error: null,
+        selectSession: setSession,
+        session,
+        status: 'loading',
+        transport: null,
+      };
+    }
+    return { ...runtime, selectSession: setSession, session };
+  }, [runtime, session]);
+  return <CoreContext.Provider value={context}>{children}</CoreContext.Provider>;
+}

--- a/apps/desktop/src/core/actions.ts
+++ b/apps/desktop/src/core/actions.ts
@@ -1,0 +1,89 @@
+import type { CoreAction, CoreMetaPreview, CoreStream, CoreVideo } from './types';
+
+export interface PlaybackSelection {
+  meta: CoreMetaPreview;
+  metaTransportUrl: string;
+  stream: CoreStream;
+  streamTransportUrl: string;
+  video: CoreVideo | null;
+}
+
+export const loadBoardAction: CoreAction = {
+  action: 'Load',
+  args: { model: 'CatalogsWithExtra', args: { extra: [] } },
+};
+
+export function loadSearchAction(query: string): CoreAction {
+  return {
+    action: 'Load',
+    args: {
+      model: 'CatalogsWithExtra',
+      args: { extra: [['search', query]] },
+    },
+  };
+}
+
+export function loadMetaDetailsAction(meta: CoreMetaPreview, videoId: string | null): CoreAction {
+  return {
+    action: 'Load',
+    args: {
+      model: 'MetaDetails',
+      args: {
+        metaPath: { resource: 'meta', type: meta.type, id: meta.id, extra: [] },
+        streamPath: videoId
+          ? { resource: 'stream', type: meta.type, id: videoId, extra: [] }
+          : null,
+        guessStream: true,
+      },
+    },
+  };
+}
+
+function streamPayload(stream: CoreStream) {
+  const payload: Partial<CoreStream> = { ...stream };
+  delete payload.deepLinks;
+  delete payload.lastUsed;
+  delete payload.progress;
+  return payload;
+}
+
+export function loadPlayerAction(selection: PlaybackSelection): CoreAction {
+  const videoId = selection.video?.id ?? selection.meta.id;
+  return {
+    action: 'Load',
+    args: {
+      model: 'Player',
+      args: {
+        stream: streamPayload(selection.stream),
+        streamRequest: {
+          base: selection.streamTransportUrl,
+          path: {
+            resource: 'stream',
+            type: selection.meta.type,
+            id: videoId,
+            extra: [],
+          },
+        },
+        metaRequest: {
+          base: selection.metaTransportUrl,
+          path: {
+            resource: 'meta',
+            type: selection.meta.type,
+            id: selection.meta.id,
+            extra: [],
+          },
+        },
+        subtitlesPath: {
+          resource: 'subtitles',
+          type: selection.meta.type,
+          id: videoId,
+          extra: [],
+        },
+      },
+    },
+  };
+}
+
+export function playerAction(action: string, args?: unknown): CoreAction {
+  return { action: 'Player', args: { action, ...(args === undefined ? {} : { args }) } };
+}

--- a/apps/desktop/src/core/bootstrap.ts
+++ b/apps/desktop/src/core/bootstrap.ts
@@ -1,0 +1,37 @@
+import type { CoreTransport } from './transport';
+import type { ProfileState } from './types';
+
+const CINEMETA_MANIFEST_URL = 'https://v3-cinemeta.strem.io/manifest.json';
+
+function isManifest(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof Reflect.get(value, 'id') === 'string' &&
+    typeof Reflect.get(value, 'name') === 'string'
+  );
+}
+
+export async function ensureGuestCatalog(transport: CoreTransport) {
+  const context = await transport.getState<ProfileState>('ctx');
+  if (context.profile.addons.length > 0) return;
+
+  const response = await fetch(CINEMETA_MANIFEST_URL, {
+    headers: { Accept: 'application/json' },
+  });
+  if (!response.ok) throw new Error(`Cinemeta manifest returned ${response.status}.`);
+  const manifest: unknown = await response.json();
+  if (!isManifest(manifest)) throw new Error('Cinemeta returned an invalid manifest.');
+
+  await transport.dispatch({
+    action: 'Ctx',
+    args: {
+      action: 'InstallAddon',
+      args: {
+        flags: { official: true, protected: true },
+        manifest,
+        transportUrl: CINEMETA_MANIFEST_URL,
+      },
+    },
+  });
+}

--- a/apps/desktop/src/core/context.ts
+++ b/apps/desktop/src/core/context.ts
@@ -1,0 +1,26 @@
+import { createContext, useContext } from 'react';
+
+import type { CoreSession } from './storage';
+import type { CoreTransport } from './transport';
+
+export type CoreStatus = 'error' | 'loading' | 'ready' | 'unavailable';
+
+export interface CoreContextValue {
+  error: string | null;
+  selectSession(session: CoreSession): void;
+  session: CoreSession;
+  status: CoreStatus;
+  transport: CoreTransport | null;
+}
+
+export const CoreContext = createContext<CoreContextValue>({
+  error: null,
+  selectSession: () => undefined,
+  session: 'guest',
+  status: 'loading',
+  transport: null,
+});
+
+export function useCore() {
+  return useContext(CoreContext);
+}

--- a/apps/desktop/src/core/core.worker.ts
+++ b/apps/desktop/src/core/core.worker.ts
@@ -1,0 +1,46 @@
+/// <reference lib="webworker" />
+
+import Bridge from '@stremio/stremio-core-web/bridge.js';
+import wasmUrl from '@stremio/stremio-core-web/stremio_core_web_bg.wasm?url';
+
+interface CoreWorkerScope extends DedicatedWorkerGlobalScope {
+  app_version: string;
+  decodeStream(stream: string): unknown;
+  dispatch(action: unknown, field: unknown, locationHash: string): void;
+  document: { baseURI: string };
+  encodeStream(stream: unknown): string | null;
+  get_location_hash(): Promise<unknown>;
+  getState(field: unknown): unknown;
+  init(args: { appVersion: string; shellVersion: string | null }): Promise<void>;
+  local_storage_get_item(key: string): Promise<unknown>;
+  local_storage_remove_item(key: string): Promise<unknown>;
+  local_storage_set_item(key: string, value: string): Promise<unknown>;
+  shell_version: string | null;
+}
+
+const scope = self as unknown as CoreWorkerScope;
+const bridge = new Bridge(scope, scope);
+
+scope.init = async ({ appVersion, shellVersion }) => {
+  scope.document = { baseURI: scope.location.href };
+  scope.app_version = appVersion;
+  scope.shell_version = shellVersion;
+  scope.get_location_hash = () => bridge.call(['location', 'hash'], []);
+  scope.local_storage_get_item = (key) => bridge.call(['localStorage', 'getItem'], [key]);
+  scope.local_storage_remove_item = (key) => bridge.call(['localStorage', 'removeItem'], [key]);
+  scope.local_storage_set_item = (key, value) =>
+    bridge.call(['localStorage', 'setItem'], [key, value]);
+
+  const loadedCore = await import('@stremio/stremio-core-web/stremio_core_web.js');
+  const core =
+    typeof loadedCore.default === 'function'
+      ? loadedCore
+      : (loadedCore.default as unknown as typeof loadedCore);
+  scope.getState = core.get_state;
+  scope.dispatch = core.dispatch;
+  scope.decodeStream = core.decode_stream;
+  scope.encodeStream = core.encode_stream;
+
+  await core.default(wasmUrl);
+  await core.initialize_runtime((event) => bridge.call(['onCoreEvent'], [event]));
+};

--- a/apps/desktop/src/core/sources.test.ts
+++ b/apps/desktop/src/core/sources.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifySource, sourceSize } from './sources';
+
+const base = { deepLinks: { player: 'stremio:///player/value' } };
+
+describe('source compatibility', () => {
+  it('distinguishes direct, torrent, external, and unsupported sources', () => {
+    expect(classifySource({ ...base, url: 'https://example.com/video.mp4' })).toBe('direct');
+    expect(classifySource({ ...base, infoHash: 'abc' })).toBe('torrent');
+    expect(classifySource({ ...base, externalUrl: 'https://example.com/watch' })).toBe('external');
+    expect(classifySource({ ...base, ytId: 'video' })).toBe('unsupported');
+  });
+
+  it('formats binary source size without inventing missing metadata', () => {
+    expect(sourceSize({ ...base, behaviorHints: { videoSize: 5 * 1024 ** 3 } })).toBe('5.0 GB');
+    expect(sourceSize(base)).toBeNull();
+  });
+});

--- a/apps/desktop/src/core/sources.ts
+++ b/apps/desktop/src/core/sources.ts
@@ -1,0 +1,40 @@
+import type { CoreStream } from './types';
+
+export type SourceSupport = 'direct' | 'external' | 'torrent' | 'unsupported';
+
+export function classifySource(stream: CoreStream): SourceSupport {
+  if (stream.url?.startsWith('https://')) return 'direct';
+  if (stream.infoHash) return 'torrent';
+  if (stream.externalUrl) return 'external';
+  return 'unsupported';
+}
+
+export function sourceTitle(stream: CoreStream) {
+  return stream.name?.trim() || stream.description?.split('\n')[0]?.trim() || 'Unnamed source';
+}
+
+export function sourceDetails(stream: CoreStream) {
+  const detail = stream.description?.trim();
+  if (detail && detail !== sourceTitle(stream)) return detail;
+
+  const filename = stream.behaviorHints?.filename?.trim();
+  if (filename) return filename;
+
+  switch (classifySource(stream)) {
+    case 'direct':
+      return 'HTTPS direct stream';
+    case 'torrent':
+      return 'Torrent source';
+    case 'external':
+      return 'External destination';
+    case 'unsupported':
+      return 'Unsupported source type';
+  }
+}
+
+export function sourceSize(stream: CoreStream) {
+  const bytes = stream.behaviorHints?.videoSize;
+  if (!bytes || bytes <= 0) return null;
+  const gibibytes = bytes / 1024 ** 3;
+  return `${gibibytes < 1 ? gibibytes.toFixed(2) : gibibytes.toFixed(1)} GB`;
+}

--- a/apps/desktop/src/core/storage.test.ts
+++ b/apps/desktop/src/core/storage.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { NamespacedStorage } from './storage';
+
+describe('core session storage', () => {
+  it('keeps guest and account data isolated under the same logical key', () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      removeItem: (key: string) => values.delete(key),
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+    const guest = new NamespacedStorage(storage, 'guest');
+    const account = new NamespacedStorage(storage, 'account');
+
+    guest.setItem('profile', 'guest-profile');
+    account.setItem('profile', 'account-profile');
+
+    expect(guest.getItem('profile')).toBe('guest-profile');
+    expect(account.getItem('profile')).toBe('account-profile');
+
+    guest.removeItem('profile');
+
+    expect(guest.getItem('profile')).toBeNull();
+    expect(account.getItem('profile')).toBe('account-profile');
+  });
+});

--- a/apps/desktop/src/core/storage.ts
+++ b/apps/desktop/src/core/storage.ts
@@ -1,0 +1,29 @@
+interface KeyValueStorage {
+  getItem(key: string): string | null;
+  removeItem(key: string): void;
+  setItem(key: string, value: string): void;
+}
+
+export type CoreSession = 'account' | 'guest';
+
+export class NamespacedStorage implements KeyValueStorage {
+  readonly #prefix: string;
+  readonly #storage: KeyValueStorage;
+
+  constructor(storage: KeyValueStorage, session: CoreSession) {
+    this.#storage = storage;
+    this.#prefix = `kino.core.v1.${session}.`;
+  }
+
+  getItem(key: string) {
+    return this.#storage.getItem(this.#prefix + key);
+  }
+
+  removeItem(key: string) {
+    this.#storage.removeItem(this.#prefix + key);
+  }
+
+  setItem(key: string, value: string) {
+    this.#storage.setItem(this.#prefix + key, value);
+  }
+}

--- a/apps/desktop/src/core/stremio-core-web.d.ts
+++ b/apps/desktop/src/core/stremio-core-web.d.ts
@@ -1,0 +1,21 @@
+declare module '@stremio/stremio-core-web/bridge.js' {
+  interface MessageEndpoint {
+    addEventListener(type: 'message', listener: (event: MessageEvent) => void): void;
+    postMessage(message: unknown): void;
+    removeEventListener(type: 'message', listener: (event: MessageEvent) => void): void;
+  }
+
+  export default class Bridge {
+    constructor(scope: object, handler: MessageEndpoint);
+    call<Result>(path: string[], args: unknown[]): Promise<Result>;
+  }
+}
+
+declare module '@stremio/stremio-core-web/stremio_core_web.js' {
+  export function decode_stream(stream: string): unknown;
+  export function dispatch(action: unknown, field: unknown, locationHash: string): void;
+  export function encode_stream(stream: unknown): string | null;
+  export function get_state(field: unknown): unknown;
+  export default function initializeWasm(path: string): Promise<unknown>;
+  export function initialize_runtime(emit: (event: unknown) => void): Promise<void>;
+}

--- a/apps/desktop/src/core/transport.ts
+++ b/apps/desktop/src/core/transport.ts
@@ -1,0 +1,56 @@
+import Bridge from '@stremio/stremio-core-web/bridge.js';
+import CoreWorker from './core.worker?worker';
+
+import { NamespacedStorage, type CoreSession } from './storage';
+import type { CoreAction, CoreModelName, CoreRuntimeEvent } from './types';
+
+type CoreEventListener = (event: CoreRuntimeEvent) => void;
+
+export interface CoreTransport {
+  destroy(): void;
+  dispatch(action: CoreAction, model?: CoreModelName): Promise<void>;
+  getState<State>(model: CoreModelName): Promise<State>;
+  init(): Promise<void>;
+  subscribe(listener: CoreEventListener): () => void;
+}
+
+function currentHash() {
+  return window.location.hash;
+}
+
+export function createCoreTransport(session: CoreSession = 'guest'): CoreTransport {
+  const listeners = new Set<CoreEventListener>();
+  const worker = new CoreWorker();
+  const scope = {
+    localStorage: new NamespacedStorage(window.localStorage, session),
+    location: {
+      get hash() {
+        return currentHash();
+      },
+    },
+    onCoreEvent(event: CoreRuntimeEvent) {
+      listeners.forEach((listener) => listener(event));
+    },
+  };
+  const bridge = new Bridge(scope, worker);
+
+  return {
+    destroy() {
+      listeners.clear();
+      worker.terminate();
+    },
+    async dispatch(action, model) {
+      await bridge.call(['dispatch'], [action, model, currentHash()]);
+    },
+    getState<State>(model: CoreModelName) {
+      return bridge.call<State>(['getState'], [model]);
+    },
+    async init() {
+      await bridge.call(['init'], [{ appVersion: '0.0.0', shellVersion: null }]);
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+}

--- a/apps/desktop/src/core/types.ts
+++ b/apps/desktop/src/core/types.ts
@@ -1,0 +1,144 @@
+export type CoreModelName =
+  'board' | 'continue_watching_preview' | 'ctx' | 'meta_details' | 'player' | 'search';
+
+export interface CoreAction {
+  action: string;
+  args?: unknown;
+}
+
+export type CoreRuntimeEvent =
+  | { name: 'CoreEvent'; args: { event: string; args?: unknown } }
+  | { name: 'NewState'; args: CoreModelName[] };
+
+export type Loadable<Ready, Failure = unknown> =
+  { type: 'Err'; content: Failure } | { type: 'Loading' } | { type: 'Ready'; content: Ready };
+
+export interface CoreMetaPreview {
+  background?: string | null;
+  behaviorHints?: Record<string, unknown>;
+  deepLinks?: Record<string, unknown>;
+  description?: string | null;
+  id: string;
+  inLibrary: boolean;
+  links?: Array<{ category: string; name: string; url: string }>;
+  logo?: string | null;
+  name: string;
+  poster?: string | null;
+  posterShape?: 'Landscape' | 'Poster' | 'Square';
+  releaseInfo?: string | null;
+  released?: string | null;
+  runtime?: string | null;
+  type: string;
+  watched: boolean;
+}
+
+export interface CoreCatalog {
+  addon: { manifest: { id: string; name: string } };
+  content: Loadable<CoreMetaPreview[], string> | null;
+  id: string;
+  name: string;
+  type: string;
+}
+
+export interface BoardState {
+  catalogs: CoreCatalog[];
+  selected: { extra: Array<[string, string]>; type?: string | null } | null;
+}
+
+export interface ContinueWatchingItem {
+  _id: string;
+  name: string;
+  poster?: string | null;
+  posterShape: 'Landscape' | 'Poster' | 'Square';
+  progress: number;
+  state: { videoId?: string | null };
+  type: string;
+}
+
+export interface ContinueWatchingState {
+  items: ContinueWatchingItem[];
+}
+
+export interface CoreVideo {
+  deepLinks?: Record<string, unknown>;
+  episode?: number;
+  id: string;
+  overview?: string | null;
+  progress?: number | null;
+  released?: string | null;
+  season?: number;
+  thumbnail?: string | null;
+  title: string;
+  watched?: boolean;
+}
+
+export interface StreamDeepLinks {
+  externalPlayer?: {
+    download?: string | null;
+    magnet?: string | null;
+    streaming?: string | null;
+  };
+  player: string;
+}
+
+export interface CoreStream {
+  behaviorHints?: {
+    filename?: string | null;
+    notWebReady?: boolean;
+    videoHash?: string | null;
+    videoSize?: number | null;
+  };
+  deepLinks: StreamDeepLinks;
+  description?: string | null;
+  externalUrl?: string | null;
+  fileIdx?: number | null;
+  infoHash?: string;
+  lastUsed?: boolean | null;
+  name?: string | null;
+  playerFrameUrl?: string;
+  progress?: number | null;
+  url?: string;
+  ytId?: string;
+}
+
+export interface CoreMetaItem extends CoreMetaPreview {
+  videos: CoreVideo[];
+}
+
+interface CoreResource<Ready> {
+  addon: {
+    manifest: { id: string; logo?: string | null; name: string };
+    transportUrl?: string;
+  };
+  content: Loadable<Ready>;
+}
+
+export interface MetaDetailsState {
+  libraryItem: unknown | null;
+  metaItem: CoreResource<CoreMetaItem> | null;
+  selected: unknown | null;
+  streams: Array<CoreResource<CoreStream[]>>;
+  title?: string | null;
+}
+
+export interface PlayerState {
+  addon?: { manifest: { name: string } } | null;
+  introOutro?: {
+    intro?: { duration?: number | null; from: number; to: number } | null;
+    outro?: number | null;
+  } | null;
+  libraryItem?: {
+    _id: string;
+    state: { timeOffset: number; video_id?: string | null };
+  } | null;
+  selected: { stream: CoreStream } | null;
+  stream: Loadable<CoreStream> | null;
+  title?: string | null;
+}
+
+export interface ProfileState {
+  profile: {
+    addons: Array<{ manifest: { id: string; name: string }; transportUrl: string }>;
+    auth?: { user: { email?: string; name?: string; uid?: string } };
+  };
+}

--- a/apps/desktop/src/core/useCoreModel.ts
+++ b/apps/desktop/src/core/useCoreModel.ts
@@ -1,0 +1,94 @@
+import { useEffect, useEffectEvent, useState } from 'react';
+
+import { useCore } from './context';
+import type { CoreTransport } from './transport';
+import type { CoreAction, CoreModelName, CoreRuntimeEvent } from './types';
+
+interface CoreModelResult<State> {
+  error: string | null;
+  loading: boolean;
+  state: State | null;
+}
+
+interface CoreModelSnapshot<State> extends CoreModelResult<State> {
+  actionKey: string | null;
+  transport: CoreTransport | null;
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : 'The Stremio model failed to load.';
+}
+
+export function useCoreModel<State>(
+  model: CoreModelName,
+  action: CoreAction | null,
+  actionKey: string,
+): CoreModelResult<State> {
+  const { status, transport } = useCore();
+  const dispatchLoad = useEffectEvent(async (target: CoreTransport, targetModel: CoreModelName) => {
+    if (action) await target.dispatch(action, targetModel);
+  });
+  const [result, setResult] = useState<CoreModelSnapshot<State>>({
+    actionKey: null,
+    error: null,
+    loading: true,
+    state: null,
+    transport: null,
+  });
+
+  useEffect(() => {
+    if (status !== 'ready' || !transport) return;
+
+    let disposed = false;
+    const read = async () => {
+      try {
+        const state = await transport.getState<State>(model);
+        if (!disposed) setResult({ actionKey, error: null, loading: false, state, transport });
+      } catch (error) {
+        console.error(`[kino:core] ${model} state failed`, errorMessage(error));
+        if (!disposed)
+          setResult({
+            actionKey,
+            error: errorMessage(error),
+            loading: false,
+            state: null,
+            transport,
+          });
+      }
+    };
+    const onEvent = (event: CoreRuntimeEvent) => {
+      if (event.name === 'NewState' && event.args.includes(model)) void read();
+    };
+    const unsubscribe = transport.subscribe(onEvent);
+
+    void (async () => {
+      try {
+        await dispatchLoad(transport, model);
+        await read();
+      } catch (error) {
+        console.error(`[kino:core] ${model} action failed`, errorMessage(error));
+        if (!disposed)
+          setResult({
+            actionKey,
+            error: errorMessage(error),
+            loading: false,
+            state: null,
+            transport,
+          });
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      unsubscribe();
+      void transport.dispatch({ action: 'Unload' }, model).catch(() => undefined);
+    };
+  }, [actionKey, model, status, transport]);
+
+  if (status !== 'ready' || !transport) {
+    return { error: null, loading: status === 'loading', state: null };
+  }
+  return result.actionKey === actionKey && result.transport === transport
+    ? result
+    : { error: null, loading: true, state: null };
+}

--- a/apps/desktop/src/intro/markers.test.ts
+++ b/apps/desktop/src/intro/markers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { markerFromChapters, markerFromCommunity } from './markers';
+
+describe('intro marker trust', () => {
+  it('prefers an explicitly named chapter with safe bounds', () => {
+    expect(
+      markerFromChapters([{ title: 'Opening Credits', startMs: 12_000, endMs: 96_000 }], 3_000_000),
+    ).toEqual({ source: 'chapter', startMs: 12_000, endMs: 96_000 });
+  });
+
+  it('rejects vague chapter names and invalid durations', () => {
+    expect(
+      markerFromChapters(
+        [
+          { title: 'Chapter 1', startMs: 0, endMs: 90_000 },
+          { title: 'Intro', startMs: 0, endMs: 300_000 },
+        ],
+        3_000_000,
+      ),
+    ).toBeNull();
+  });
+
+  it('requires confidence, corroboration, and duration-safe community data', () => {
+    const base = {
+      durationMs: 80_000,
+      endMs: 92_000,
+      endsAtMediaEnd: false,
+      startMs: 12_000,
+      startsAtBeginning: false,
+    };
+    expect(
+      markerFromCommunity(
+        [
+          { ...base, confidence: 0.95, submissionCount: 1 },
+          { ...base, confidence: 0.8, submissionCount: 2 },
+        ],
+        3_000_000,
+      ),
+    ).toEqual({ source: 'theintrodb', startMs: 12_000, endMs: 92_000 });
+    expect(
+      markerFromCommunity([{ ...base, confidence: 0.79, submissionCount: 3 }], 3_000_000),
+    ).toBeNull();
+  });
+});

--- a/apps/desktop/src/intro/markers.ts
+++ b/apps/desktop/src/intro/markers.ts
@@ -1,0 +1,79 @@
+import { createIntroDbClient, type NormalizedSegmentTimestamp } from 'theintrodb';
+
+export interface Chapter {
+  endMs: number;
+  startMs: number;
+  title: string;
+}
+
+export interface IntroIdentity {
+  durationMs: number;
+  episode?: number;
+  imdbId?: string;
+  season?: number;
+  tmdbId?: number;
+}
+
+export interface IntroMarker {
+  endMs: number;
+  source: 'chapter' | 'theintrodb';
+  startMs: number;
+}
+
+const introDb = createIntroDbClient();
+const INTRO_LABEL = /^(intro|introduction|opening|opening credits|op)$/i;
+
+function validBounds(startMs: number, endMs: number, durationMs: number) {
+  const segmentDuration = endMs - startMs;
+  return (
+    Number.isFinite(startMs) &&
+    Number.isFinite(endMs) &&
+    startMs >= 0 &&
+    endMs <= durationMs &&
+    segmentDuration >= 5_000 &&
+    segmentDuration <= 200_000
+  );
+}
+
+export function markerFromChapters(chapters: Chapter[], durationMs: number): IntroMarker | null {
+  const chapter = chapters.find(
+    (candidate) =>
+      INTRO_LABEL.test(candidate.title.trim()) &&
+      validBounds(candidate.startMs, candidate.endMs, durationMs),
+  );
+  return chapter ? { source: 'chapter', startMs: chapter.startMs, endMs: chapter.endMs } : null;
+}
+
+export function markerFromCommunity(
+  candidates: NormalizedSegmentTimestamp[],
+  durationMs: number,
+): IntroMarker | null {
+  const candidate = candidates.find(
+    (segment) =>
+      segment.endMs !== null &&
+      (segment.confidence ?? 0) >= 0.8 &&
+      (segment.submissionCount ?? 0) >= 2 &&
+      validBounds(segment.startMs, segment.endMs, durationMs),
+  );
+  return candidate?.endMs == null
+    ? null
+    : { source: 'theintrodb', startMs: candidate.startMs, endMs: candidate.endMs };
+}
+
+export async function lookupCommunityIntro(
+  identity: IntroIdentity,
+  signal?: AbortSignal,
+): Promise<IntroMarker | null> {
+  if (!identity.tmdbId && !identity.imdbId) return null;
+  const media = await introDb.getMedia(
+    {
+      durationMs: identity.durationMs,
+      ...(identity.episode === undefined ? {} : { episode: identity.episode }),
+      ...(identity.imdbId === undefined ? {} : { imdbId: identity.imdbId }),
+      ...(identity.season === undefined ? {} : { season: identity.season }),
+      ...(identity.tmdbId === undefined ? {} : { tmdbId: identity.tmdbId }),
+    },
+    { signal },
+  );
+  return markerFromCommunity(media.intro, identity.durationMs);
+}

--- a/apps/desktop/src/locales/en-US.ts
+++ b/apps/desktop/src/locales/en-US.ts
@@ -15,13 +15,16 @@ export const enUS = {
     continueWatching: 'Continue Watching',
     continueEmpty: 'Nothing to resume yet.',
     catalogs: 'Catalogs',
-    catalogsEmpty: 'Connect to Stremio to see catalogs from your installed add-ons.',
+    catalogsEmpty: 'No catalogs are available from the installed add-ons.',
+    catalogsUnavailable: 'Installed add-ons are present, but their catalogs returned no items.',
+    catalogsError: 'Catalogs could not be loaded. Check the local log and try again.',
   },
   search: {
     title: 'Search',
     placeholder: 'Search movies and series',
     idle: 'Search across catalogs from your installed add-ons.',
-    disconnected: 'Search will be available after you connect to Stremio.',
+    loading: 'Searching installed add-ons…',
+    error: 'Search could not be completed.',
   },
   discover: {
     title: 'Discover',
@@ -57,11 +60,23 @@ export const enUS = {
     audioStereo: 'Stereo',
     diagnostics: 'Diagnostics',
     localLogging: 'Verbose local logging',
-    localLoggingDescription: 'Stored only on this device with automatic rotation',
+    localLoggingDescription: 'Detailed diagnostics stay on this device',
     active: 'Active',
   },
   status: {
     unavailable: 'Not connected',
+  },
+  actions: {
+    back: 'Back',
+  },
+  details: {
+    loading: 'Loading title details…',
+    error: 'Title details could not be loaded.',
+    episodes: 'Episodes',
+    sources: 'Sources',
+    refreshing: 'Refreshing sources…',
+    noSources: 'No sources were returned for this title.',
+    unavailable: 'Not available',
   },
   errors: {
     title: 'Kino could not render this screen.',

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -4,6 +4,7 @@ import { createRoot } from 'react-dom/client';
 
 import { App } from './App';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { CoreProvider } from './core/CoreProvider';
 import './global.css';
 
 const root = document.getElementById('root');
@@ -15,7 +16,9 @@ if (!root) {
 createRoot(root).render(
   <StrictMode>
     <ErrorBoundary>
-      <App />
+      <CoreProvider>
+        <App />
+      </CoreProvider>
     </ErrorBoundary>
   </StrictMode>,
 );

--- a/apps/desktop/src/screens/HomeScreen.tsx
+++ b/apps/desktop/src/screens/HomeScreen.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useMemo } from 'react';
+
+import styles from '../App.module.css';
+import { MediaCard } from '../components/MediaCard';
+import { loadBoardAction } from '../core/actions';
+import { useCore } from '../core/context';
+import type {
+  BoardState,
+  ContinueWatchingState,
+  CoreMetaPreview,
+  ProfileState,
+} from '../core/types';
+import { useCoreModel } from '../core/useCoreModel';
+import { enUS } from '../locales/en-US';
+
+function RowSkeleton() {
+  return (
+    <div className={styles.mediaRow} aria-hidden>
+      {Array.from({ length: 6 }, (_, index) => (
+        <div className={styles.mediaSkeleton} key={index} />
+      ))}
+    </div>
+  );
+}
+
+export function HomeScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => void }) {
+  const core = useCore();
+  const board = useCoreModel<BoardState>('board', loadBoardAction, 'board');
+  const continueWatching = useCoreModel<ContinueWatchingState>(
+    'continue_watching_preview',
+    null,
+    'continue-watching',
+  );
+  const context = useCoreModel<ProfileState>('ctx', null, 'context');
+  const catalogs = board.state?.catalogs ?? [];
+
+  useEffect(() => {
+    if (!core.transport || catalogs.length === 0) return;
+    void core.transport.dispatch(
+      {
+        action: 'CatalogsWithExtra',
+        args: { action: 'LoadRange', args: { start: 0, end: catalogs.length } },
+      },
+      'board',
+    );
+  }, [catalogs.length, core.transport]);
+
+  const readyCatalogs = catalogs.filter(
+    (catalog) => catalog.content?.type === 'Ready' && catalog.content.content.length > 0,
+  );
+  const failedCatalogs = catalogs.some((catalog) => catalog.content?.type === 'Err');
+  const loadingCatalogs = catalogs.filter(
+    (catalog) => catalog.content === null || catalog.content?.type === 'Loading',
+  ).length;
+  const catalogsPending = board.loading || (catalogs.length > 0 && loadingCatalogs > 0);
+  const continueItems = useMemo(
+    () => continueWatching.state?.items.slice(0, 10) ?? [],
+    [continueWatching.state],
+  );
+
+  return (
+    <div className={styles.homePage}>
+      <h1 className={styles.visuallyHidden}>{enUS.home.title}</h1>
+      <section className={styles.homeSection} aria-labelledby="continue-watching-title">
+        <h2 id="continue-watching-title">{enUS.home.continueWatching}</h2>
+        {continueWatching.loading ? <RowSkeleton /> : null}
+        {!continueWatching.loading && continueItems.length === 0 ? (
+          <p className={styles.inlineEmpty}>{enUS.home.continueEmpty}</p>
+        ) : null}
+        {continueItems.length > 0 ? (
+          <div className={styles.continueRow}>
+            {continueItems.map((item) => (
+              <button
+                className={styles.continueCard}
+                key={item._id}
+                onClick={() =>
+                  onOpen({
+                    id: item._id,
+                    inLibrary: true,
+                    name: item.name,
+                    ...(item.poster === undefined ? {} : { poster: item.poster }),
+                    posterShape: item.posterShape,
+                    type: item.type,
+                    watched: false,
+                  })
+                }
+                type="button"
+              >
+                <span className={styles.continueArtwork}>
+                  {item.poster ? <img alt="" src={item.poster} /> : null}
+                  <span className={styles.continueLabel}>{item.name}</span>
+                  <span className={styles.progressTrack}>
+                    <span style={{ width: `${Math.max(0, Math.min(100, item.progress))}%` }} />
+                  </span>
+                </span>
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </section>
+
+      {catalogsPending && readyCatalogs.length === 0 ? (
+        <section className={styles.homeSection} aria-label={enUS.home.catalogs}>
+          <h2>{enUS.home.catalogs}</h2>
+          <RowSkeleton />
+        </section>
+      ) : null}
+      {board.error ? <p className={styles.loadError}>{enUS.home.catalogsError}</p> : null}
+      {core.error ? <p className={styles.loadError}>Stremio Core failed: {core.error}</p> : null}
+      {!catalogsPending && !board.error && readyCatalogs.length === 0 ? (
+        <section className={styles.homeSection} aria-label={enUS.home.catalogs}>
+          <h2>{enUS.home.catalogs}</h2>
+          <p className={styles.inlineEmpty}>
+            {failedCatalogs
+              ? enUS.home.catalogsError
+              : context.loading
+                ? 'Loading the guest profile…'
+                : context.error
+                  ? `Guest profile failed: ${context.error}`
+                  : context.state?.profile.addons.length
+                    ? enUS.home.catalogsUnavailable
+                    : enUS.home.catalogsEmpty}
+          </p>
+        </section>
+      ) : null}
+      {readyCatalogs.map((catalog) => {
+        const items = catalog.content?.type === 'Ready' ? catalog.content.content : [];
+        return (
+          <section
+            className={styles.homeSection}
+            key={`${catalog.addon.manifest.id}:${catalog.id}`}
+          >
+            <div className={styles.sectionHeading}>
+              <h2>{catalog.name}</h2>
+              <span>{catalog.addon.manifest.name}</span>
+            </div>
+            <div className={styles.mediaRow}>
+              {items.map((item) => (
+                <MediaCard
+                  item={item}
+                  key={`${item.type}:${item.id}`}
+                  onOpen={() => onOpen(item)}
+                />
+              ))}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/desktop/src/screens/MetaDetailsScreen.tsx
+++ b/apps/desktop/src/screens/MetaDetailsScreen.tsx
@@ -1,0 +1,203 @@
+import { ArrowLeft, Play } from '@phosphor-icons/react';
+import { useEffect, useMemo, useState } from 'react';
+
+import styles from '../App.module.css';
+import { loadMetaDetailsAction, type PlaybackSelection } from '../core/actions';
+import { classifySource, sourceDetails, sourceSize, sourceTitle } from '../core/sources';
+import type {
+  CoreMetaItem,
+  CoreMetaPreview,
+  CoreStream,
+  CoreVideo,
+  MetaDetailsState,
+} from '../core/types';
+import { useCoreModel } from '../core/useCoreModel';
+import { enUS } from '../locales/en-US';
+
+interface SourceChoice {
+  addonName: string;
+  stream: CoreStream;
+  transportUrl: string;
+}
+
+function metadata(item: CoreMetaItem) {
+  return [item.releaseInfo, item.runtime, item.type === 'series' ? 'Series' : 'Movie']
+    .filter(Boolean)
+    .join(' · ');
+}
+
+function defaultVideoId(item: CoreMetaPreview) {
+  const value = item.behaviorHints?.defaultVideoId;
+  return typeof value === 'string' ? value : null;
+}
+
+export function MetaDetailsScreen({
+  item,
+  onBack,
+  onPlay,
+}: {
+  item: CoreMetaPreview;
+  onBack: () => void;
+  onPlay: (selection: PlaybackSelection) => void;
+}) {
+  const [videoId, setVideoId] = useState<string | null>(() => defaultVideoId(item));
+  const result = useCoreModel<MetaDetailsState>(
+    'meta_details',
+    loadMetaDetailsAction(item, videoId),
+    `${item.type}:${item.id}:${videoId ?? 'guess'}`,
+  );
+  const resource = result.state?.metaItem;
+  const meta = resource?.content.type === 'Ready' ? resource.content.content : null;
+  const videos = useMemo(() => meta?.videos ?? [], [meta]);
+
+  useEffect(() => {
+    if (item.type !== 'series' || videoId !== null || videos.length === 0) return;
+    const firstEpisode = videos.find((video) => (video.season ?? 0) > 0) ?? videos[0];
+    if (!firstEpisode) return;
+    const timeout = window.setTimeout(() => setVideoId(firstEpisode.id), 0);
+    return () => window.clearTimeout(timeout);
+  }, [item.type, videoId, videos]);
+
+  const seasons = useMemo(
+    () => [...new Set(videos.map((video) => video.season).filter((value) => value !== undefined))],
+    [videos],
+  );
+  const activeVideo =
+    videos.find((video) => video.id === videoId) ??
+    videos.find((video) => (video.season ?? 0) > 0) ??
+    videos[0] ??
+    null;
+  const activeSeason = activeVideo?.season ?? seasons[0];
+  const visibleVideos = videos.filter((video) => video.season === activeSeason);
+  const sources = useMemo<SourceChoice[]>(
+    () =>
+      result.state?.streams.flatMap((sourceResource) =>
+        sourceResource.content.type === 'Ready'
+          ? sourceResource.content.content.map((stream) => ({
+              addonName: sourceResource.addon.manifest.name,
+              stream,
+              transportUrl: sourceResource.addon.transportUrl ?? '',
+            }))
+          : [],
+      ) ?? [],
+    [result.state],
+  );
+  const display = meta ?? item;
+
+  return (
+    <div className={styles.detailPage}>
+      <header className={styles.detailHero}>
+        {display.background ? (
+          <img alt="" className={styles.detailBackdrop} src={display.background} />
+        ) : null}
+        <div className={styles.detailShade} />
+        <button className={styles.backButton} onClick={onBack} type="button">
+          <ArrowLeft aria-hidden size={16} />
+          {enUS.actions.back}
+        </button>
+        <div className={styles.detailCopy}>
+          <h1>{display.name}</h1>
+          <p className={styles.detailMetadata}>{metadata(display as CoreMetaItem)}</p>
+          {display.description ? (
+            <p className={styles.detailDescription}>{display.description}</p>
+          ) : null}
+        </div>
+      </header>
+
+      <div className={styles.detailBody}>
+        {result.loading && !meta ? (
+          <p className={styles.inlineEmpty}>{enUS.details.loading}</p>
+        ) : null}
+        {result.error ? <p className={styles.loadError}>{enUS.details.error}</p> : null}
+        {item.type === 'series' && videos.length > 0 ? (
+          <section className={styles.detailSection} aria-labelledby="episodes-heading">
+            <div className={styles.detailSectionHeading}>
+              <h2 id="episodes-heading">{enUS.details.episodes}</h2>
+              <div className={styles.seasonTabs}>
+                {seasons.map((season) => (
+                  <button
+                    aria-pressed={season === activeSeason}
+                    className={season === activeSeason ? styles.seasonActive : styles.seasonButton}
+                    key={season}
+                    onClick={() => {
+                      const first = videos.find((video) => video.season === season);
+                      if (first) setVideoId(first.id);
+                    }}
+                    type="button"
+                  >
+                    Season {season}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className={styles.episodeList}>
+              {visibleVideos.map((video: CoreVideo) => (
+                <button
+                  aria-current={video.id === videoId ? 'true' : undefined}
+                  className={video.id === videoId ? styles.episodeActive : styles.episodeButton}
+                  key={video.id}
+                  onClick={() => setVideoId(video.id)}
+                  type="button"
+                >
+                  <span className={styles.episodeNumber}>
+                    {String(video.episode ?? 0).padStart(2, '0')}
+                  </span>
+                  <span>
+                    <strong>{video.title || `Episode ${video.episode}`}</strong>
+                    {video.overview ? <small>{video.overview}</small> : null}
+                  </span>
+                  <Play aria-hidden size={16} weight="fill" />
+                </button>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        <section className={styles.detailSection} aria-labelledby="sources-heading">
+          <div className={styles.detailSectionHeading}>
+            <h2 id="sources-heading">{enUS.details.sources}</h2>
+            {result.loading ? <span>{enUS.details.refreshing}</span> : null}
+          </div>
+          {!result.loading && sources.length === 0 ? (
+            <p className={styles.inlineEmpty}>{enUS.details.noSources}</p>
+          ) : null}
+          <div className={styles.sourceList}>
+            {sources.map((source, index) => {
+              const support = classifySource(source.stream);
+              const playable =
+                (support === 'direct' || support === 'torrent') && Boolean(source.transportUrl);
+              return (
+                <button
+                  className={styles.sourceButton}
+                  disabled={!playable}
+                  key={`${source.transportUrl}:${index}`}
+                  onClick={() => {
+                    if (!playable || !resource?.addon.transportUrl) return;
+                    onPlay({
+                      meta: display,
+                      metaTransportUrl: resource.addon.transportUrl,
+                      stream: source.stream,
+                      streamTransportUrl: source.transportUrl,
+                      video: activeVideo,
+                    });
+                  }}
+                  type="button"
+                >
+                  <span className={styles.sourcePrimary}>
+                    <strong>{sourceTitle(source.stream)}</strong>
+                    <small>{sourceDetails(source.stream)}</small>
+                  </span>
+                  <span className={styles.sourceMeta}>
+                    {sourceSize(source.stream) ? <span>{sourceSize(source.stream)}</span> : null}
+                    <span>{source.addonName}</span>
+                    {!playable ? <em>{enUS.details.unavailable}</em> : null}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/screens/PlayerScreen.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.tsx
@@ -1,0 +1,351 @@
+import { ArrowLeft, ArrowsOut, Pause, Play, SkipForward, SpeakerHigh } from '@phosphor-icons/react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import styles from '../App.module.css';
+import { loadPlayerAction, playerAction, type PlaybackSelection } from '../core/actions';
+import { useCore } from '../core/context';
+import type { PlayerState } from '../core/types';
+import { useCoreModel } from '../core/useCoreModel';
+import { lookupCommunityIntro, type IntroMarker } from '../intro/markers';
+import type { KinoSettings } from '../settings';
+
+function formatTime(milliseconds: number) {
+  const seconds = Math.max(0, Math.floor(milliseconds / 1000));
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const remainder = seconds % 60;
+  const padded = (value: number) => String(value).padStart(2, '0');
+  return hours > 0
+    ? `${hours}:${padded(minutes)}:${padded(remainder)}`
+    : `${minutes}:${padded(remainder)}`;
+}
+
+function introIdentity(selection: PlaybackSelection, durationMs: number) {
+  const imdbId = /^tt\d+$/.test(selection.meta.id) ? selection.meta.id : undefined;
+  return {
+    durationMs,
+    ...(selection.video?.episode === undefined ? {} : { episode: selection.video.episode }),
+    ...(imdbId === undefined ? {} : { imdbId }),
+    ...(selection.video?.season === undefined ? {} : { season: selection.video.season }),
+  };
+}
+
+export function PlayerScreen({
+  onBack,
+  selection,
+  settings,
+}: {
+  onBack: () => void;
+  selection: PlaybackSelection;
+  settings: KinoSettings;
+}) {
+  const { transport } = useCore();
+  const result = useCoreModel<PlayerState>(
+    'player',
+    loadPlayerAction(selection),
+    `${selection.meta.id}:${selection.video?.id ?? 'movie'}:${selection.streamTransportUrl}`,
+  );
+  const containerRef = useRef<HTMLDivElement>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const lastProgressRef = useRef(0);
+  const autoSkippedRef = useRef(false);
+  const autoSkipSuppressedRef = useRef(false);
+  const [duration, setDuration] = useState(0);
+  const [time, setTime] = useState(0);
+  const [paused, setPaused] = useState(true);
+  const [buffering, setBuffering] = useState(false);
+  const [mediaError, setMediaError] = useState<string | null>(null);
+  const [marker, setMarker] = useState<IntroMarker | null>(null);
+  const [automaticNotice, setAutomaticNotice] = useState(false);
+  const stream = result.state?.stream?.type === 'Ready' ? result.state.stream.content : null;
+  const streamUrl = stream?.url ?? null;
+  const resumeTime = result.state?.libraryItem?.state.timeOffset ?? 0;
+  const sourceFailed = result.state?.stream?.type === 'Err' || Boolean(result.error || mediaError);
+
+  const dispatchPlayer = useCallback(
+    (action: string, args?: unknown) => {
+      if (!transport) return;
+      void transport.dispatch(playerAction(action, args), 'player').catch((error: unknown) => {
+        console.error(
+          '[kino:player] progress update failed',
+          error instanceof Error ? error.message : error,
+        );
+      });
+    },
+    [transport],
+  );
+
+  const reportProgress = useCallback(
+    (isSeek = false) => {
+      const video = videoRef.current;
+      if (!video || !Number.isFinite(video.duration)) return;
+      const args = {
+        device: 'kino-web',
+        duration: Math.round(video.duration * 1000),
+        time: Math.round(video.currentTime * 1000),
+      };
+      dispatchPlayer(isSeek ? 'Seek' : 'TimeChanged', args);
+    },
+    [dispatchPlayer],
+  );
+
+  const togglePlayback = useCallback(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    if (!video.paused) {
+      video.pause();
+      return;
+    }
+    void video.play().catch((error: unknown) => {
+      setPaused(true);
+      setMediaError('Playback could not start with this source.');
+      console.error(
+        '[kino:player] playback start failed',
+        error instanceof DOMException ? error.name : 'UnknownError',
+      );
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!duration) return;
+    const controller = new AbortController();
+    void lookupCommunityIntro(introIdentity(selection, duration), controller.signal)
+      .then(setMarker)
+      .catch((error: unknown) => {
+        if (error instanceof DOMException && error.name === 'AbortError') return;
+        console.info(
+          '[kino:intro] no trusted community marker',
+          error instanceof Error ? error.message : error,
+        );
+      });
+    return () => controller.abort();
+  }, [duration, selection]);
+
+  useEffect(() => {
+    if (
+      !marker ||
+      !settings.automaticIntroSkipping ||
+      autoSkippedRef.current ||
+      autoSkipSuppressedRef.current
+    )
+      return;
+    if (time < marker.startMs || time >= marker.endMs) return;
+    const video = videoRef.current;
+    if (!video) return;
+    video.currentTime = marker.endMs / 1000;
+    setTime(marker.endMs);
+    autoSkippedRef.current = true;
+    setAutomaticNotice(true);
+    reportProgress(true);
+  }, [marker, reportProgress, settings.automaticIntroSkipping, time]);
+
+  useEffect(() => {
+    if (!automaticNotice) return;
+    const timeout = window.setTimeout(() => setAutomaticNotice(false), 8_000);
+    return () => window.clearTimeout(timeout);
+  }, [automaticNotice]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const video = videoRef.current;
+      if (!video) return;
+      if (event.code === 'Space' || event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        togglePlayback();
+      } else if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+        event.preventDefault();
+        video.currentTime = Math.max(
+          0,
+          video.currentTime + (event.key === 'ArrowRight' ? 10 : -10),
+        );
+        reportProgress(true);
+      } else if (event.key.toLowerCase() === 'm') {
+        video.muted = !video.muted;
+      } else if (event.key.toLowerCase() === 'f') {
+        void containerRef.current?.requestFullscreen();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [reportProgress, togglePlayback]);
+
+  useEffect(() => () => reportProgress(), [reportProgress]);
+
+  const insideIntro = Boolean(marker && time >= marker.startMs && time < marker.endMs);
+  const markerStyle = useMemo(() => {
+    if (!marker || duration <= 0) return undefined;
+    return {
+      left: `${(marker.startMs / duration) * 100}%`,
+      width: `${((marker.endMs - marker.startMs) / duration) * 100}%`,
+    };
+  }, [duration, marker]);
+
+  return (
+    <div className={styles.player} ref={containerRef}>
+      {streamUrl ? (
+        <video
+          autoPlay
+          onCanPlay={() => setBuffering(false)}
+          onDurationChange={(event) => setDuration(event.currentTarget.duration * 1000)}
+          onEnded={() => {
+            setBuffering(false);
+            setPaused(true);
+            dispatchPlayer('Ended');
+          }}
+          onError={(event) => {
+            const video = event.currentTarget;
+            setBuffering(false);
+            setMediaError('This source could not be decoded or loaded.');
+            console.error('[kino:player] media failure', {
+              code: video.error?.code ?? 0,
+              networkState: video.networkState,
+              readyState: video.readyState,
+            });
+          }}
+          onLoadedMetadata={(event) => {
+            const video = event.currentTarget;
+            setDuration(video.duration * 1000);
+            setPaused(video.paused);
+            if (resumeTime > 0 && resumeTime < video.duration * 1000)
+              video.currentTime = resumeTime / 1000;
+          }}
+          onLoadStart={() => setBuffering(true)}
+          onPause={() => {
+            setPaused(true);
+            dispatchPlayer('PausedChanged', { paused: true });
+            reportProgress();
+          }}
+          onPlay={() => {
+            setPaused(false);
+            dispatchPlayer('PausedChanged', { paused: false });
+          }}
+          onPlaying={() => setBuffering(false)}
+          onSeeked={() => reportProgress(true)}
+          onStalled={() => setBuffering(true)}
+          onTimeUpdate={(event) => {
+            const nextTime = event.currentTarget.currentTime * 1000;
+            setTime(nextTime);
+            if (nextTime - lastProgressRef.current >= 5_000 || nextTime < lastProgressRef.current) {
+              lastProgressRef.current = nextTime;
+              reportProgress();
+            }
+          }}
+          playsInline
+          ref={videoRef}
+          src={streamUrl}
+          onWaiting={() => setBuffering(true)}
+        />
+      ) : null}
+
+      <div className={styles.playerTopbar}>
+        <button onClick={onBack} type="button">
+          <ArrowLeft aria-hidden size={18} />
+          Back to sources
+        </button>
+        <div>
+          <strong>{result.state?.title ?? selection.meta.name}</strong>
+          <span>{selection.video?.title ?? selection.stream.name ?? 'Selected source'}</span>
+        </div>
+      </div>
+
+      {result.loading ? <div className={styles.playerStatus}>Preparing source…</div> : null}
+      {sourceFailed ? (
+        <div className={styles.playerStatus}>
+          <strong>Source failed</strong>
+          <span>{mediaError ?? 'Return to source selection and choose another option.'}</span>
+        </div>
+      ) : null}
+      {streamUrl && buffering && !sourceFailed ? (
+        <div className={styles.playerStatus}>Buffering…</div>
+      ) : null}
+
+      {settings.skipIntroButton && insideIntro && !settings.automaticIntroSkipping ? (
+        <button
+          className={styles.skipIntro}
+          onClick={() => {
+            const video = videoRef.current;
+            if (!video || !marker) return;
+            video.currentTime = marker.endMs / 1000;
+            setTime(marker.endMs);
+            reportProgress(true);
+          }}
+          type="button"
+        >
+          Skip Intro
+          <SkipForward aria-hidden size={16} weight="fill" />
+        </button>
+      ) : null}
+
+      {automaticNotice && marker ? (
+        <div className={styles.skipNotice} role="status">
+          <span>Intro skipped</span>
+          <button
+            onClick={() => {
+              const video = videoRef.current;
+              if (!video) return;
+              autoSkipSuppressedRef.current = true;
+              video.currentTime = marker.startMs / 1000;
+              setTime(marker.startMs);
+              setAutomaticNotice(false);
+              reportProgress(true);
+            }}
+            type="button"
+          >
+            Undo
+          </button>
+        </div>
+      ) : null}
+
+      {streamUrl ? (
+        <div className={styles.playerControls}>
+          <div className={styles.timeline}>
+            {markerStyle ? <span className={styles.introRange} style={markerStyle} /> : null}
+            <input
+              aria-label="Playback position"
+              max={duration || 1}
+              min={0}
+              onChange={(event) => {
+                const video = videoRef.current;
+                if (!video) return;
+                video.currentTime = Number(event.target.value) / 1000;
+                setTime(Number(event.target.value));
+                reportProgress(true);
+              }}
+              step={1000}
+              type="range"
+              value={Math.min(time, duration || 1)}
+            />
+          </div>
+          <div className={styles.controlRow}>
+            <button aria-label={paused ? 'Play' : 'Pause'} onClick={togglePlayback} type="button">
+              {paused ? (
+                <Play aria-hidden size={20} weight="fill" />
+              ) : (
+                <Pause aria-hidden size={20} weight="fill" />
+              )}
+            </button>
+            <button
+              aria-label="Mute"
+              onClick={() => {
+                if (videoRef.current) videoRef.current.muted = !videoRef.current.muted;
+              }}
+              type="button"
+            >
+              <SpeakerHigh aria-hidden size={20} />
+            </button>
+            <span className={styles.timeLabel}>
+              {formatTime(time)} / {formatTime(duration)}
+            </span>
+            <button
+              aria-label="Fullscreen"
+              onClick={() => void containerRef.current?.requestFullscreen()}
+              type="button"
+            >
+              <ArrowsOut aria-hidden size={20} />
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/screens/SearchScreen.tsx
+++ b/apps/desktop/src/screens/SearchScreen.tsx
@@ -1,0 +1,74 @@
+import { useDeferredValue, useEffect, useMemo, useState } from 'react';
+
+import styles from '../App.module.css';
+import { MediaCard } from '../components/MediaCard';
+import { loadSearchAction } from '../core/actions';
+import { useCore } from '../core/context';
+import type { BoardState, CoreMetaPreview } from '../core/types';
+import { useCoreModel } from '../core/useCoreModel';
+import { enUS } from '../locales/en-US';
+
+export function SearchScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => void }) {
+  const { transport } = useCore();
+  const [query, setQuery] = useState('');
+  const deferredQuery = useDeferredValue(query.trim());
+  const result = useCoreModel<BoardState>(
+    'search',
+    deferredQuery ? loadSearchAction(deferredQuery) : null,
+    deferredQuery,
+  );
+  const catalogCount = result.state?.catalogs.length ?? 0;
+
+  useEffect(() => {
+    if (!transport || !deferredQuery || catalogCount === 0) return;
+    void transport.dispatch(
+      {
+        action: 'CatalogsWithExtra',
+        args: { action: 'LoadRange', args: { start: 0, end: catalogCount } },
+      },
+      'search',
+    );
+  }, [catalogCount, deferredQuery, transport]);
+  const items = useMemo(() => {
+    if (!deferredQuery) return [];
+    const unique = new Map<string, CoreMetaPreview>();
+    result.state?.catalogs.forEach((catalog) => {
+      if (catalog.content?.type !== 'Ready') return;
+      catalog.content.content.forEach((item) => unique.set(`${item.type}:${item.id}`, item));
+    });
+    return [...unique.values()];
+  }, [deferredQuery, result.state]);
+
+  return (
+    <div className={styles.page}>
+      <h1 className={styles.visuallyHidden}>{enUS.search.title}</h1>
+      <label className={styles.visuallyHidden} htmlFor="catalog-search">
+        {enUS.search.placeholder}
+      </label>
+      <input
+        autoFocus
+        className={styles.searchInput}
+        id="catalog-search"
+        onChange={(event) => setQuery(event.target.value)}
+        placeholder={enUS.search.placeholder}
+        type="search"
+        value={query}
+      />
+      {deferredQuery ? (
+        <p className={styles.searchHelp} role="status">
+          {result.loading ? enUS.search.loading : `${items.length} results`}
+        </p>
+      ) : (
+        <p className={styles.searchHelp}>{enUS.search.idle}</p>
+      )}
+      {result.error ? <p className={styles.loadError}>{enUS.search.error}</p> : null}
+      {items.length > 0 ? (
+        <div className={styles.mediaGrid}>
+          {items.map((item) => (
+            <MediaCard item={item} key={`${item.type}:${item.id}`} onOpen={() => onOpen(item)} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [react()],
+  worker: {
+    format: 'es',
+  },
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,12 +47,18 @@ importers:
       '@phosphor-icons/react':
         specifier: 2.1.10
         version: 2.1.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@stremio/stremio-core-web':
+        specifier: 0.61.0
+        version: 0.61.0
       react:
         specifier: 19.2.8
         version: 19.2.8
       react-dom:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
+      theintrodb:
+        specifier: 3.2.0
+        version: 3.2.0
     devDependencies:
       '@testing-library/jest-dom':
         specifier: 7.0.1
@@ -151,6 +157,10 @@ packages:
     resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.24.1':
+    resolution: {integrity: sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
@@ -406,6 +416,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@stremio/stremio-core-web@0.61.0':
+    resolution: {integrity: sha512-Wx3lDU5221rjg5U/ATgSg/e9crAbB2+/l4inlvl+lCHY6AlhOrcw+Po9+LPa6eLVkd2afjHTkBnUcnS92e7dkg==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -1083,6 +1096,9 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -1135,6 +1151,10 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  theintrodb@3.2.0:
+    resolution: {integrity: sha512-i/T5RMSBrrEzlWWoPulZo6ZY0GVFMzPf5SsjCCWAXn6H2mSYZW1vpqjlPfkTvKUyp9pElkA5L7gByRAuAvNmCw==}
+    engines: {node: '>=18.0'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1342,6 +1362,9 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -1440,6 +1463,10 @@ snapshots:
   '@babel/parser@7.29.8':
     dependencies:
       '@babel/types': 7.29.8
+
+  '@babel/runtime@7.24.1':
+    dependencies:
+      regenerator-runtime: 0.14.1
 
   '@babel/runtime@7.29.7': {}
 
@@ -1622,6 +1649,10 @@ snapshots:
   '@rolldown/pluginutils@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@stremio/stremio-core-web@0.61.0':
+    dependencies:
+      '@babel/runtime': 7.24.1
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -2268,6 +2299,8 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  regenerator-runtime@0.14.1: {}
+
   require-from-string@2.0.2: {}
 
   rolldown@1.2.5:
@@ -2320,6 +2353,10 @@ snapshots:
       min-indent: 1.0.1
 
   symbol-tree@3.2.4: {}
+
+  theintrodb@3.2.0:
+    dependencies:
+      zod: 3.25.76
 
   tinybench@2.9.0: {}
 
@@ -2466,5 +2503,7 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}


### PR DESCRIPTION
## Summary
- run the published Stremio Core Web runtime in an isolated worker with separate guest and account storage
- add real catalogs, search, title details, episode selection, explicit source selection, progress plumbing, and Stremio sign-in
- add the browser playback boundary plus trusted chapter/TheIntroDB intro marker rules and manual/automatic Skip Intro behavior
- preserve the original Kino UI while documenting the temporary Stremio Service requirement for torrent playback

## Validation
- pnpm check
- live guest catalog, search, series episode, public-domain source, player entry, account isolation, and responsive-width regression checks

## Checkpoint
Native macOS playback, decoding policy enforcement, HDR-to-SDR tone mapping, stereo downmix, and service packaging remain the next delivery step.