### PR TITLE
Resolve Skip Intro from native media chapters

### DIFF
--- a/apps/desktop/src/intro/markers.test.ts
+++ b/apps/desktop/src/intro/markers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { markerFromChapters, markerFromCommunity } from './markers';
+import { markerFromChapterCues, markerFromChapters, markerFromCommunity } from './markers';
 
 describe('intro marker trust', () => {
   it('prefers an explicitly named chapter with safe bounds', () => {
@@ -19,6 +19,19 @@ describe('intro marker trust', () => {
         3_000_000,
       ),
     ).toBeNull();
+  });
+
+  it('ends a named native chapter at the next chapter cue', () => {
+    expect(
+      markerFromChapterCues(
+        [
+          { title: 'Prologue', startMs: 0 },
+          { title: 'Intro', startMs: 20_000 },
+          { title: '', startMs: 87_000 },
+        ],
+        2_400_000,
+      ),
+    ).toEqual({ source: 'chapter', startMs: 20_000, endMs: 87_000 });
   });
 
   it('requires confidence, corroboration, and duration-safe community data', () => {

--- a/apps/desktop/src/intro/markers.ts
+++ b/apps/desktop/src/intro/markers.ts
@@ -6,6 +6,8 @@ export interface Chapter {
   title: string;
 }
 
+export type ChapterCue = Omit<Chapter, 'endMs'>;
+
 export interface IntroIdentity {
   durationMs: number;
   episode?: number;
@@ -42,6 +44,22 @@ export function markerFromChapters(chapters: Chapter[], durationMs: number): Int
       validBounds(candidate.startMs, candidate.endMs, durationMs),
   );
   return chapter ? { source: 'chapter', startMs: chapter.startMs, endMs: chapter.endMs } : null;
+}
+
+export function markerFromChapterCues(
+  chapters: ChapterCue[],
+  durationMs: number,
+): IntroMarker | null {
+  const ordered = chapters
+    .filter((chapter) => Number.isFinite(chapter.startMs) && chapter.startMs >= 0)
+    .toSorted((left, right) => left.startMs - right.startMs);
+  return markerFromChapters(
+    ordered.map((chapter, index) => ({
+      ...chapter,
+      endMs: ordered[index + 1]?.startMs ?? durationMs,
+    })),
+    durationMs,
+  );
 }
 
 export function markerFromCommunity(

--- a/apps/desktop/src/screens/PlayerScreen.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.tsx
@@ -6,7 +6,12 @@ import { loadPlayerAction, playerAction, type PlaybackSelection } from '../core/
 import { useCore } from '../core/context';
 import type { PlayerState } from '../core/types';
 import { useCoreModel } from '../core/useCoreModel';
-import { lookupCommunityIntro, type IntroMarker } from '../intro/markers';
+import {
+  lookupCommunityIntro,
+  markerFromChapterCues,
+  type ChapterCue,
+  type IntroMarker,
+} from '../intro/markers';
 import { connectNativePlayer, nativeShellPresent, type NativePlayer } from '../native/player';
 import type { KinoSettings } from '../settings';
 
@@ -41,6 +46,17 @@ function nativeErrorMessage(code: unknown) {
   return 'The native player could not decode or load this source.';
 }
 
+function nativeChapterCues(value: unknown): ChapterCue[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((candidate): ChapterCue[] => {
+    if (!candidate || typeof candidate !== 'object') return [];
+    const { startMs, title } = candidate as Record<string, unknown>;
+    return typeof startMs === 'number' && Number.isFinite(startMs) && typeof title === 'string'
+      ? [{ startMs, title }]
+      : [];
+  });
+}
+
 export function PlayerScreen({
   onBack,
   selection,
@@ -61,7 +77,6 @@ export function PlayerScreen({
   const playbackRef = useRef({ duration: 0, time: 0 });
   const lastProgressRef = useRef(0);
   const resumeAppliedRef = useRef(false);
-  const autoSkippedRef = useRef(false);
   const autoSkipSuppressedRef = useRef(false);
   const [duration, setDuration] = useState(0);
   const [time, setTime] = useState(0);
@@ -70,13 +85,20 @@ export function PlayerScreen({
   const [buffering, setBuffering] = useState(false);
   const [mediaError, setMediaError] = useState<string | null>(null);
   const [nativePlayer, setNativePlayer] = useState<NativePlayer | null>(null);
-  const [marker, setMarker] = useState<IntroMarker | null>(null);
+  const [chapterCues, setChapterCues] = useState<ChapterCue[]>([]);
+  const [communityMarker, setCommunityMarker] = useState<IntroMarker | null>(null);
+  const [automaticSkipComplete, setAutomaticSkipComplete] = useState(false);
   const [automaticNotice, setAutomaticNotice] = useState(false);
   const stream = result.state?.stream?.type === 'Ready' ? result.state.stream.content : null;
   const streamUrl = stream?.url ?? null;
   const resumeTime = result.state?.libraryItem?.state.timeOffset ?? 0;
   const sourceFailed = result.state?.stream?.type === 'Err' || Boolean(result.error || mediaError);
   const nativeShell = nativeShellPresent();
+  const chapterMarker = useMemo(
+    () => markerFromChapterCues(chapterCues, duration),
+    [chapterCues, duration],
+  );
+  const marker = chapterMarker ?? communityMarker;
 
   const updateDuration = useCallback((milliseconds: number) => {
     playbackRef.current.duration = milliseconds;
@@ -216,6 +238,8 @@ export function PlayerScreen({
         setBuffering(payload.active);
       } else if (name === 'ready') {
         setBuffering(false);
+      } else if (name === 'chapters') {
+        setChapterCues(nativeChapterCues(payload.items));
       } else if (name === 'error') {
         setBuffering(false);
         setPaused(true);
@@ -256,10 +280,11 @@ export function PlayerScreen({
   }, [duration, resumeTime, seekTo]);
 
   useEffect(() => {
-    if (!duration) return;
+    if (!duration || chapterMarker) return;
+
     const controller = new AbortController();
     void lookupCommunityIntro(introIdentity(selection, duration), controller.signal)
-      .then(setMarker)
+      .then(setCommunityMarker)
       .catch((error: unknown) => {
         if (error instanceof DOMException && error.name === 'AbortError') return;
         console.info(
@@ -268,23 +293,31 @@ export function PlayerScreen({
         );
       });
     return () => controller.abort();
-  }, [duration, selection]);
+  }, [chapterMarker, duration, selection]);
 
   useEffect(() => {
     if (
       !marker ||
       !settings.automaticIntroSkipping ||
-      autoSkippedRef.current ||
+      automaticSkipComplete ||
       autoSkipSuppressedRef.current
     )
       return;
     if (time < marker.startMs || time >= marker.endMs) return;
     if (!nativePlayer && !videoRef.current) return;
     seekTo(marker.endMs);
-    autoSkippedRef.current = true;
+    setAutomaticSkipComplete(true);
     setAutomaticNotice(true);
     reportProgress(true);
-  }, [marker, nativePlayer, reportProgress, seekTo, settings.automaticIntroSkipping, time]);
+  }, [
+    automaticSkipComplete,
+    marker,
+    nativePlayer,
+    reportProgress,
+    seekTo,
+    settings.automaticIntroSkipping,
+    time,
+  ]);
 
   useEffect(() => {
     if (!automaticNotice) return;
@@ -410,7 +443,9 @@ export function PlayerScreen({
         <div className={styles.playerStatus}>Buffering…</div>
       ) : null}
 
-      {settings.skipIntroButton && insideIntro && !settings.automaticIntroSkipping ? (
+      {settings.skipIntroButton &&
+      insideIntro &&
+      (!settings.automaticIntroSkipping || automaticSkipComplete) ? (
         <button
           className={styles.skipIntro}
           onClick={() => {

--- a/apps/macos-shell/src/mpvitem.cpp
+++ b/apps/macos-shell/src/mpvitem.cpp
@@ -8,6 +8,7 @@
 #include <QOpenGLContext>
 #include <QOpenGLFramebufferObject>
 #include <QQuickOpenGLUtils>
+#include <QVariantList>
 
 #include <cmath>
 #include <stdexcept>
@@ -24,6 +25,43 @@ void *resolveOpenGlSymbol(void *, const char *name) {
 
 QVariantMap millisecondsPayload(double seconds) {
     return {{QStringLiteral("milliseconds"), std::llround(seconds * 1000.0)}};
+}
+
+QVariantList chapterPayload(const mpv_node &root) {
+    QVariantList chapters;
+    if (root.format != MPV_FORMAT_NODE_ARRAY || !root.u.list) {
+        return chapters;
+    }
+
+    for (int index = 0; index < root.u.list->num; ++index) {
+        const mpv_node &chapter = root.u.list->values[index];
+        if (chapter.format != MPV_FORMAT_NODE_MAP || !chapter.u.list) {
+            continue;
+        }
+
+        bool hasTime = false;
+        double time = 0;
+        QString title;
+        for (int field = 0; field < chapter.u.list->num; ++field) {
+            const QByteArray name(chapter.u.list->keys[field]);
+            const mpv_node &value = chapter.u.list->values[field];
+            if (name == "time" && value.format == MPV_FORMAT_DOUBLE) {
+                hasTime = std::isfinite(value.u.double_) && value.u.double_ >= 0;
+                time = value.u.double_;
+            } else if (name == "title" && value.format == MPV_FORMAT_STRING &&
+                       value.u.string) {
+                title = QString::fromUtf8(value.u.string);
+            }
+        }
+
+        if (hasTime) {
+            chapters.append(QVariantMap{
+                {QStringLiteral("startMs"), std::llround(time * 1000.0)},
+                {QStringLiteral("title"), title},
+            });
+        }
+    }
+    return chapters;
 }
 
 } // namespace
@@ -159,6 +197,7 @@ void MpvItem::initialize() {
     mpv_observe_property(handle_, 5, "mute", MPV_FORMAT_FLAG);
     mpv_observe_property(handle_, 6, "hwdec-current", MPV_FORMAT_STRING);
     mpv_observe_property(handle_, 7, "video-format", MPV_FORMAT_STRING);
+    mpv_observe_property(handle_, 8, "chapter-list", MPV_FORMAT_NODE);
 }
 
 void MpvItem::load(const QString &url, bool forceStereo) {
@@ -280,6 +319,11 @@ void MpvItem::handleEvent(mpv_event *event) {
             } else if (!videoPresent_) {
                 hardwareDecoderTimer_.stop();
             }
+        } else if (name == "chapter-list") {
+            const auto *chapters = static_cast<const mpv_node *>(property->data);
+            emit playerEvent(
+                QStringLiteral("chapters"),
+                {{QStringLiteral("items"), chapterPayload(*chapters)}});
         }
         break;
     }


### PR DESCRIPTION
## Summary
- expose libmpv chapter cues to the packaged Kino UI
- derive trusted intro ranges from recognized chapter names before querying TheIntroDB
- restore the manual Skip Intro action after an automatic skip has already run

## Validation
- `pnpm check` (21 tests)
- `pnpm macos:build`
- `cmake --build build/macos --target Kino_qmllint`
- `pnpm macos:check-launch`
- verified a disposable legal H.264/AAC fixture with Prologue, Opening Credits, and Story chapters emits the expected native QWebChannel payload

## Current boundary
The locked Mac still prevents a positive VideoToolbox rendered-frame test; chapter metadata validation completes before decode and was verified independently.