### PR TITLE
Secure native Stremio sessions in Keychain

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pnpm macos:build
 open build/macos/Kino.app
 ```
 
-The shell loads the packaged Kino UI and hands playback to libmpv with VideoToolbox hardware decoding, forced SDR output, and optional stereo downmixing. It is a local validation build, not yet a signed or self-contained distribution. Run the short native launch regression probe with:
+The shell loads the packaged Kino UI, keeps Stremio authentication material in macOS Keychain, and hands playback to libmpv with VideoToolbox hardware decoding, forced SDR output, and optional stereo downmixing. It is a local validation build, not yet a signed or self-contained distribution. Run the short native launch regression probe with:
 
 ```sh
 pnpm macos:check-launch

--- a/apps/desktop/src/core/secureProfileStorage.test.ts
+++ b/apps/desktop/src/core/secureProfileStorage.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { NamespacedStorage, SecureProfileStorage, type SecureAuthStorage } from './storage';
+
+function harness(initialSecret: string | null = null) {
+  const values = new Map<string, string>();
+  let secret = initialSecret;
+  const secure: SecureAuthStorage = {
+    read: async () => secret,
+    remove: async () => {
+      secret = null;
+    },
+    write: async (value) => {
+      secret = value;
+    },
+  };
+  const local = new NamespacedStorage(
+    {
+      getItem: (key) => values.get(key) ?? null,
+      removeItem: (key) => values.delete(key),
+      setItem: (key, value) => values.set(key, value),
+    },
+    'account',
+  );
+  return {
+    local,
+    secret: () => secret,
+    storage: new SecureProfileStorage(local, secure),
+  };
+}
+
+const auth = { key: 'secret-token', user: { email: 'viewer@example.com' } };
+const profile = { addons: [], auth, settings: { interfaceLanguage: 'eng' } };
+
+describe('secure account profile storage', () => {
+  it('keeps authentication material out of local storage and reconstructs the core profile', async () => {
+    const { local, secret, storage } = harness();
+
+    await storage.setItem('profile', JSON.stringify(profile));
+
+    expect(JSON.parse(local.getItem('profile') ?? '{}').auth).toBeNull();
+    expect(JSON.parse(secret() ?? '{}')).toEqual(auth);
+    expect(JSON.parse((await storage.getItem('profile')) ?? '{}')).toEqual(profile);
+  });
+
+  it('migrates a legacy native profile without leaving its auth object in local storage', async () => {
+    const { local, secret, storage } = harness();
+    local.setItem('profile', JSON.stringify(profile));
+
+    expect(JSON.parse((await storage.getItem('profile')) ?? '{}')).toEqual(profile);
+    expect(JSON.parse(local.getItem('profile') ?? '{}').auth).toBeNull();
+    expect(JSON.parse(secret() ?? '{}')).toEqual(auth);
+  });
+
+  it('removes secure authentication when the core signs out', async () => {
+    const { local, secret, storage } = harness(JSON.stringify(auth));
+
+    await storage.setItem('profile', JSON.stringify({ ...profile, auth: null }));
+
+    expect(secret()).toBeNull();
+    expect(JSON.parse(local.getItem('profile') ?? '{}').auth).toBeNull();
+  });
+
+  it('refuses to persist an invalid account profile in ordinary storage', async () => {
+    const { local, storage } = harness();
+
+    await expect(storage.setItem('profile', '{"auth":')).rejects.toThrow('invalid account profile');
+    expect(local.getItem('profile')).toBeNull();
+  });
+
+  it('clears an orphaned secure session when its profile is gone', async () => {
+    const { secret, storage } = harness(JSON.stringify(auth));
+
+    expect(await storage.getItem('profile')).toBeNull();
+    expect(secret()).toBeNull();
+  });
+
+  it('clears a corrupted secure session so the account can sign in again', async () => {
+    const { local, secret, storage } = harness('not-json');
+    local.setItem('profile', JSON.stringify({ ...profile, auth: null }));
+
+    expect(await storage.getItem('profile')).toBeNull();
+    expect(local.getItem('profile')).toBeNull();
+    expect(secret()).toBeNull();
+  });
+});

--- a/apps/desktop/src/core/storage.ts
+++ b/apps/desktop/src/core/storage.ts
@@ -4,6 +4,12 @@ interface KeyValueStorage {
   setItem(key: string, value: string): void;
 }
 
+export interface SecureAuthStorage {
+  read(): Promise<string | null>;
+  remove(): Promise<void>;
+  write(value: string): Promise<void>;
+}
+
 export type CoreSession = 'account' | 'guest';
 
 export class NamespacedStorage implements KeyValueStorage {
@@ -25,5 +31,107 @@ export class NamespacedStorage implements KeyValueStorage {
 
   setItem(key: string, value: string) {
     this.#storage.setItem(this.#prefix + key, value);
+  }
+}
+
+function jsonObject(value: string) {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export class SecureProfileStorage {
+  readonly #local: NamespacedStorage;
+  readonly #secure: SecureAuthStorage;
+
+  constructor(local: NamespacedStorage, secure: SecureAuthStorage) {
+    this.#local = local;
+    this.#secure = secure;
+  }
+
+  async getItem(key: string) {
+    const localValue = this.#local.getItem(key);
+    if (key !== 'profile') return localValue;
+    if (!localValue) {
+      await this.#secure.remove();
+      return null;
+    }
+
+    const profile = jsonObject(localValue);
+    if (!profile) {
+      await this.#secure.remove();
+      this.#local.removeItem(key);
+      return null;
+    }
+
+    const localAuth = profile.auth;
+    const secureValue = await this.#secure.read();
+    if (secureValue) {
+      const secureAuth = jsonObject(secureValue);
+      if (!secureAuth) {
+        await this.#secure.remove();
+        this.#local.removeItem(key);
+        return null;
+      }
+      if (localAuth !== null) {
+        profile.auth = null;
+        this.#local.setItem(key, JSON.stringify(profile));
+      }
+      profile.auth = secureAuth;
+      return JSON.stringify(profile);
+    }
+
+    if (localAuth && typeof localAuth === 'object' && !Array.isArray(localAuth)) {
+      try {
+        await this.#secure.write(JSON.stringify(localAuth));
+      } catch (error) {
+        this.#local.removeItem(key);
+        throw error;
+      }
+      profile.auth = null;
+      this.#local.setItem(key, JSON.stringify(profile));
+      profile.auth = localAuth;
+      return JSON.stringify(profile);
+    }
+
+    if (localAuth !== null && localAuth !== undefined) {
+      this.#local.removeItem(key);
+      throw new Error('The stored Stremio session is invalid.');
+    }
+
+    return localValue;
+  }
+
+  async removeItem(key: string) {
+    if (key === 'profile') await this.#secure.remove();
+    this.#local.removeItem(key);
+  }
+
+  async setItem(key: string, value: string) {
+    if (key !== 'profile') {
+      this.#local.setItem(key, value);
+      return;
+    }
+
+    const profile = jsonObject(value);
+    if (!profile || !('auth' in profile)) {
+      throw new Error('Stremio Core returned an invalid account profile.');
+    }
+
+    const auth = profile.auth;
+    if (auth && typeof auth === 'object' && !Array.isArray(auth)) {
+      await this.#secure.write(JSON.stringify(auth));
+    } else if (auth === null) {
+      await this.#secure.remove();
+    } else {
+      throw new Error('Stremio Core returned an invalid account profile.');
+    }
+    profile.auth = null;
+    this.#local.setItem(key, JSON.stringify(profile));
   }
 }

--- a/apps/desktop/src/core/transport.ts
+++ b/apps/desktop/src/core/transport.ts
@@ -1,7 +1,13 @@
 import Bridge from '@stremio/stremio-core-web/bridge.js';
 import CoreWorker from './core.worker?worker';
 
-import { NamespacedStorage, type CoreSession } from './storage';
+import { connectNativeSecureStore, nativeShellPresent } from '../native/player';
+import {
+  NamespacedStorage,
+  SecureProfileStorage,
+  type CoreSession,
+  type SecureAuthStorage,
+} from './storage';
 import type { CoreAction, CoreModelName, CoreRuntimeEvent } from './types';
 
 type CoreEventListener = (event: CoreRuntimeEvent) => void;
@@ -18,11 +24,63 @@ function currentHash() {
   return window.location.hash;
 }
 
+function nativeAuthStorage(): SecureAuthStorage {
+  let pending = Promise.resolve();
+  const store = async () => {
+    const secureStore = await connectNativeSecureStore();
+    if (!secureStore) throw new Error('The macOS secure store is unavailable.');
+    return secureStore;
+  };
+  const enqueue = <Result>(operation: () => Promise<Result>) => {
+    const result = pending.then(operation, operation);
+    pending = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+
+  return {
+    read: () =>
+      enqueue(async () => {
+        const secureStore = await store();
+        const result = await secureStore.readStremioAuth();
+        if (!result.ok) throw new Error('The macOS Keychain could not be read.');
+        return result.value || null;
+      }),
+    remove: () =>
+      enqueue(async () => {
+        const secureStore = await store();
+        if (!(await secureStore.clearStremioAuth())) {
+          throw new Error('The Stremio session could not be removed from macOS Keychain.');
+        }
+      }),
+    write: (value) =>
+      enqueue(async () => {
+        const secureStore = await store();
+        if (!(await secureStore.writeStremioAuth(value))) {
+          throw new Error('The Stremio session could not be saved to macOS Keychain.');
+        }
+      }),
+  };
+}
+
+export async function migrateNativeAccountProfile() {
+  if (!nativeShellPresent()) return;
+  const local = new NamespacedStorage(window.localStorage, 'account');
+  await new SecureProfileStorage(local, nativeAuthStorage()).getItem('profile');
+}
+
 export function createCoreTransport(session: CoreSession = 'guest'): CoreTransport {
   const listeners = new Set<CoreEventListener>();
   const worker = new CoreWorker();
+  const localStorage = new NamespacedStorage(window.localStorage, session);
+  const storage =
+    session === 'account' && nativeShellPresent()
+      ? new SecureProfileStorage(localStorage, nativeAuthStorage())
+      : localStorage;
   const scope = {
-    localStorage: new NamespacedStorage(window.localStorage, session),
+    localStorage: storage,
     location: {
       get hash() {
         return currentHash();

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -5,6 +5,7 @@ import { createRoot } from 'react-dom/client';
 import { App } from './App';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { CoreProvider } from './core/CoreProvider';
+import { migrateNativeAccountProfile } from './core/transport';
 import { nativeShellPresent } from './native/player';
 import './global.css';
 
@@ -15,13 +16,27 @@ const root = document.getElementById('root');
 if (!root) {
   throw new Error('Kino root element was not found.');
 }
+const rootElement = root;
 
-createRoot(root).render(
-  <StrictMode>
-    <ErrorBoundary>
-      <CoreProvider>
-        <App />
-      </CoreProvider>
-    </ErrorBoundary>
-  </StrictMode>,
-);
+async function start() {
+  try {
+    await migrateNativeAccountProfile();
+  } catch (error) {
+    console.error(
+      '[kino:keychain] account migration failed',
+      error instanceof Error ? error.message : 'UnknownError',
+    );
+  }
+
+  createRoot(rootElement).render(
+    <StrictMode>
+      <ErrorBoundary>
+        <CoreProvider>
+          <App />
+        </CoreProvider>
+      </ErrorBoundary>
+    </StrictMode>,
+  );
+}
+
+void start();

--- a/apps/desktop/src/native/player.ts
+++ b/apps/desktop/src/native/player.ts
@@ -15,8 +15,19 @@ export interface NativePlayer {
   stop(): void;
 }
 
+export interface NativeSecureStore {
+  clearStremioAuth(): Promise<boolean>;
+  readStremioAuth(): Promise<{ ok: boolean; value: string }>;
+  writeStremioAuth(value: string): Promise<boolean>;
+}
+
+interface NativeShellConnection {
+  player: NativePlayer;
+  secureStore: NativeSecureStore;
+}
+
 interface WebChannelResult {
-  objects: { kinoNative?: NativePlayer };
+  objects: { kinoNative?: NativePlayer; kinoSecureStore?: NativeSecureStore };
 }
 
 interface NativeWindow extends Window {
@@ -24,7 +35,7 @@ interface NativeWindow extends Window {
   qt?: { webChannelTransport?: object };
 }
 
-let connection: Promise<NativePlayer | null> | null = null;
+let connection: Promise<NativeShellConnection | null> | null = null;
 let channelScript: Promise<void> | null = null;
 
 function nativeWindow() {
@@ -50,16 +61,20 @@ function loadChannelScript() {
     });
     document.head.append(script);
   });
+  const pendingScript = channelScript;
+  void pendingScript.catch(() => {
+    if (channelScript === pendingScript) channelScript = null;
+  });
   return channelScript;
 }
 
-export function connectNativePlayer(): Promise<NativePlayer | null> {
+function connectNativeShell(): Promise<NativeShellConnection | null> {
   if (!nativeShellPresent()) return Promise.resolve(null);
   if (connection) return connection;
 
   connection = loadChannelScript().then(
     () =>
-      new Promise<NativePlayer>((resolve, reject) => {
+      new Promise<NativeShellConnection>((resolve, reject) => {
         const target = nativeWindow();
         const transport = target.qt?.webChannelTransport;
         const Channel = target.QWebChannel;
@@ -73,13 +88,27 @@ export function connectNativePlayer(): Promise<NativePlayer | null> {
         );
         new Channel(transport, (channel) => {
           window.clearTimeout(timeout);
-          if (!channel.objects.kinoNative) {
-            reject(new Error('Native player is unavailable.'));
+          const player = channel.objects.kinoNative;
+          const secureStore = channel.objects.kinoSecureStore;
+          if (!player || !secureStore) {
+            reject(new Error('Native shell services are unavailable.'));
             return;
           }
-          resolve(channel.objects.kinoNative);
+          resolve({ player, secureStore });
         });
       }),
   );
+  const pendingConnection = connection;
+  void pendingConnection.catch(() => {
+    if (connection === pendingConnection) connection = null;
+  });
   return connection;
+}
+
+export async function connectNativePlayer() {
+  return (await connectNativeShell())?.player ?? null;
+}
+
+export async function connectNativeSecureStore() {
+  return (await connectNativeShell())?.secureStore ?? null;
 }

--- a/apps/macos-shell/CMakeLists.txt
+++ b/apps/macos-shell/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(
   Qt6 6.8
   REQUIRED COMPONENTS
     Core
+    Concurrent
     Gui
     Qml
     Quick
@@ -21,6 +22,7 @@ find_package(
     WebEngineQuick
 )
 pkg_check_modules(MPV REQUIRED IMPORTED_TARGET mpv)
+find_library(SECURITY_FRAMEWORK Security REQUIRED)
 
 qt_standard_project_setup(REQUIRES 6.8)
 
@@ -34,6 +36,7 @@ qt_add_executable(
   src/logging.cpp
   src/main.cpp
   src/mpvitem.cpp
+  src/securestore.cpp
 )
 
 qt_add_qml_module(
@@ -41,7 +44,9 @@ qt_add_qml_module(
   URI KinoShell
   VERSION 1.0
   QML_FILES qml/Main.qml
-  SOURCES src/mpvitem.h
+  SOURCES
+    src/mpvitem.h
+    src/securestore.h
 )
 
 target_include_directories(Kino PRIVATE src)
@@ -49,6 +54,8 @@ target_link_libraries(
   Kino
   PRIVATE
     PkgConfig::MPV
+    ${SECURITY_FRAMEWORK}
+    Qt6::Concurrent
     Qt6::Core
     Qt6::Gui
     Qt6::Qml

--- a/apps/macos-shell/qml/Main.qml
+++ b/apps/macos-shell/qml/Main.qml
@@ -28,6 +28,10 @@ ApplicationWindow {
         visible: player.active
     }
 
+    SecureStore {
+        id: secureStore
+    }
+
     QtObject {
         id: nativeBridge
 
@@ -72,7 +76,10 @@ ApplicationWindow {
     WebChannel {
         id: channel
 
-        Component.onCompleted: registerObject("kinoNative", nativeBridge)
+        Component.onCompleted: {
+            registerObject("kinoNative", nativeBridge)
+            registerObject("kinoSecureStore", secureStore)
+        }
     }
 
     WebEngineView {

--- a/apps/macos-shell/src/securestore.cpp
+++ b/apps/macos-shell/src/securestore.cpp
@@ -1,0 +1,95 @@
+#include "securestore.h"
+
+#include <QtConcurrentRun>
+
+#include <Security/Security.h>
+
+namespace {
+
+CFMutableDictionaryRef makeQuery() {
+    CFMutableDictionaryRef query = CFDictionaryCreateMutable(
+        kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks,
+        &kCFTypeDictionaryValueCallBacks);
+    CFDictionarySetValue(query, kSecClass, kSecClassGenericPassword);
+    CFDictionarySetValue(query, kSecAttrService, CFSTR("com.chriscorbell.kino"));
+    CFDictionarySetValue(query, kSecAttrAccount, CFSTR("stremio-account-auth-v1"));
+    return query;
+}
+
+QVariantMap readAuth() {
+    CFMutableDictionaryRef query = makeQuery();
+    CFDictionarySetValue(query, kSecMatchLimit, kSecMatchLimitOne);
+    CFDictionarySetValue(query, kSecReturnData, kCFBooleanTrue);
+
+    CFTypeRef result = nullptr;
+    const OSStatus status = SecItemCopyMatching(query, &result);
+    CFRelease(query);
+    if (status == errSecItemNotFound) {
+        return {{QStringLiteral("ok"), true}, {QStringLiteral("value"), QString{}}};
+    }
+    if (status != errSecSuccess || !result || CFGetTypeID(result) != CFDataGetTypeID()) {
+        if (result) {
+            CFRelease(result);
+        }
+        qWarning("[kino:keychain] read failed status=%d", static_cast<int>(status));
+        return {{QStringLiteral("ok"), false}, {QStringLiteral("value"), QString{}}};
+    }
+
+    const auto data = static_cast<CFDataRef>(result);
+    const QString value = QString::fromUtf8(
+        reinterpret_cast<const char *>(CFDataGetBytePtr(data)), CFDataGetLength(data));
+    CFRelease(result);
+    return {{QStringLiteral("ok"), true}, {QStringLiteral("value"), value}};
+}
+
+bool writeAuth(const QString &value) {
+    const QByteArray encoded = value.toUtf8();
+    CFDataRef data = CFDataCreate(kCFAllocatorDefault,
+                                  reinterpret_cast<const UInt8 *>(encoded.constData()),
+                                  encoded.size());
+    CFMutableDictionaryRef query = makeQuery();
+    CFMutableDictionaryRef attributes = CFDictionaryCreateMutable(
+        kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks,
+        &kCFTypeDictionaryValueCallBacks);
+    CFDictionarySetValue(attributes, kSecValueData, data);
+
+    OSStatus status = SecItemUpdate(query, attributes);
+    if (status == errSecItemNotFound) {
+        CFDictionarySetValue(query, kSecValueData, data);
+        status = SecItemAdd(query, nullptr);
+    }
+
+    CFRelease(attributes);
+    CFRelease(query);
+    CFRelease(data);
+    if (status != errSecSuccess) {
+        qWarning("[kino:keychain] write failed status=%d", static_cast<int>(status));
+        return false;
+    }
+    return true;
+}
+
+bool clearAuth() {
+    CFMutableDictionaryRef query = makeQuery();
+    const OSStatus status = SecItemDelete(query);
+    CFRelease(query);
+    if (status != errSecSuccess && status != errSecItemNotFound) {
+        qWarning("[kino:keychain] delete failed status=%d", static_cast<int>(status));
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+QFuture<bool> SecureStore::clearStremioAuth() {
+    return QtConcurrent::run(clearAuth);
+}
+
+QFuture<QVariantMap> SecureStore::readStremioAuth() {
+    return QtConcurrent::run(readAuth);
+}
+
+QFuture<bool> SecureStore::writeStremioAuth(const QString &value) {
+    return QtConcurrent::run([value]() { return writeAuth(value); });
+}

--- a/apps/macos-shell/src/securestore.h
+++ b/apps/macos-shell/src/securestore.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <QFuture>
+#include <QObject>
+#include <QString>
+#include <QVariantMap>
+#include <QtQml/qqmlregistration.h>
+
+class SecureStore : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+public:
+    using QObject::QObject;
+
+    Q_INVOKABLE QFuture<bool> clearStremioAuth();
+    Q_INVOKABLE QFuture<QVariantMap> readStremioAuth();
+    Q_INVOKABLE QFuture<bool> writeStremioAuth(const QString &value);
+};


### PR DESCRIPTION
## Summary

- add an asynchronous macOS Keychain service exposed through QWebChannel
- split Stremio Core account profiles so auth material lives in Keychain while non-secret profile state stays namespaced in WebEngine storage
- migrate older native profiles at startup and fail closed when auth/profile data is malformed or Keychain operations fail
- serialize secure-store operations and clear Keychain state on logout or orphaned profiles

## Validation

- pnpm check (6 files, 20 tests)
- pnpm macos:build
- cmake --build build/macos --target Kino_qmllint
- pnpm macos:check-launch
- verified a disposable Keychain write/read/delete round-trip in the packaged app
- verified a disposable legacy local profile migrated to auth: null locally with its auth object in Keychain, then cleaned up both copies