### PR TITLE
Fail unavailable macOS hardware decoding

### DIFF
--- a/apps/desktop/src/screens/PlayerScreen.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.tsx
@@ -32,6 +32,9 @@ function introIdentity(selection: PlaybackSelection, durationMs: number) {
 }
 
 function nativeErrorMessage(code: unknown) {
+  if (code === 'hardware-decoding-unavailable') {
+    return 'This source could not be hardware-decoded on this Mac.';
+  }
   if (code === 'render-context-unavailable') {
     return 'Kino could not start the native video renderer.';
   }

--- a/apps/macos-shell/src/mpvitem.cpp
+++ b/apps/macos-shell/src/mpvitem.cpp
@@ -84,6 +84,16 @@ MpvItem::MpvItem(QQuickItem *parent)
     }
     connect(this, &MpvItem::renderUpdateRequested, this, qOverload<>(&MpvItem::update),
             Qt::QueuedConnection);
+    hardwareDecoderTimer_.setInterval(5'000);
+    hardwareDecoderTimer_.setSingleShot(true);
+    connect(&hardwareDecoderTimer_, &QTimer::timeout, this, [this]() {
+        if (!active_ || !videoPresent_ || hardwareDecoderActive_) {
+            return;
+        }
+        emitError(QStringLiteral("hardware-decoding-unavailable"));
+        const char *command[] = {"stop", nullptr};
+        mpv_command_async(handle_, 0, command);
+    });
     initialize();
 }
 
@@ -148,10 +158,14 @@ void MpvItem::initialize() {
     mpv_observe_property(handle_, 4, "paused-for-cache", MPV_FORMAT_FLAG);
     mpv_observe_property(handle_, 5, "mute", MPV_FORMAT_FLAG);
     mpv_observe_property(handle_, 6, "hwdec-current", MPV_FORMAT_STRING);
+    mpv_observe_property(handle_, 7, "video-format", MPV_FORMAT_STRING);
 }
 
 void MpvItem::load(const QString &url, bool forceStereo) {
     failed_ = false;
+    hardwareDecoderActive_ = false;
+    hardwareDecoderTimer_.stop();
+    videoPresent_ = false;
     setActive(true);
     QByteArray audioChannels = forceStereo ? QByteArrayLiteral("stereo")
                                            : QByteArrayLiteral("auto-safe");
@@ -188,6 +202,7 @@ void MpvItem::setPaused(bool paused) {
 }
 
 void MpvItem::stop() {
+    hardwareDecoderTimer_.stop();
     const char *command[] = {"stop", nullptr};
     mpv_command_async(handle_, 0, command);
     setActive(false);
@@ -250,14 +265,27 @@ void MpvItem::handleEvent(mpv_event *event) {
                                *static_cast<int *>(property->data) != 0}});
         } else if (name == "hwdec-current") {
             const auto *decoder = static_cast<const char *>(property->data);
-            if (*decoder != '\0') {
+            hardwareDecoderActive_ = decoder && *decoder != '\0';
+            if (hardwareDecoderActive_) {
+                hardwareDecoderTimer_.stop();
                 qInfo("[kino:mpv] hardware decoder active");
+            } else if (videoPresent_) {
+                hardwareDecoderTimer_.start();
+            }
+        } else if (name == "video-format") {
+            const auto *format = static_cast<const char *>(property->data);
+            videoPresent_ = format && *format != '\0';
+            if (videoPresent_ && !hardwareDecoderActive_) {
+                hardwareDecoderTimer_.start();
+            } else if (!videoPresent_) {
+                hardwareDecoderTimer_.stop();
             }
         }
         break;
     }
     case MPV_EVENT_END_FILE: {
         const auto *end = static_cast<mpv_event_end_file *>(event->data);
+        hardwareDecoderTimer_.stop();
         setActive(false);
         if (end && end->reason == MPV_END_FILE_REASON_ERROR) {
             emitError(QStringLiteral("decoder-or-stream-failed"));
@@ -281,6 +309,7 @@ void MpvItem::handleEvent(mpv_event *event) {
 
 void MpvItem::emitError(const QString &code) {
     failed_ = true;
+    hardwareDecoderTimer_.stop();
     setActive(false);
     qCritical("[kino:mpv] playback failed code=%s", qPrintable(code));
     emit playerEvent(QStringLiteral("error"), {{QStringLiteral("code"), code}});

--- a/apps/macos-shell/src/mpvitem.h
+++ b/apps/macos-shell/src/mpvitem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QQuickFramebufferObject>
+#include <QTimer>
 #include <QVariantMap>
 #include <QtQml/qqmlregistration.h>
 
@@ -47,6 +48,9 @@ private:
 
     bool active_ = false;
     bool failed_ = false;
+    bool hardwareDecoderActive_ = false;
+    bool videoPresent_ = false;
     mpv_handle *handle_ = nullptr;
     mpv_render_context *renderContext_ = nullptr;
+    QTimer hardwareDecoderTimer_;
 };


### PR DESCRIPTION
## Summary
- observe native video presence and the active mpv hardware decoder
- stop playback with a clear error when VideoToolbox does not initialize within five seconds
- preserve the hardware-only policy without silently falling back to software decoding

## Validation
- `pnpm check`
- `pnpm macos:build`
- `cmake --build build/macos --target Kino_qmllint`
- `pnpm macos:check-launch`
- verified a legal local H.264/AAC fixture produces `hardware-decoding-unavailable` while this Mac is locked
- independently confirmed standalone mpv cannot create a VideoToolbox device while the Mac is locked

## Current boundary
A positive rendered-frame VideoToolbox test still requires an unlocked Mac. This change does not enable software fallback.