### PR TITLE
feat: complete native playback contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pnpm macos:build
 open build/macos/Kino.app
 ```
 
-The shell loads the packaged Kino UI, keeps Stremio authentication material in macOS Keychain, and hands playback to libmpv with VideoToolbox hardware decoding, forced SDR output, and optional stereo downmixing. It is a local validation build, not yet a signed or self-contained distribution. Run the short native launch regression probe with:
+The shell loads the packaged Kino UI, keeps Stremio authentication material in macOS Keychain, and hands playback to libmpv with VideoToolbox hardware decoding, forced SDR output, and optional stereo downmixing. Playback integrates with macOS media keys and Now Playing, blocks display sleep only while video plays, and exposes embedded and add-on subtitles with delay, size, and position controls. It is a local validation build, not yet a signed or self-contained distribution. Run the short native launch regression probe with:
 
 ```sh
 pnpm macos:check-launch

--- a/apps/desktop/src/App.module.css
+++ b/apps/desktop/src/App.module.css
@@ -711,13 +711,106 @@
   background: transparent;
 }
 
-.controlRow button:last-child {
-  margin-left: auto;
-}
-
 .timeLabel {
+  margin-right: auto;
   color: var(--kino-text-muted);
   font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.controlActive {
+  color: var(--kino-accent);
+}
+
+.subtitlePanel {
+  position: absolute;
+  right: 30px;
+  bottom: calc(100% - 44px);
+  display: grid;
+  overflow: hidden;
+  width: 264px;
+  border: 1px solid rgb(255 255 255 / 12%);
+  border-radius: var(--kino-panel-radius);
+  background: rgb(10 10 11 / 92%);
+  backdrop-filter: blur(14px);
+  animation: enter var(--kino-duration-standard) var(--kino-ease-out);
+}
+
+.subtitleTrackList {
+  display: grid;
+  overflow-y: auto;
+  max-height: 240px;
+  padding: 8px;
+}
+
+.subtitleTrackList button,
+.subtitleAdjustControls button {
+  display: flex;
+  align-items: center;
+  border: 0;
+  border-radius: var(--kino-control-radius);
+  color: var(--kino-text);
+  background: transparent;
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.subtitleTrackList button {
+  min-height: 34px;
+  justify-content: flex-start;
+  padding: 0 10px;
+  text-align: left;
+}
+
+.subtitleTrackList button[aria-pressed='true'] {
+  color: var(--kino-accent);
+  background: rgb(255 255 255 / 7%);
+}
+
+.subtitleGroupLabel {
+  padding: 10px 10px 4px;
+  color: var(--kino-text-faint);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.subtitleAdjust {
+  display: grid;
+  gap: 2px;
+  padding: 10px;
+  border-top: 1px solid rgb(255 255 255 / 8%);
+}
+
+.subtitleAdjustRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+}
+
+.subtitleAdjustRow > span:first-child {
+  color: var(--kino-text-muted);
+}
+
+.subtitleAdjustControls {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.subtitleAdjustControls button {
+  width: 28px;
+  min-height: 28px;
+  justify-content: center;
+  padding: 0;
+}
+
+.subtitleAdjustValue {
+  min-width: 48px;
+  text-align: center;
   font-variant-numeric: tabular-nums;
 }
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -7,12 +7,13 @@ import {
   Toolbox,
   type Icon,
 } from '@phosphor-icons/react';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import logo from './assets/kino.svg';
 import styles from './App.module.css';
 import { AccountDialog } from './components/AccountDialog';
 import type { PlaybackSelection } from './core/actions';
+import { sourceKey } from './core/sources';
 import type { CoreMetaPreview, ProfileState } from './core/types';
 import { useCoreModel } from './core/useCoreModel';
 import { enUS } from './locales/en-US';
@@ -230,6 +231,7 @@ export function App() {
   const [previousScreen, setPreviousScreen] = useState<Exclude<Screen, 'detail'>>('home');
   const [detail, setDetail] = useState<CoreMetaPreview | null>(null);
   const [playback, setPlayback] = useState<PlaybackSelection | null>(null);
+  const [failedSources, setFailedSources] = useState<ReadonlyMap<string, string>>(new Map());
   const [accountOpen, setAccountOpen] = useState(false);
   const profile = useCoreModel<ProfileState>('ctx', null, 'app-profile');
   const [settings, setSettings] = useState<KinoSettings>(() =>
@@ -243,12 +245,34 @@ export function App() {
   const openDetail = (item: CoreMetaPreview) => {
     if (screen !== 'detail') setPreviousScreen(screen);
     setDetail(item);
+    setFailedSources(new Map());
     setScreen('detail');
   };
 
+  const closePlayer = useCallback(() => setPlayback(null), []);
+  // Stable across settings re-renders: an unstable identity would restart the
+  // player's load effect while a stream is playing.
+  const reportSourceFailure = useCallback(
+    (message: string) => {
+      if (playback) {
+        const key = sourceKey(playback.stream, playback.streamTransportUrl);
+        setFailedSources((previous) => new Map(previous).set(key, message));
+      }
+      setPlayback(null);
+    },
+    [playback],
+  );
+
   if (playback) {
     return (
-      <PlayerScreen onBack={() => setPlayback(null)} selection={playback} settings={settings} />
+      <PlayerScreen
+        onBack={closePlayer}
+        onSettingsChange={setSettings}
+        onSourceFailure={reportSourceFailure}
+        preferredSubtitleLanguage={profile.state?.profile.settings?.subtitlesLanguage ?? null}
+        selection={playback}
+        settings={settings}
+      />
     );
   }
 
@@ -269,6 +293,7 @@ export function App() {
       case 'detail':
         return detail ? (
           <MetaDetailsScreen
+            failedSources={failedSources}
             item={detail}
             onBack={() => setScreen(previousScreen)}
             onPlay={setPlayback}

--- a/apps/desktop/src/core/sources.test.ts
+++ b/apps/desktop/src/core/sources.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { classifySource, sourceSize } from './sources';
+import { classifySource, sourceKey, sourceSize } from './sources';
 
 const base = { deepLinks: { player: 'stremio:///player/value' } };
 
@@ -15,5 +15,16 @@ describe('source compatibility', () => {
   it('formats binary source size without inventing missing metadata', () => {
     expect(sourceSize({ ...base, behaviorHints: { videoSize: 5 * 1024 ** 3 } })).toBe('5.0 GB');
     expect(sourceSize(base)).toBeNull();
+  });
+
+  it('keys sources by transport and stream identity', () => {
+    const transport = 'https://addon.example/manifest.json';
+    expect(sourceKey({ ...base, url: 'https://example.com/video.mp4' }, transport)).toBe(
+      `${transport}|https://example.com/video.mp4`,
+    );
+    expect(sourceKey({ ...base, infoHash: 'abc' }, transport)).toBe(`${transport}|abc`);
+    expect(sourceKey({ ...base, url: 'https://example.com/video.mp4' }, transport)).not.toBe(
+      sourceKey({ ...base, url: 'https://example.com/other.mp4' }, transport),
+    );
   });
 });

--- a/apps/desktop/src/core/sources.ts
+++ b/apps/desktop/src/core/sources.ts
@@ -9,6 +9,10 @@ export function classifySource(stream: CoreStream): SourceSupport {
   return 'unsupported';
 }
 
+export function sourceKey(stream: CoreStream, transportUrl: string) {
+  return `${transportUrl}|${stream.url ?? stream.infoHash ?? 'unknown'}`;
+}
+
 export function sourceTitle(stream: CoreStream) {
   return stream.name?.trim() || stream.description?.split('\n')[0]?.trim() || 'Unnamed source';
 }

--- a/apps/desktop/src/core/types.ts
+++ b/apps/desktop/src/core/types.ts
@@ -133,6 +133,7 @@ export interface PlayerState {
   } | null;
   selected: { stream: CoreStream } | null;
   stream: Loadable<CoreStream> | null;
+  subtitles?: unknown;
   title?: string | null;
 }
 
@@ -140,5 +141,6 @@ export interface ProfileState {
   profile: {
     addons: Array<{ manifest: { id: string; name: string }; transportUrl: string }>;
     auth?: { user: { email?: string; name?: string; uid?: string } };
+    settings?: { subtitlesLanguage?: string | null };
   };
 }

--- a/apps/desktop/src/locales/en-US.ts
+++ b/apps/desktop/src/locales/en-US.ts
@@ -77,6 +77,18 @@ export const enUS = {
     refreshing: 'Refreshing sources…',
     noSources: 'No sources were returned for this title.',
     unavailable: 'Not available',
+    failed: 'Failed',
+  },
+  player: {
+    subtitles: 'Subtitles',
+    subtitlesOff: 'Off',
+    subtitlesEmbedded: 'From this source',
+    subtitlesAddons: 'From add-ons',
+    subtitleDelay: 'Delay',
+    subtitleSize: 'Size',
+    subtitlePosition: 'Position',
+    decrease: 'Decrease',
+    increase: 'Increase',
   },
   errors: {
     title: 'Kino could not render this screen.',

--- a/apps/desktop/src/native/player.ts
+++ b/apps/desktop/src/native/player.ts
@@ -4,13 +4,19 @@ export interface NativePlayerEvent {
 }
 
 export interface NativePlayer {
+  addSubtitles(url: string, title: string, lang: string): void;
   load(url: string, forceStereo: boolean): void;
   platform: string;
   playerEvent: NativePlayerEvent;
   seek(seconds: number): void;
   setFullscreen(enabled: boolean): void;
   setMuted(muted: boolean): void;
+  setNowPlayingMetadata(title: string, subtitle: string): void;
   setPaused(paused: boolean): void;
+  setSubtitleDelay(seconds: number): void;
+  setSubtitlePosition(position: number): void;
+  setSubtitleScale(scale: number): void;
+  setSubtitleTrack(id: number): void;
   shellVersion: string;
   stop(): void;
 }

--- a/apps/desktop/src/player/subtitles.test.ts
+++ b/apps/desktop/src/player/subtitles.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  languagesMatch,
+  parseAddonSubtitles,
+  parseSubtitleTracks,
+  preferredSubtitleTrack,
+  subtitleTrackLabel,
+} from './subtitles';
+
+describe('subtitle tracks', () => {
+  it('keeps only well-formed subtitle track entries', () => {
+    expect(
+      parseSubtitleTracks([
+        { codec: 'subrip', external: false, id: 1, lang: 'eng', selected: true },
+        { id: 'two' },
+        null,
+        { external: true, id: 2, title: 'Signs & Songs' },
+      ]),
+    ).toEqual([
+      { codec: 'subrip', external: false, id: 1, lang: 'eng', selected: true },
+      { external: true, id: 2, selected: false, title: 'Signs & Songs' },
+    ]);
+  });
+
+  it('matches languages across ISO code variants', () => {
+    expect(languagesMatch('eng', 'en')).toBe(true);
+    expect(languagesMatch('ger', 'de')).toBe(true);
+    expect(languagesMatch('eng', 'de')).toBe(false);
+    expect(languagesMatch(undefined, 'en')).toBe(false);
+  });
+
+  it('prefers the profile language and refuses a wrong-language fallback', () => {
+    const tracks = parseSubtitleTracks([
+      { id: 1, lang: 'fre' },
+      { id: 2, lang: 'eng' },
+    ]);
+
+    expect(preferredSubtitleTrack(tracks, 'en')?.id).toBe(2);
+    expect(preferredSubtitleTrack(tracks, 'ja')).toBeNull();
+    expect(preferredSubtitleTrack(tracks, null)?.id).toBe(1);
+    expect(preferredSubtitleTrack([], 'en')).toBeNull();
+  });
+
+  it('labels tracks with a readable language and format', () => {
+    expect(
+      subtitleTrackLabel({ codec: 'subrip', external: false, id: 1, lang: 'eng', selected: false }),
+    ).toBe('English · SRT');
+    expect(
+      subtitleTrackLabel({ external: true, id: 3, selected: false, title: 'Director notes' }),
+    ).toBe('Director notes');
+    expect(subtitleTrackLabel({ external: false, id: 4, selected: false })).toBe('Track 4');
+  });
+
+  it('accepts only HTTPS add-on subtitles', () => {
+    expect(
+      parseAddonSubtitles([
+        { id: 'a', lang: 'eng', url: 'https://subs.example/a.srt' },
+        { lang: 'eng', url: 'http://subs.example/insecure.srt' },
+        { lang: 'eng' },
+        'nonsense',
+      ]),
+    ).toEqual([{ id: 'a', lang: 'eng', url: 'https://subs.example/a.srt' }]);
+  });
+});

--- a/apps/desktop/src/player/subtitles.ts
+++ b/apps/desktop/src/player/subtitles.ts
@@ -1,0 +1,100 @@
+export interface SubtitleTrack {
+  codec?: string;
+  external: boolean;
+  id: number;
+  lang?: string;
+  selected: boolean;
+  title?: string;
+}
+
+export interface AddonSubtitle {
+  id: string;
+  lang: string;
+  url: string;
+}
+
+const codecLabels: Record<string, string> = {
+  ass: 'ASS',
+  dvb_subtitle: 'DVB',
+  dvd_subtitle: 'DVD',
+  hdmv_pgs_subtitle: 'PGS',
+  mov_text: 'MP4',
+  ssa: 'SSA',
+  subrip: 'SRT',
+  webvtt: 'VTT',
+};
+
+function languageName(code: string) {
+  try {
+    const resolved = new Intl.DisplayNames(['en'], { type: 'language' }).of(code);
+    return resolved && resolved.toLowerCase() !== code ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+
+export function languagesMatch(candidate: string | undefined, preferred: string) {
+  const left = candidate?.trim().toLowerCase() ?? '';
+  const right = preferred.trim().toLowerCase();
+  if (!left || !right) return false;
+  if (left === right) return true;
+  const leftName = languageName(left);
+  return leftName !== null && leftName === languageName(right);
+}
+
+export function parseSubtitleTracks(value: unknown): SubtitleTrack[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((candidate): SubtitleTrack[] => {
+    if (!candidate || typeof candidate !== 'object') return [];
+    const entry = candidate as Record<string, unknown>;
+    if (typeof entry.id !== 'number' || !Number.isFinite(entry.id)) return [];
+    return [
+      {
+        ...(typeof entry.codec === 'string' ? { codec: entry.codec } : {}),
+        external: entry.external === true,
+        id: entry.id,
+        ...(typeof entry.lang === 'string' ? { lang: entry.lang } : {}),
+        selected: entry.selected === true,
+        ...(typeof entry.title === 'string' ? { title: entry.title } : {}),
+      },
+    ];
+  });
+}
+
+export function parseAddonSubtitles(value: unknown): AddonSubtitle[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((candidate): AddonSubtitle[] => {
+    if (!candidate || typeof candidate !== 'object') return [];
+    const entry = candidate as Record<string, unknown>;
+    if (typeof entry.url !== 'string' || !entry.url.startsWith('https://')) return [];
+    const lang = typeof entry.lang === 'string' ? entry.lang : '';
+    return [{ id: typeof entry.id === 'string' ? entry.id : entry.url, lang, url: entry.url }];
+  });
+}
+
+export function preferredSubtitleTrack(
+  tracks: SubtitleTrack[],
+  preferredLanguage: string | null,
+): SubtitleTrack | null {
+  if (tracks.length === 0) return null;
+  if (!preferredLanguage?.trim()) return tracks[0] ?? null;
+  return tracks.find((track) => languagesMatch(track.lang, preferredLanguage)) ?? null;
+}
+
+export function subtitleTrackLabel(track: SubtitleTrack) {
+  const name =
+    (track.lang ? languageName(track.lang.toLowerCase()) : null) ??
+    track.title?.trim() ??
+    track.lang ??
+    `Track ${track.id}`;
+  const codec = track.codec ? codecLabels[track.codec] : undefined;
+  return codec ? `${name} · ${codec}` : name;
+}
+
+export function addonSubtitleLabel(subtitle: AddonSubtitle) {
+  return (
+    (subtitle.lang ? languageName(subtitle.lang.toLowerCase()) : null) ??
+    subtitle.lang ??
+    'Unknown language'
+  );
+}

--- a/apps/desktop/src/screens/MetaDetailsScreen.tsx
+++ b/apps/desktop/src/screens/MetaDetailsScreen.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import styles from '../App.module.css';
 import { loadMetaDetailsAction, type PlaybackSelection } from '../core/actions';
-import { classifySource, sourceDetails, sourceSize, sourceTitle } from '../core/sources';
+import { classifySource, sourceDetails, sourceKey, sourceSize, sourceTitle } from '../core/sources';
 import type {
   CoreMetaItem,
   CoreMetaPreview,
@@ -32,10 +32,12 @@ function defaultVideoId(item: CoreMetaPreview) {
 }
 
 export function MetaDetailsScreen({
+  failedSources,
   item,
   onBack,
   onPlay,
 }: {
+  failedSources: ReadonlyMap<string, string>;
   item: CoreMetaPreview;
   onBack: () => void;
   onPlay: (selection: PlaybackSelection) => void;
@@ -158,6 +160,11 @@ export function MetaDetailsScreen({
             <h2 id="sources-heading">{enUS.details.sources}</h2>
             {result.loading ? <span>{enUS.details.refreshing}</span> : null}
           </div>
+          {failedSources.size > 0 ? (
+            <p className={styles.loadError} role="status">
+              {[...failedSources.values()].at(-1)}
+            </p>
+          ) : null}
           {!result.loading && sources.length === 0 ? (
             <p className={styles.inlineEmpty}>{enUS.details.noSources}</p>
           ) : null}
@@ -166,6 +173,7 @@ export function MetaDetailsScreen({
               const support = classifySource(source.stream);
               const playable =
                 (support === 'direct' || support === 'torrent') && Boolean(source.transportUrl);
+              const failed = failedSources.has(sourceKey(source.stream, source.transportUrl));
               return (
                 <button
                   className={styles.sourceButton}
@@ -191,6 +199,7 @@ export function MetaDetailsScreen({
                     {sourceSize(source.stream) ? <span>{sourceSize(source.stream)}</span> : null}
                     <span>{source.addonName}</span>
                     {!playable ? <em>{enUS.details.unavailable}</em> : null}
+                    {playable && failed ? <em>{enUS.details.failed}</em> : null}
                   </span>
                 </button>
               );

--- a/apps/desktop/src/screens/PlayerScreen.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.tsx
@@ -1,4 +1,14 @@
-import { ArrowLeft, ArrowsOut, Pause, Play, SkipForward, SpeakerHigh } from '@phosphor-icons/react';
+import {
+  ArrowLeft,
+  ArrowsOut,
+  Minus,
+  Pause,
+  Play,
+  Plus,
+  SkipForward,
+  SpeakerHigh,
+  Subtitles,
+} from '@phosphor-icons/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import styles from '../App.module.css';
@@ -12,8 +22,18 @@ import {
   type ChapterCue,
   type IntroMarker,
 } from '../intro/markers';
+import { enUS } from '../locales/en-US';
 import { connectNativePlayer, nativeShellPresent, type NativePlayer } from '../native/player';
-import type { KinoSettings } from '../settings';
+import {
+  addonSubtitleLabel,
+  parseAddonSubtitles,
+  parseSubtitleTracks,
+  preferredSubtitleTrack,
+  subtitleTrackLabel,
+  type AddonSubtitle,
+  type SubtitleTrack,
+} from '../player/subtitles';
+import { subtitlePositionRange, subtitleSizeRange, type KinoSettings } from '../settings';
 
 function formatTime(milliseconds: number) {
   const seconds = Math.max(0, Math.floor(milliseconds / 1000));
@@ -57,12 +77,45 @@ function nativeChapterCues(value: unknown): ChapterCue[] {
   });
 }
 
+function AdjustRow({
+  label,
+  onDecrease,
+  onIncrease,
+  value,
+}: {
+  label: string;
+  onDecrease: () => void;
+  onIncrease: () => void;
+  value: string;
+}) {
+  return (
+    <div className={styles.subtitleAdjustRow}>
+      <span>{label}</span>
+      <span className={styles.subtitleAdjustControls}>
+        <button aria-label={`${enUS.player.decrease} ${label}`} onClick={onDecrease} type="button">
+          <Minus aria-hidden size={14} />
+        </button>
+        <span className={styles.subtitleAdjustValue}>{value}</span>
+        <button aria-label={`${enUS.player.increase} ${label}`} onClick={onIncrease} type="button">
+          <Plus aria-hidden size={14} />
+        </button>
+      </span>
+    </div>
+  );
+}
+
 export function PlayerScreen({
   onBack,
+  onSettingsChange,
+  onSourceFailure,
+  preferredSubtitleLanguage,
   selection,
   settings,
 }: {
   onBack: () => void;
+  onSettingsChange: (settings: KinoSettings) => void;
+  onSourceFailure: (message: string) => void;
+  preferredSubtitleLanguage: string | null;
   selection: PlaybackSelection;
   settings: KinoSettings;
 }) {
@@ -83,17 +136,26 @@ export function PlayerScreen({
   const [paused, setPaused] = useState(true);
   const [muted, setMuted] = useState(false);
   const [buffering, setBuffering] = useState(false);
-  const [mediaError, setMediaError] = useState<string | null>(null);
   const [nativePlayer, setNativePlayer] = useState<NativePlayer | null>(null);
   const [chapterCues, setChapterCues] = useState<ChapterCue[]>([]);
   const [communityMarker, setCommunityMarker] = useState<IntroMarker | null>(null);
   const [automaticSkipComplete, setAutomaticSkipComplete] = useState(false);
   const [automaticNotice, setAutomaticNotice] = useState(false);
+  const [subtitleTracks, setSubtitleTracks] = useState<SubtitleTrack[]>([]);
+  const [subtitleMenuOpen, setSubtitleMenuOpen] = useState(false);
+  const [subtitleDelayMs, setSubtitleDelayMs] = useState(0);
+  const [addedSubtitleUrls, setAddedSubtitleUrls] = useState<ReadonlySet<string>>(new Set());
+  const failureReportedRef = useRef(false);
+  const subtitleAutoDoneRef = useRef(false);
   const stream = result.state?.stream?.type === 'Ready' ? result.state.stream.content : null;
   const streamUrl = stream?.url ?? null;
   const resumeTime = result.state?.libraryItem?.state.timeOffset ?? 0;
-  const sourceFailed = result.state?.stream?.type === 'Err' || Boolean(result.error || mediaError);
   const nativeShell = nativeShellPresent();
+  const addonSubtitles = useMemo(
+    () => parseAddonSubtitles(result.state?.subtitles),
+    [result.state],
+  );
+  const selectedSubtitleId = subtitleTracks.find((track) => track.selected)?.id ?? null;
   const chapterMarker = useMemo(
     () => markerFromChapterCues(chapterCues, duration),
     [chapterCues, duration],
@@ -142,6 +204,19 @@ export function PlayerScreen({
     [dispatchPlayer, nativeShell],
   );
 
+  // The contract on failure: save progress, record a sanitized diagnostic, mark
+  // the source failed for this selection session, and return to the source list.
+  const reportFailure = useCallback(
+    (message: string, diagnostic: Record<string, unknown> = {}) => {
+      if (failureReportedRef.current) return;
+      failureReportedRef.current = true;
+      reportProgress();
+      console.error('[kino:player] source failed', { message, ...diagnostic });
+      onSourceFailure(message);
+    },
+    [onSourceFailure, reportProgress],
+  );
+
   const togglePlayback = useCallback(() => {
     if (nativePlayer) {
       const nextPaused = !paused;
@@ -158,13 +233,11 @@ export function PlayerScreen({
     }
     void video.play().catch((error: unknown) => {
       setPaused(true);
-      setMediaError('Playback could not start with this source.');
-      console.error(
-        '[kino:player] playback start failed',
-        error instanceof DOMException ? error.name : 'UnknownError',
-      );
+      reportFailure('Playback could not start with this source.', {
+        code: error instanceof DOMException ? error.name : 'UnknownError',
+      });
     });
-  }, [dispatchPlayer, nativePlayer, paused]);
+  }, [dispatchPlayer, nativePlayer, paused, reportFailure]);
 
   const seekTo = useCallback(
     (milliseconds: number) => {
@@ -197,6 +270,47 @@ export function PlayerScreen({
     }
   }, [nativePlayer]);
 
+  const selectSubtitleTrack = (id: number | null) => {
+    if (!nativePlayer) return;
+    subtitleAutoDoneRef.current = true;
+    nativePlayer.setSubtitleTrack(id ?? 0);
+    if (settings.subtitles !== (id !== null)) {
+      onSettingsChange({ ...settings, subtitles: id !== null });
+    }
+  };
+
+  const addAddonSubtitle = (subtitle: AddonSubtitle) => {
+    if (!nativePlayer || addedSubtitleUrls.has(subtitle.url)) return;
+    subtitleAutoDoneRef.current = true;
+    setAddedSubtitleUrls((previous) => new Set(previous).add(subtitle.url));
+    nativePlayer.addSubtitles(subtitle.url, addonSubtitleLabel(subtitle), subtitle.lang);
+    if (!settings.subtitles) onSettingsChange({ ...settings, subtitles: true });
+  };
+
+  const changeSubtitleDelay = (deltaMs: number) => {
+    const next = Math.max(-60_000, Math.min(60_000, subtitleDelayMs + deltaMs));
+    setSubtitleDelayMs(next);
+    nativePlayer?.setSubtitleDelay(next / 1000);
+  };
+
+  const changeSubtitleSize = (delta: number) => {
+    const next = Math.max(
+      subtitleSizeRange.min,
+      Math.min(subtitleSizeRange.max, settings.subtitleSize + delta),
+    );
+    if (next !== settings.subtitleSize) onSettingsChange({ ...settings, subtitleSize: next });
+  };
+
+  const changeSubtitlePosition = (delta: number) => {
+    const next = Math.max(
+      subtitlePositionRange.min,
+      Math.min(subtitlePositionRange.max, settings.subtitlePosition + delta),
+    );
+    if (next !== settings.subtitlePosition) {
+      onSettingsChange({ ...settings, subtitlePosition: next });
+    }
+  };
+
   useEffect(() => {
     if (!nativeShell) return;
     let disposed = false;
@@ -206,16 +320,23 @@ export function PlayerScreen({
       })
       .catch((error: unknown) => {
         if (disposed) return;
-        setMediaError('Kino could not connect to the native player.');
-        console.error(
-          '[kino:native] player connection failed',
-          error instanceof Error ? error.message : 'UnknownError',
-        );
+        reportFailure('Kino could not connect to the native player.', {
+          code: error instanceof Error ? error.message : 'UnknownError',
+        });
       });
     return () => {
       disposed = true;
     };
-  }, [nativeShell]);
+  }, [nativeShell, reportFailure]);
+
+  useEffect(() => {
+    if (result.loading) return;
+    if (result.error) {
+      reportFailure('The source could not be prepared.');
+    } else if (result.state?.stream?.type === 'Err') {
+      reportFailure('The add-on could not resolve this source.');
+    }
+  }, [reportFailure, result.error, result.loading, result.state]);
 
   useEffect(() => {
     if (!nativePlayer || !streamUrl) return;
@@ -240,10 +361,12 @@ export function PlayerScreen({
         setBuffering(false);
       } else if (name === 'chapters') {
         setChapterCues(nativeChapterCues(payload.items));
+      } else if (name === 'subtitleTracks') {
+        setSubtitleTracks(parseSubtitleTracks(payload.items));
       } else if (name === 'error') {
         setBuffering(false);
         setPaused(true);
-        setMediaError(nativeErrorMessage(payload.code));
+        reportFailure(nativeErrorMessage(payload.code), { code: payload.code });
       } else if (name === 'ended') {
         setBuffering(false);
         setPaused(true);
@@ -262,12 +385,35 @@ export function PlayerScreen({
   }, [
     dispatchPlayer,
     nativePlayer,
+    reportFailure,
     reportProgress,
     settings.audioOutput,
     streamUrl,
     updateDuration,
     updateTime,
   ]);
+
+  useEffect(() => {
+    if (!nativePlayer) return;
+    nativePlayer.setSubtitleScale(settings.subtitleSize / 100);
+    nativePlayer.setSubtitlePosition(settings.subtitlePosition);
+  }, [nativePlayer, settings.subtitlePosition, settings.subtitleSize]);
+
+  useEffect(() => {
+    if (!nativePlayer) return;
+    nativePlayer.setNowPlayingMetadata(
+      result.state?.title ?? selection.meta.name,
+      selection.video?.title ?? selection.meta.name,
+    );
+  }, [nativePlayer, result.state?.title, selection]);
+
+  useEffect(() => {
+    if (!nativePlayer || subtitleAutoDoneRef.current || !settings.subtitles) return;
+    const track = preferredSubtitleTrack(subtitleTracks, preferredSubtitleLanguage);
+    if (!track) return;
+    subtitleAutoDoneRef.current = true;
+    nativePlayer.setSubtitleTrack(track.id);
+  }, [nativePlayer, preferredSubtitleLanguage, settings.subtitles, subtitleTracks]);
 
   useEffect(() => {
     if (resumeAppliedRef.current || duration <= 0 || resumeTime <= 0 || resumeTime >= duration)
@@ -378,8 +524,7 @@ export function PlayerScreen({
           onError={(event) => {
             const video = event.currentTarget;
             setBuffering(false);
-            setMediaError('This source could not be decoded or loaded.');
-            console.error('[kino:player] media failure', {
+            reportFailure('This source could not be decoded or loaded.', {
               code: video.error?.code ?? 0,
               networkState: video.networkState,
               readyState: video.readyState,
@@ -430,18 +575,10 @@ export function PlayerScreen({
       </div>
 
       {result.loading ? <div className={styles.playerStatus}>Preparing source…</div> : null}
-      {nativeShell && !nativePlayer && !sourceFailed ? (
+      {nativeShell && !nativePlayer ? (
         <div className={styles.playerStatus}>Preparing native player…</div>
       ) : null}
-      {sourceFailed ? (
-        <div className={styles.playerStatus}>
-          <strong>Source failed</strong>
-          <span>{mediaError ?? 'Return to source selection and choose another option.'}</span>
-        </div>
-      ) : null}
-      {streamUrl && buffering && !sourceFailed ? (
-        <div className={styles.playerStatus}>Buffering…</div>
-      ) : null}
+      {streamUrl && buffering ? <div className={styles.playerStatus}>Buffering…</div> : null}
 
       {settings.skipIntroButton &&
       insideIntro &&
@@ -479,6 +616,64 @@ export function PlayerScreen({
 
       {streamUrl ? (
         <div className={styles.playerControls}>
+          {subtitleMenuOpen && nativePlayer ? (
+            <div aria-label={enUS.player.subtitles} className={styles.subtitlePanel}>
+              <div className={styles.subtitleTrackList}>
+                <button
+                  aria-pressed={selectedSubtitleId === null}
+                  onClick={() => selectSubtitleTrack(null)}
+                  type="button"
+                >
+                  {enUS.player.subtitlesOff}
+                </button>
+                {subtitleTracks.map((track) => (
+                  <button
+                    aria-pressed={track.id === selectedSubtitleId}
+                    key={track.id}
+                    onClick={() => selectSubtitleTrack(track.id)}
+                    type="button"
+                  >
+                    {subtitleTrackLabel(track)}
+                  </button>
+                ))}
+                {addonSubtitles.some((subtitle) => !addedSubtitleUrls.has(subtitle.url)) ? (
+                  <span className={styles.subtitleGroupLabel}>{enUS.player.subtitlesAddons}</span>
+                ) : null}
+                {addonSubtitles
+                  .filter((subtitle) => !addedSubtitleUrls.has(subtitle.url))
+                  .map((subtitle) => (
+                    <button
+                      aria-pressed={false}
+                      key={subtitle.id}
+                      onClick={() => addAddonSubtitle(subtitle)}
+                      type="button"
+                    >
+                      {addonSubtitleLabel(subtitle)}
+                    </button>
+                  ))}
+              </div>
+              <div className={styles.subtitleAdjust}>
+                <AdjustRow
+                  label={enUS.player.subtitleDelay}
+                  onDecrease={() => changeSubtitleDelay(-500)}
+                  onIncrease={() => changeSubtitleDelay(500)}
+                  value={`${subtitleDelayMs >= 0 ? '+' : ''}${(subtitleDelayMs / 1000).toFixed(1)}s`}
+                />
+                <AdjustRow
+                  label={enUS.player.subtitleSize}
+                  onDecrease={() => changeSubtitleSize(-10)}
+                  onIncrease={() => changeSubtitleSize(10)}
+                  value={`${settings.subtitleSize}%`}
+                />
+                <AdjustRow
+                  label={enUS.player.subtitlePosition}
+                  onDecrease={() => changeSubtitlePosition(-5)}
+                  onIncrease={() => changeSubtitlePosition(5)}
+                  value={`${settings.subtitlePosition}%`}
+                />
+              </div>
+            </div>
+          ) : null}
           <div className={styles.timeline}>
             {markerStyle ? <span className={styles.introRange} style={markerStyle} /> : null}
             <input
@@ -508,6 +703,17 @@ export function PlayerScreen({
             <span className={styles.timeLabel}>
               {formatTime(time)} / {formatTime(duration)}
             </span>
+            {nativePlayer ? (
+              <button
+                aria-expanded={subtitleMenuOpen}
+                aria-label={enUS.player.subtitles}
+                className={subtitleMenuOpen ? styles.controlActive : undefined}
+                onClick={() => setSubtitleMenuOpen((open) => !open)}
+                type="button"
+              >
+                <Subtitles aria-hidden size={20} />
+              </button>
+            ) : null}
             <button aria-label="Fullscreen" onClick={enterFullscreen} type="button">
               <ArrowsOut aria-hidden size={20} />
             </button>

--- a/apps/desktop/src/settings.test.ts
+++ b/apps/desktop/src/settings.test.ts
@@ -38,6 +38,8 @@ describe('settings storage', () => {
         audioOutput: 'surround',
         matchFrameRate: true,
         skipIntroButton: false,
+        subtitlePosition: 90,
+        subtitleSize: 9000,
         subtitles: 'yes',
       }),
     );
@@ -47,6 +49,8 @@ describe('settings storage', () => {
       audioOutput: 'auto',
       matchFrameRate: true,
       skipIntroButton: false,
+      subtitlePosition: 90,
+      subtitleSize: 100,
       subtitles: false,
     });
   });

--- a/apps/desktop/src/settings.ts
+++ b/apps/desktop/src/settings.ts
@@ -7,19 +7,35 @@ export interface KinoSettings {
   audioOutput: AudioOutput;
   matchFrameRate: boolean;
   skipIntroButton: boolean;
+  subtitlePosition: number;
+  subtitleSize: number;
   subtitles: boolean;
 }
+
+export const subtitlePositionRange = { max: 110, min: 50 } as const;
+export const subtitleSizeRange = { max: 200, min: 50 } as const;
 
 export const defaultSettings: KinoSettings = {
   automaticIntroSkipping: false,
   audioOutput: 'auto',
   matchFrameRate: false,
   skipIntroButton: true,
+  subtitlePosition: 100,
+  subtitleSize: 100,
   subtitles: false,
 };
 
 function isAudioOutput(value: unknown): value is AudioOutput {
   return value === 'auto' || value === 'stereo';
+}
+
+function boundedNumber(value: unknown, range: { max: number; min: number }, fallback: number) {
+  return typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value >= range.min &&
+    value <= range.max
+    ? value
+    : fallback;
 }
 
 export function loadSettings(storage: Pick<Storage, 'getItem'>): KinoSettings {
@@ -60,6 +76,16 @@ export function loadSettings(storage: Pick<Storage, 'getItem'>): KinoSettings {
         typeof values.skipIntroButton === 'boolean'
           ? values.skipIntroButton
           : defaultSettings.skipIntroButton,
+      subtitlePosition: boundedNumber(
+        values.subtitlePosition,
+        subtitlePositionRange,
+        defaultSettings.subtitlePosition,
+      ),
+      subtitleSize: boundedNumber(
+        values.subtitleSize,
+        subtitleSizeRange,
+        defaultSettings.subtitleSize,
+      ),
       subtitles:
         typeof values.subtitles === 'boolean' ? values.subtitles : defaultSettings.subtitles,
     };

--- a/apps/macos-shell/CMakeLists.txt
+++ b/apps/macos-shell/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(Kino VERSION 0.1.0 LANGUAGES CXX)
+project(Kino VERSION 0.1.0 LANGUAGES CXX OBJCXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -22,6 +22,9 @@ find_package(
     WebEngineQuick
 )
 pkg_check_modules(MPV REQUIRED IMPORTED_TARGET mpv)
+find_library(FOUNDATION_FRAMEWORK Foundation REQUIRED)
+find_library(IOKIT_FRAMEWORK IOKit REQUIRED)
+find_library(MEDIAPLAYER_FRAMEWORK MediaPlayer REQUIRED)
 find_library(SECURITY_FRAMEWORK Security REQUIRED)
 
 qt_standard_project_setup(REQUIRES 6.8)
@@ -36,6 +39,8 @@ qt_add_executable(
   src/logging.cpp
   src/main.cpp
   src/mpvitem.cpp
+  src/nowplaying.mm
+  src/powerguard.cpp
   src/securestore.cpp
 )
 
@@ -46,6 +51,7 @@ qt_add_qml_module(
   QML_FILES qml/Main.qml
   SOURCES
     src/mpvitem.h
+    src/nowplaying.h
     src/securestore.h
 )
 
@@ -54,6 +60,9 @@ target_link_libraries(
   Kino
   PRIVATE
     PkgConfig::MPV
+    ${FOUNDATION_FRAMEWORK}
+    ${IOKIT_FRAMEWORK}
+    ${MEDIAPLAYER_FRAMEWORK}
     ${SECURITY_FRAMEWORK}
     Qt6::Concurrent
     Qt6::Core

--- a/apps/macos-shell/qml/Main.qml
+++ b/apps/macos-shell/qml/Main.qml
@@ -26,6 +26,12 @@ ApplicationWindow {
         id: player
         anchors.fill: parent
         visible: player.active
+
+        onActiveChanged: nowPlaying.setActive(player.active)
+    }
+
+    NowPlaying {
+        id: nowPlaying
     }
 
     SecureStore {
@@ -39,6 +45,10 @@ ApplicationWindow {
         readonly property string shellVersion: Qt.application.version
 
         signal playerEvent(string name, var payload)
+
+        function addSubtitles(url, title, lang) {
+            player.addSubtitles(url, title, lang)
+        }
 
         function load(url, forceStereo) {
             player.load(url, forceStereo)
@@ -56,8 +66,28 @@ ApplicationWindow {
             player.setMuted(muted)
         }
 
+        function setNowPlayingMetadata(title, subtitle) {
+            nowPlaying.setMetadata(title, subtitle)
+        }
+
         function setPaused(paused) {
             player.setPaused(paused)
+        }
+
+        function setSubtitleDelay(seconds) {
+            player.setSubtitleDelay(seconds)
+        }
+
+        function setSubtitlePosition(position) {
+            player.setSubtitlePosition(position)
+        }
+
+        function setSubtitleScale(scale) {
+            player.setSubtitleScale(scale)
+        }
+
+        function setSubtitleTrack(id) {
+            player.setSubtitleTrack(id)
         }
 
         function stop() {
@@ -70,6 +100,33 @@ ApplicationWindow {
 
         function onPlayerEvent(name, payload) {
             nativeBridge.playerEvent(name, payload)
+            if (name === "time") {
+                nowPlaying.setPosition(payload.milliseconds / 1000)
+            } else if (name === "duration") {
+                nowPlaying.setDuration(payload.milliseconds / 1000)
+            } else if (name === "paused") {
+                nowPlaying.setPaused(payload.paused)
+            }
+        }
+    }
+
+    Connections {
+        target: nowPlaying
+
+        function onPauseRequested() {
+            player.setPaused(true)
+        }
+
+        function onPlayRequested() {
+            player.setPaused(false)
+        }
+
+        function onSeekRequested(seconds) {
+            player.seek(seconds)
+        }
+
+        function onToggleRequested() {
+            player.togglePaused()
         }
     }
 

--- a/apps/macos-shell/src/mpvitem.cpp
+++ b/apps/macos-shell/src/mpvitem.cpp
@@ -10,6 +10,7 @@
 #include <QQuickOpenGLUtils>
 #include <QVariantList>
 
+#include <algorithm>
 #include <cmath>
 #include <stdexcept>
 
@@ -62,6 +63,47 @@ QVariantList chapterPayload(const mpv_node &root) {
         }
     }
     return chapters;
+}
+
+QVariantList subtitleTrackPayload(const mpv_node &root) {
+    QVariantList tracks;
+    if (root.format != MPV_FORMAT_NODE_ARRAY || !root.u.list) {
+        return tracks;
+    }
+
+    for (int index = 0; index < root.u.list->num; ++index) {
+        const mpv_node &track = root.u.list->values[index];
+        if (track.format != MPV_FORMAT_NODE_MAP || !track.u.list) {
+            continue;
+        }
+
+        bool isSubtitle = false;
+        QVariantMap entry{{QStringLiteral("external"), false},
+                          {QStringLiteral("selected"), false}};
+        for (int field = 0; field < track.u.list->num; ++field) {
+            const QByteArray name(track.u.list->keys[field]);
+            const mpv_node &value = track.u.list->values[field];
+            if (name == "type" && value.format == MPV_FORMAT_STRING && value.u.string) {
+                isSubtitle = qstrcmp(value.u.string, "sub") == 0;
+            } else if (name == "id" && value.format == MPV_FORMAT_INT64) {
+                entry.insert(QStringLiteral("id"),
+                             static_cast<qlonglong>(value.u.int64));
+            } else if (name == "selected" && value.format == MPV_FORMAT_FLAG) {
+                entry.insert(QStringLiteral("selected"), value.u.flag != 0);
+            } else if (name == "external" && value.format == MPV_FORMAT_FLAG) {
+                entry.insert(QStringLiteral("external"), value.u.flag != 0);
+            } else if (value.format == MPV_FORMAT_STRING && value.u.string &&
+                       (name == "title" || name == "lang" || name == "codec")) {
+                entry.insert(QString::fromUtf8(name),
+                             QString::fromUtf8(value.u.string));
+            }
+        }
+
+        if (isSubtitle && entry.contains(QStringLiteral("id"))) {
+            tracks.append(entry);
+        }
+    }
+    return tracks;
 }
 
 } // namespace
@@ -177,6 +219,8 @@ void MpvItem::initialize() {
         {"audio-fallback-to-null", "yes"},
         {"audio-client-name", "Kino"},
         {"title", "Kino"},
+        {"sid", "no"},
+        {"sub-auto", "no"},
     };
 
     for (const Option &option : options) {
@@ -198,12 +242,14 @@ void MpvItem::initialize() {
     mpv_observe_property(handle_, 6, "hwdec-current", MPV_FORMAT_STRING);
     mpv_observe_property(handle_, 7, "video-format", MPV_FORMAT_STRING);
     mpv_observe_property(handle_, 8, "chapter-list", MPV_FORMAT_NODE);
+    mpv_observe_property(handle_, 9, "track-list", MPV_FORMAT_NODE);
 }
 
 void MpvItem::load(const QString &url, bool forceStereo) {
     failed_ = false;
     hardwareDecoderActive_ = false;
     hardwareDecoderTimer_.stop();
+    paused_ = false;
     videoPresent_ = false;
     setActive(true);
     QByteArray audioChannels = forceStereo ? QByteArrayLiteral("stereo")
@@ -211,6 +257,11 @@ void MpvItem::load(const QString &url, bool forceStereo) {
     char *audioChannelsData = audioChannels.data();
     mpv_set_property_async(handle_, 0, "audio-channels", MPV_FORMAT_STRING,
                            &audioChannelsData);
+    QByteArray subtitleTrack = QByteArrayLiteral("no");
+    char *subtitleTrackData = subtitleTrack.data();
+    mpv_set_property_async(handle_, 0, "sid", MPV_FORMAT_STRING, &subtitleTrackData);
+    double subtitleDelay = 0;
+    mpv_set_property_async(handle_, 0, "sub-delay", MPV_FORMAT_DOUBLE, &subtitleDelay);
     int unpaused = 0;
     mpv_set_property_async(handle_, 0, "pause", MPV_FORMAT_FLAG, &unpaused);
     const QByteArray encodedUrl = url.toUtf8();
@@ -223,6 +274,21 @@ void MpvItem::load(const QString &url, bool forceStereo) {
     emit playerEvent(QStringLiteral("buffering"), {{QStringLiteral("active"), true}});
     emit playerEvent(QStringLiteral("paused"), {{QStringLiteral("paused"), false}});
     qInfo("[kino:mpv] source load requested");
+}
+
+void MpvItem::addSubtitles(const QString &url, const QString &title, const QString &lang) {
+    const QByteArray encodedUrl = url.toUtf8();
+    const QByteArray encodedTitle =
+        title.trimmed().isEmpty() ? QByteArrayLiteral("External subtitles")
+                                  : title.trimmed().toUtf8();
+    const QByteArray encodedLang = lang.trimmed().toUtf8();
+    const char *command[] = {"sub-add", encodedUrl.constData(), "select",
+                             encodedTitle.constData(),
+                             encodedLang.isEmpty() ? nullptr : encodedLang.constData(),
+                             nullptr};
+    if (mpv_command_async(handle_, 0, command) < 0) {
+        qWarning("[kino:mpv] external subtitles rejected");
+    }
 }
 
 void MpvItem::seek(double seconds) {
@@ -240,11 +306,42 @@ void MpvItem::setPaused(bool paused) {
     mpv_set_property_async(handle_, 0, "pause", MPV_FORMAT_FLAG, &value);
 }
 
+void MpvItem::setSubtitleDelay(double seconds) {
+    double value = std::clamp(seconds, -60.0, 60.0);
+    mpv_set_property_async(handle_, 0, "sub-delay", MPV_FORMAT_DOUBLE, &value);
+}
+
+void MpvItem::setSubtitlePosition(int position) {
+    int64_t value = std::clamp(position, 0, 150);
+    mpv_set_property_async(handle_, 0, "sub-pos", MPV_FORMAT_INT64, &value);
+}
+
+void MpvItem::setSubtitleScale(double scale) {
+    double value = std::clamp(scale, 0.1, 5.0);
+    mpv_set_property_async(handle_, 0, "sub-scale", MPV_FORMAT_DOUBLE, &value);
+}
+
+void MpvItem::setSubtitleTrack(int id) {
+    if (id > 0) {
+        int64_t value = id;
+        mpv_set_property_async(handle_, 0, "sid", MPV_FORMAT_INT64, &value);
+        return;
+    }
+    QByteArray disabled = QByteArrayLiteral("no");
+    char *disabledData = disabled.data();
+    mpv_set_property_async(handle_, 0, "sid", MPV_FORMAT_STRING, &disabledData);
+}
+
 void MpvItem::stop() {
     hardwareDecoderTimer_.stop();
     const char *command[] = {"stop", nullptr};
     mpv_command_async(handle_, 0, command);
     setActive(false);
+}
+
+void MpvItem::togglePaused() {
+    const char *command[] = {"cycle", "pause", nullptr};
+    mpv_command_async(handle_, 0, command);
 }
 
 void MpvItem::onRenderUpdate(void *context) {
@@ -291,9 +388,10 @@ void MpvItem::handleEvent(mpv_event *event) {
                                                 : QStringLiteral("duration"),
                              millisecondsPayload(seconds));
         } else if (name == "pause") {
+            paused_ = *static_cast<int *>(property->data) != 0;
+            updatePowerGuard();
             emit playerEvent(QStringLiteral("paused"),
-                             {{QStringLiteral("paused"),
-                               *static_cast<int *>(property->data) != 0}});
+                             {{QStringLiteral("paused"), paused_}});
         } else if (name == "paused-for-cache") {
             emit playerEvent(QStringLiteral("buffering"),
                              {{QStringLiteral("active"),
@@ -314,6 +412,7 @@ void MpvItem::handleEvent(mpv_event *event) {
         } else if (name == "video-format") {
             const auto *format = static_cast<const char *>(property->data);
             videoPresent_ = format && *format != '\0';
+            updatePowerGuard();
             if (videoPresent_ && !hardwareDecoderActive_) {
                 hardwareDecoderTimer_.start();
             } else if (!videoPresent_) {
@@ -324,6 +423,11 @@ void MpvItem::handleEvent(mpv_event *event) {
             emit playerEvent(
                 QStringLiteral("chapters"),
                 {{QStringLiteral("items"), chapterPayload(*chapters)}});
+        } else if (name == "track-list") {
+            const auto *tracks = static_cast<const mpv_node *>(property->data);
+            emit playerEvent(
+                QStringLiteral("subtitleTracks"),
+                {{QStringLiteral("items"), subtitleTrackPayload(*tracks)}});
         }
         break;
     }
@@ -364,8 +468,13 @@ void MpvItem::setActive(bool active) {
         return;
     }
     active_ = active;
+    updatePowerGuard();
     emit activeChanged();
     if (active_) {
         update();
     }
+}
+
+void MpvItem::updatePowerGuard() {
+    powerGuard_.setActive(active_ && videoPresent_ && !paused_);
 }

--- a/apps/macos-shell/src/mpvitem.h
+++ b/apps/macos-shell/src/mpvitem.h
@@ -8,6 +8,8 @@
 #include <mpv/client.h>
 #include <mpv/render_gl.h>
 
+#include "powerguard.h"
+
 class MpvRenderer;
 
 class MpvItem : public QQuickFramebufferObject {
@@ -21,11 +23,17 @@ public:
     bool active() const;
     Renderer *createRenderer() const override;
 
+    Q_INVOKABLE void addSubtitles(const QString &url, const QString &title, const QString &lang);
     Q_INVOKABLE void load(const QString &url, bool forceStereo);
     Q_INVOKABLE void seek(double seconds);
     Q_INVOKABLE void setMuted(bool muted);
     Q_INVOKABLE void setPaused(bool paused);
+    Q_INVOKABLE void setSubtitleDelay(double seconds);
+    Q_INVOKABLE void setSubtitlePosition(int position);
+    Q_INVOKABLE void setSubtitleScale(double scale);
+    Q_INVOKABLE void setSubtitleTrack(int id);
     Q_INVOKABLE void stop();
+    Q_INVOKABLE void togglePaused();
 
 signals:
     void activeChanged();
@@ -45,12 +53,15 @@ private:
     void handleEvent(mpv_event *event);
     void initialize();
     void setActive(bool active);
+    void updatePowerGuard();
 
     bool active_ = false;
     bool failed_ = false;
     bool hardwareDecoderActive_ = false;
+    bool paused_ = true;
     bool videoPresent_ = false;
     mpv_handle *handle_ = nullptr;
     mpv_render_context *renderContext_ = nullptr;
+    PowerGuard powerGuard_;
     QTimer hardwareDecoderTimer_;
 };

--- a/apps/macos-shell/src/nowplaying.h
+++ b/apps/macos-shell/src/nowplaying.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QtQml/qqmlregistration.h>
+
+class NowPlaying : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+public:
+    explicit NowPlaying(QObject *parent = nullptr);
+    ~NowPlaying() override;
+
+    Q_INVOKABLE void setActive(bool active);
+    Q_INVOKABLE void setDuration(double seconds);
+    Q_INVOKABLE void setMetadata(const QString &title, const QString &subtitle);
+    Q_INVOKABLE void setPaused(bool paused);
+    Q_INVOKABLE void setPosition(double seconds);
+
+signals:
+    void pauseRequested();
+    void playRequested();
+    void seekRequested(double seconds);
+    void toggleRequested();
+
+private:
+    void publish();
+
+    bool active_ = false;
+    bool paused_ = true;
+    double duration_ = 0;
+    double position_ = 0;
+    double publishedPosition_ = 0;
+    double publishedUptime_ = 0;
+    QString subtitle_;
+    QString title_;
+};

--- a/apps/macos-shell/src/nowplaying.mm
+++ b/apps/macos-shell/src/nowplaying.mm
@@ -1,0 +1,133 @@
+#include "nowplaying.h"
+
+#import <Foundation/Foundation.h>
+#import <MediaPlayer/MediaPlayer.h>
+
+#include <cmath>
+
+namespace {
+
+double systemUptimeSeconds() {
+    return [[NSProcessInfo processInfo] systemUptime];
+}
+
+} // namespace
+
+NowPlaying::NowPlaying(QObject *parent) : QObject(parent) {
+    MPRemoteCommandCenter *commands = [MPRemoteCommandCenter sharedCommandCenter];
+    [commands.playCommand addTargetWithHandler:^(MPRemoteCommandEvent *) {
+        if (!active_) {
+            return MPRemoteCommandHandlerStatusNoActionableNowPlayingItem;
+        }
+        emit playRequested();
+        return MPRemoteCommandHandlerStatusSuccess;
+    }];
+    [commands.pauseCommand addTargetWithHandler:^(MPRemoteCommandEvent *) {
+        if (!active_) {
+            return MPRemoteCommandHandlerStatusNoActionableNowPlayingItem;
+        }
+        emit pauseRequested();
+        return MPRemoteCommandHandlerStatusSuccess;
+    }];
+    [commands.togglePlayPauseCommand addTargetWithHandler:^(MPRemoteCommandEvent *) {
+        if (!active_) {
+            return MPRemoteCommandHandlerStatusNoActionableNowPlayingItem;
+        }
+        emit toggleRequested();
+        return MPRemoteCommandHandlerStatusSuccess;
+    }];
+    [commands.changePlaybackPositionCommand addTargetWithHandler:^(MPRemoteCommandEvent *event) {
+        if (!active_) {
+            return MPRemoteCommandHandlerStatusNoActionableNowPlayingItem;
+        }
+        auto *positionEvent = static_cast<MPChangePlaybackPositionCommandEvent *>(event);
+        emit seekRequested(positionEvent.positionTime);
+        return MPRemoteCommandHandlerStatusSuccess;
+    }];
+}
+
+NowPlaying::~NowPlaying() {
+    MPRemoteCommandCenter *commands = [MPRemoteCommandCenter sharedCommandCenter];
+    [commands.playCommand removeTarget:nil];
+    [commands.pauseCommand removeTarget:nil];
+    [commands.togglePlayPauseCommand removeTarget:nil];
+    [commands.changePlaybackPositionCommand removeTarget:nil];
+    active_ = false;
+    publish();
+}
+
+void NowPlaying::setActive(bool active) {
+    if (active_ == active) {
+        return;
+    }
+    active_ = active;
+    if (!active_) {
+        duration_ = 0;
+        position_ = 0;
+        subtitle_.clear();
+        title_.clear();
+    }
+    publish();
+}
+
+void NowPlaying::setDuration(double seconds) {
+    const bool changed = std::fabs(seconds - duration_) > 0.5;
+    duration_ = seconds;
+    if (active_ && changed) {
+        publish();
+    }
+}
+
+void NowPlaying::setMetadata(const QString &title, const QString &subtitle) {
+    title_ = title;
+    subtitle_ = subtitle;
+    if (active_) {
+        publish();
+    }
+}
+
+void NowPlaying::setPaused(bool paused) {
+    const bool changed = paused_ != paused;
+    paused_ = paused;
+    if (active_ && changed) {
+        publish();
+    }
+}
+
+void NowPlaying::setPosition(double seconds) {
+    position_ = seconds;
+    if (!active_) {
+        return;
+    }
+    // The system extrapolates elapsed time from the published rate; republish
+    // only when the real position drifts from that projection, such as a seek.
+    const double projected =
+        publishedPosition_ + (paused_ ? 0.0 : systemUptimeSeconds() - publishedUptime_);
+    if (std::fabs(seconds - projected) > 2.0) {
+        publish();
+    }
+}
+
+void NowPlaying::publish() {
+    MPNowPlayingInfoCenter *center = [MPNowPlayingInfoCenter defaultCenter];
+    if (!active_) {
+        center.nowPlayingInfo = nil;
+        center.playbackState = MPNowPlayingPlaybackStateStopped;
+        return;
+    }
+    NSMutableDictionary *info = [NSMutableDictionary dictionary];
+    info[MPMediaItemPropertyTitle] =
+        title_.isEmpty() ? @"Kino" : title_.toNSString();
+    if (!subtitle_.isEmpty()) {
+        info[MPMediaItemPropertyArtist] = subtitle_.toNSString();
+    }
+    info[MPNowPlayingInfoPropertyMediaType] = @(MPNowPlayingInfoMediaTypeVideo);
+    info[MPMediaItemPropertyPlaybackDuration] = @(duration_);
+    info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = @(position_);
+    info[MPNowPlayingInfoPropertyPlaybackRate] = @(paused_ ? 0.0 : 1.0);
+    center.nowPlayingInfo = info;
+    center.playbackState =
+        paused_ ? MPNowPlayingPlaybackStatePaused : MPNowPlayingPlaybackStatePlaying;
+    publishedPosition_ = position_;
+    publishedUptime_ = systemUptimeSeconds();
+}

--- a/apps/macos-shell/src/powerguard.cpp
+++ b/apps/macos-shell/src/powerguard.cpp
@@ -1,0 +1,28 @@
+#include "powerguard.h"
+
+#include <QtGlobal>
+
+PowerGuard::~PowerGuard() {
+    setActive(false);
+}
+
+void PowerGuard::setActive(bool active) {
+    if (active == (assertion_ != kIOPMNullAssertionID)) {
+        return;
+    }
+    if (active) {
+        const IOReturn result = IOPMAssertionCreateWithName(
+            kIOPMAssertionTypePreventUserIdleDisplaySleep, kIOPMAssertionLevelOn,
+            CFSTR("Kino video playback"), &assertion_);
+        if (result != kIOReturnSuccess) {
+            assertion_ = kIOPMNullAssertionID;
+            qWarning("[kino:power] sleep assertion failed");
+            return;
+        }
+        qInfo("[kino:power] display sleep prevented while video plays");
+    } else {
+        IOPMAssertionRelease(assertion_);
+        assertion_ = kIOPMNullAssertionID;
+        qInfo("[kino:power] display sleep allowed");
+    }
+}

--- a/apps/macos-shell/src/powerguard.h
+++ b/apps/macos-shell/src/powerguard.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <IOKit/pwr_mgt/IOPMLib.h>
+
+class PowerGuard {
+public:
+    PowerGuard() = default;
+    ~PowerGuard();
+    PowerGuard(const PowerGuard &) = delete;
+    PowerGuard &operator=(const PowerGuard &) = delete;
+
+    void setActive(bool active);
+
+private:
+    IOPMAssertionID assertion_ = kIOPMNullAssertionID;
+};


### PR DESCRIPTION
Finishes the three playback-contract areas that were missing from the Phase 2 native shell (docs/PLAYBACK.md).

## Subtitles
- The shell observes mpv's track list and emits subtitle tracks to the client; new bridge methods cover track selection, external subtitle loading, delay, scale, and vertical position. SRT, WebVTT, ASS, SSA, and PGS come through libmpv/libass.
- Player subtitle menu: Off, embedded tracks labeled by language and format, add-on subtitles from the Stremio player model, and delay/size/position rows.
- Language preference comes from the Stremio profile with ISO-variant matching (`eng` ↔ `en`, `ger` ↔ `de`); no auto-selection when nothing matches the preferred language. Enabled state, size, and position persist locally; delay is per-session.

## Controls and lifecycle
- New `nowplaying.mm` bridges MPNowPlayingInfoCenter and MPRemoteCommandCenter: media keys and the Now Playing surface expose play, pause, toggle, position seek, and metadata. Elapsed time republishes only on drift, not every tick.
- New `powerguard.cpp` holds an IOPM display-sleep assertion strictly while video is present, active, and unpaused.

## Source failure
- Any failure (native decode/stream error, stalled hardware decode, web media error, stream resolution error, player-connection failure) saves progress, records a sanitized diagnostic, marks the source failed for the current selection session, and returns to the source list. Failed sources show a badge and remain retryable; marks reset when a new title opens. No automatic source switching.

## Validation
- `pnpm check` green (format, lint, typecheck, 27 tests incl. new subtitle/settings/source-key coverage, build)
- `pnpm macos:build` clean incl. new Objective-C++; `pnpm macos:check-launch` passes
- Client verified in the browser: Home, Settings, and detail/sources screens render with no new console errors

Manual native verification of the subtitle menu and Now Playing against a real stream lands with the upcoming playback fixture suite.