### PR TITLE
feat: gate releases on playback fixtures

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,10 @@ _Avoid_: Stereo track, transcoding
 Kino's initial video-output policy. SDR sources render unchanged, while supported HDR, HLG, and Dolby Vision inputs are tone-mapped to SDR before display.
 _Avoid_: HDR passthrough, Dolby Vision output
 
+**Playback fixture**:
+A small, legally synthesized media file that exercises one declared playback behavior, such as a codec, range, audio format, subtitle format, or failure path. The native player must satisfy the playback contract against every fixture before a release.
+_Avoid_: Sample movie, test download
+
 **TV playback**:
 A playback session in the TV presentation. TV playback always occupies the full display rather than sharing space with browsing UI.
 _Avoid_: Embedded player, windowed playback

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ The client browses, searches, and resolves sources through the real Stremio Core
 
 ### macOS shell
 
-The native bootstrap currently targets Apple Silicon on macOS 26 and links against local Homebrew libraries. Install CMake, Qt, libmpv, and pkg-config, then build the development app:
+The native bootstrap currently targets Apple Silicon on macOS 26 and links against local Homebrew libraries. Install CMake, Qt, libmpv, pkg-config, and FFmpeg (used only to generate playback fixtures), then build the development app:
 
 ```sh
-brew install cmake qt mpv pkgconf
+brew install cmake qt mpv pkgconf ffmpeg
 pnpm macos:build
 open build/macos/Kino.app
 ```
@@ -32,6 +32,12 @@ The shell loads the packaged Kino UI, keeps Stremio authentication material in m
 
 ```sh
 pnpm macos:check-launch
+```
+
+Validate the playback contract against generated legal fixtures — codecs, HDR ranges, audio formats, subtitles, chapters, and failure paths — with:
+
+```sh
+pnpm macos:check-playback
 ```
 
 Run the complete local validation suite with:

--- a/apps/macos-shell/CMakeLists.txt
+++ b/apps/macos-shell/CMakeLists.txt
@@ -40,6 +40,7 @@ qt_add_executable(
   src/main.cpp
   src/mpvitem.cpp
   src/nowplaying.mm
+  src/playbackprobe.cpp
   src/powerguard.cpp
   src/securestore.cpp
 )
@@ -48,7 +49,7 @@ qt_add_qml_module(
   Kino
   URI KinoShell
   VERSION 1.0
-  QML_FILES qml/Main.qml
+  QML_FILES qml/Main.qml qml/Probe.qml
   SOURCES
     src/mpvitem.h
     src/nowplaying.h

--- a/apps/macos-shell/qml/Probe.qml
+++ b/apps/macos-shell/qml/Probe.qml
@@ -1,0 +1,14 @@
+import QtQuick
+
+Window {
+    width: 480
+    height: 270
+    visible: true
+    color: "#09090a"
+    title: "Kino playback probe"
+
+    MpvItem {
+        objectName: "probePlayer"
+        anchors.fill: parent
+    }
+}

--- a/apps/macos-shell/src/main.cpp
+++ b/apps/macos-shell/src/main.cpp
@@ -1,5 +1,6 @@
 #include "logging.h"
 #include "mpvitem.h"
+#include "playbackprobe.h"
 
 #include <QCoreApplication>
 #include <QDir>
@@ -44,6 +45,27 @@ int main(int argc, char *argv[]) {
     QCoreApplication::setApplicationVersion(QStringLiteral("0.1.0"));
     std::setlocale(LC_NUMERIC, "C");
     installLocalLogger();
+
+    const QString probeMediaPath = qEnvironmentVariable("KINO_PLAYBACK_PROBE");
+    if (!probeMediaPath.isEmpty()) {
+        QQmlApplicationEngine probeEngine;
+        QObject::connect(&probeEngine, &QQmlApplicationEngine::objectCreationFailed, &app,
+                         []() { QCoreApplication::exit(1); }, Qt::QueuedConnection);
+        probeEngine.loadFromModule("KinoShell", "Probe");
+        auto *player = probeEngine.rootObjects().isEmpty()
+                           ? nullptr
+                           : probeEngine.rootObjects().first()->findChild<MpvItem *>(
+                                 QStringLiteral("probePlayer"));
+        if (!player) {
+            qCritical("[kino:probe] probe scene has no player");
+            return 1;
+        }
+        PlaybackProbe probe(player, probeMediaPath,
+                            qEnvironmentVariable("KINO_PLAYBACK_PROBE_SUBS"), &app);
+        probe.start();
+        qInfo("[kino:probe] playback probe started");
+        return app.exec();
+    }
 
     QQmlApplicationEngine engine;
     auto *webProfile = new QQuickWebEngineProfile(QStringLiteral("kino"), &engine);

--- a/apps/macos-shell/src/mpvitem.cpp
+++ b/apps/macos-shell/src/mpvitem.cpp
@@ -403,6 +403,8 @@ void MpvItem::handleEvent(mpv_event *event) {
         } else if (name == "hwdec-current") {
             const auto *decoder = static_cast<const char *>(property->data);
             hardwareDecoderActive_ = decoder && *decoder != '\0';
+            emit playerEvent(QStringLiteral("hardwareDecoding"),
+                             {{QStringLiteral("active"), hardwareDecoderActive_}});
             if (hardwareDecoderActive_) {
                 hardwareDecoderTimer_.stop();
                 qInfo("[kino:mpv] hardware decoder active");

--- a/apps/macos-shell/src/playbackprobe.cpp
+++ b/apps/macos-shell/src/playbackprobe.cpp
@@ -1,0 +1,114 @@
+#include "playbackprobe.h"
+
+#include "mpvitem.h"
+
+#include <QCoreApplication>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QQuickWindow>
+#include <QVariantList>
+
+#include <cstdio>
+#include <memory>
+
+namespace {
+
+// Enough playback to prove sustained decoding, comfortably past the point
+// where the hardware-decoder stall timer would have rejected the source.
+constexpr qlonglong kRequiredPlaybackMs = 2'500;
+constexpr int kTimeoutMs = 30'000;
+
+} // namespace
+
+PlaybackProbe::PlaybackProbe(MpvItem *player, const QString &mediaPath,
+                             const QString &subtitlesPath, QObject *parent)
+    : QObject(parent), player_(player), mediaPath_(mediaPath), subtitlesPath_(subtitlesPath) {
+    timeout_.setInterval(kTimeoutMs);
+    timeout_.setSingleShot(true);
+    connect(&timeout_, &QTimer::timeout, this, [this]() { finish(QStringLiteral("timeout")); });
+    connect(player_, &MpvItem::playerEvent, this, &PlaybackProbe::onPlayerEvent);
+}
+
+void PlaybackProbe::start() {
+    timeout_.start();
+    QQuickWindow *window = player_->window();
+    if (!window) {
+        player_->load(mediaPath_, false);
+        return;
+    }
+    // mpv's render context is created on the scene graph's first frame; loading
+    // before that leaves the player without a video output.
+    auto connection = std::make_shared<QMetaObject::Connection>();
+    *connection = connect(window, &QQuickWindow::frameSwapped, this,
+                          [this, connection]() {
+                              QObject::disconnect(*connection);
+                              player_->load(mediaPath_, false);
+                          });
+}
+
+void PlaybackProbe::onPlayerEvent(const QString &name, const QVariantMap &payload) {
+    if (finished_) {
+        return;
+    }
+    if (name == QLatin1String("error")) {
+        finish(QStringLiteral("failed"), payload.value(QStringLiteral("code")).toString());
+        return;
+    }
+    if (name == QLatin1String("time")) {
+        timeMs_ = payload.value(QStringLiteral("milliseconds")).toLongLong();
+    } else if (name == QLatin1String("hardwareDecoding")) {
+        hardwareDecoding_ = payload.value(QStringLiteral("active")).toBool();
+    } else if (name == QLatin1String("chapters")) {
+        chapterCount_ = payload.value(QStringLiteral("items")).toList().size();
+    } else if (name == QLatin1String("subtitleTracks")) {
+        subtitleTracks_ = QJsonArray();
+        const QVariantList items = payload.value(QStringLiteral("items")).toList();
+        for (const QVariant &item : items) {
+            const QVariantMap track = item.toMap();
+            subtitleTracks_.append(QJsonObject{
+                {QStringLiteral("codec"), track.value(QStringLiteral("codec")).toString()},
+                {QStringLiteral("external"), track.value(QStringLiteral("external")).toBool()},
+                {QStringLiteral("lang"), track.value(QStringLiteral("lang")).toString()},
+            });
+        }
+    } else if (name == QLatin1String("ready")) {
+        if (!subtitlesPath_.isEmpty() && !subtitlesAdded_) {
+            subtitlesAdded_ = true;
+            player_->addSubtitles(subtitlesPath_, QStringLiteral("Probe subtitles"),
+                                  QStringLiteral("en"));
+        }
+    } else if (name == QLatin1String("ended")) {
+        finish(QStringLiteral("ended"));
+        return;
+    }
+    evaluate();
+}
+
+void PlaybackProbe::evaluate() {
+    if (hardwareDecoding_ && timeMs_ >= kRequiredPlaybackMs) {
+        finish(QStringLiteral("played"));
+    }
+}
+
+void PlaybackProbe::finish(const QString &outcome, const QString &errorCode) {
+    if (finished_) {
+        return;
+    }
+    finished_ = true;
+    timeout_.stop();
+    player_->stop();
+
+    QJsonObject result{
+        {QStringLiteral("chapters"), chapterCount_},
+        {QStringLiteral("outcome"), outcome},
+        {QStringLiteral("subtitleTracks"), subtitleTracks_},
+        {QStringLiteral("timeMs"), timeMs_},
+    };
+    if (!errorCode.isEmpty()) {
+        result.insert(QStringLiteral("errorCode"), errorCode);
+    }
+    const QByteArray line = QJsonDocument(result).toJson(QJsonDocument::Compact);
+    std::printf("KINO_PROBE_RESULT %s\n", line.constData());
+    std::fflush(stdout);
+    QCoreApplication::exit(0);
+}

--- a/apps/macos-shell/src/playbackprobe.h
+++ b/apps/macos-shell/src/playbackprobe.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <QJsonArray>
+#include <QObject>
+#include <QString>
+#include <QTimer>
+#include <QVariantMap>
+
+class MpvItem;
+
+// Drives one media file through the production MpvItem and prints a single
+// machine-readable verdict line for the playback fixture runner.
+class PlaybackProbe : public QObject {
+    Q_OBJECT
+public:
+    PlaybackProbe(MpvItem *player, const QString &mediaPath, const QString &subtitlesPath,
+                  QObject *parent = nullptr);
+
+    void start();
+
+private slots:
+    void onPlayerEvent(const QString &name, const QVariantMap &payload);
+
+private:
+    void evaluate();
+    void finish(const QString &outcome, const QString &errorCode = QString());
+
+    bool finished_ = false;
+    bool hardwareDecoding_ = false;
+    bool subtitlesAdded_ = false;
+    qlonglong chapterCount_ = 0;
+    qlonglong timeMs_ = 0;
+    MpvItem *player_;
+    QJsonArray subtitleTracks_;
+    QString mediaPath_;
+    QString subtitlesPath_;
+    QTimer timeout_;
+};

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint": "eslint .",
     "macos:build": "./scripts/build-macos.sh",
     "macos:check-launch": "./scripts/check-macos-launch.sh",
+    "macos:check-playback": "node scripts/check-macos-playback.mjs",
     "test": "pnpm --filter @kino/desktop test",
     "typecheck": "pnpm --filter @kino/desktop typecheck"
   },

--- a/scripts/check-macos-playback.mjs
+++ b/scripts/check-macos-playback.mjs
@@ -1,0 +1,390 @@
+#!/usr/bin/env node
+// Playback fixture gate for the native macOS shell. Generates small synthetic
+// media files with ffmpeg, plays each through Kino's probe mode, and asserts
+// the playback contract: hardware-only video decoding, HDR inputs accepted for
+// tone mapping, declared audio codecs, embedded and external subtitles,
+// chapters, and clean rejection of undecodable or broken sources.
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const fixturesDir = process.env.KINO_FIXTURES_DIR ?? join(repoRoot, 'build', 'fixtures');
+const appBinary =
+  process.env.KINO_APP_BINARY ?? join(repoRoot, 'build', 'macos', 'Kino.app/Contents/MacOS/Kino');
+
+const videoSource = ['-f', 'lavfi', '-i', 'testsrc2=size=640x360:rate=24:duration=6'];
+const audioSource = ['-f', 'lavfi', '-i', 'sine=frequency=440:sample_rate=48000:duration=6'];
+const hdr10Params =
+  'hdr10=1:master-display=G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(10000000,1):max-cll=1000,400';
+
+const srtText = `1
+00:00:00,500 --> 00:00:04,000
+Kino fixture subtitles
+`;
+const assText = `[Script Info]
+ScriptType: v4.00+
+PlayResX: 640
+PlayResY: 360
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, Alignment
+Style: Default,Arial,28,&H00FFFFFF,2
+
+[Events]
+Format: Layer, Start, End, Style, Text
+Dialogue: 0,0:00:00.50,0:00:04.00,Default,Kino styled subtitles
+`;
+const vttText = `WEBVTT
+
+00:00.500 --> 00:04.000
+Kino external subtitles
+`;
+const chapterMetadata = `;FFMETADATA1
+[CHAPTER]
+TIMEBASE=1/1000
+START=0
+END=3000
+title=Intro
+[CHAPTER]
+TIMEBASE=1/1000
+START=3000
+END=6000
+title=Part 1
+`;
+
+function encode(name, args) {
+  const target = join(fixturesDir, name);
+  if (existsSync(target)) return target;
+  execFileSync('ffmpeg', ['-hide_banner', '-loglevel', 'error', '-y', ...args, target], {
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+  return target;
+}
+
+function writeFixture(name, content) {
+  const target = join(fixturesDir, name);
+  if (!existsSync(target)) writeFileSync(target, content);
+  return target;
+}
+
+function generateFixtures() {
+  mkdirSync(fixturesDir, { recursive: true });
+  const subsSrt = writeFixture('embedded.srt', srtText);
+  const subsAss = writeFixture('embedded.ass', assText);
+  const chaptersMeta = writeFixture('chapters.ffmeta', chapterMetadata);
+
+  const h264 = encode('h264-sdr-aac.mp4', [
+    ...videoSource,
+    ...audioSource,
+    '-c:v',
+    'libx264',
+    '-preset',
+    'veryfast',
+    '-pix_fmt',
+    'yuv420p',
+    '-c:a',
+    'aac',
+    '-ac',
+    '2',
+  ]);
+  encode('hevc-sdr-ac3.mkv', [
+    ...videoSource,
+    ...audioSource,
+    '-c:v',
+    'libx265',
+    '-preset',
+    'ultrafast',
+    '-pix_fmt',
+    'yuv420p',
+    '-c:a',
+    'ac3',
+    '-ac',
+    '2',
+  ]);
+  encode('hevc-hdr10-eac3.mkv', [
+    ...videoSource,
+    ...audioSource,
+    '-c:v',
+    'libx265',
+    '-preset',
+    'ultrafast',
+    '-pix_fmt',
+    'yuv420p10le',
+    '-color_primaries',
+    'bt2020',
+    '-color_trc',
+    'smpte2084',
+    '-colorspace',
+    'bt2020nc',
+    '-x265-params',
+    hdr10Params,
+    '-c:a',
+    'eac3',
+    '-ac',
+    '2',
+  ]);
+  encode('hevc-hlg-flac.mkv', [
+    ...videoSource,
+    ...audioSource,
+    '-c:v',
+    'libx265',
+    '-preset',
+    'ultrafast',
+    '-pix_fmt',
+    'yuv420p10le',
+    '-color_primaries',
+    'bt2020',
+    '-color_trc',
+    'arib-std-b67',
+    '-colorspace',
+    'bt2020nc',
+    '-c:a',
+    'flac',
+    '-ac',
+    '2',
+  ]);
+  encode('av1-aac.mkv', [
+    ...videoSource,
+    ...audioSource,
+    '-c:v',
+    'libsvtav1',
+    '-preset',
+    '12',
+    '-pix_fmt',
+    'yuv420p',
+    '-c:a',
+    'aac',
+    '-ac',
+    '2',
+  ]);
+  encode('ffv1-software-only.mkv', [
+    ...videoSource,
+    ...audioSource,
+    '-c:v',
+    'ffv1',
+    '-c:a',
+    'aac',
+    '-ac',
+    '2',
+  ]);
+  encode('h264-alac.mkv', [
+    ...videoSource,
+    ...audioSource,
+    '-c:v',
+    'libx264',
+    '-preset',
+    'veryfast',
+    '-pix_fmt',
+    'yuv420p',
+    '-c:a',
+    'alac',
+    '-ac',
+    '2',
+  ]);
+  encode('h264-dts.mkv', [
+    ...videoSource,
+    ...audioSource,
+    '-c:v',
+    'libx264',
+    '-preset',
+    'veryfast',
+    '-pix_fmt',
+    'yuv420p',
+    '-c:a',
+    'dca',
+    '-strict',
+    'experimental',
+    '-ac',
+    '2',
+  ]);
+  encode('h264-pcm.mkv', [
+    ...videoSource,
+    ...audioSource,
+    '-c:v',
+    'libx264',
+    '-preset',
+    'veryfast',
+    '-pix_fmt',
+    'yuv420p',
+    '-c:a',
+    'pcm_s16le',
+    '-ac',
+    '2',
+  ]);
+  encode('subs-embedded.mkv', [
+    ...videoSource,
+    ...audioSource,
+    '-i',
+    subsSrt,
+    '-i',
+    subsAss,
+    '-map',
+    '0:v',
+    '-map',
+    '1:a',
+    '-map',
+    '2:s',
+    '-map',
+    '3:s',
+    '-c:v',
+    'libx264',
+    '-preset',
+    'veryfast',
+    '-pix_fmt',
+    'yuv420p',
+    '-c:a',
+    'aac',
+    '-ac',
+    '2',
+    '-c:s',
+    'copy',
+  ]);
+  encode('chapters-intro.mkv', [
+    ...videoSource,
+    ...audioSource,
+    '-i',
+    chaptersMeta,
+    '-map_metadata',
+    '2',
+    '-c:v',
+    'libx264',
+    '-preset',
+    'veryfast',
+    '-pix_fmt',
+    'yuv420p',
+    '-c:a',
+    'aac',
+    '-ac',
+    '2',
+  ]);
+  writeFixture('external.srt', srtText);
+  writeFixture('external.vtt', vttText);
+  if (!existsSync(join(fixturesDir, 'corrupt.mp4'))) {
+    writeFixture('corrupt.mp4', readFileSync(h264).subarray(0, 24 * 1024));
+  }
+}
+
+// PGS, TrueHD, DTS-HD, Atmos, and Dolby Vision inputs cannot be synthesized
+// with ffmpeg encoders; those remain manual real-device release gates.
+const fixtures = [
+  { file: 'h264-sdr-aac.mp4', expect: { outcome: 'played' } },
+  { file: 'hevc-sdr-ac3.mkv', expect: { outcome: 'played' } },
+  { file: 'hevc-hdr10-eac3.mkv', expect: { outcome: 'played' } },
+  { file: 'hevc-hlg-flac.mkv', expect: { outcome: 'played' } },
+  {
+    file: 'av1-aac.mkv',
+    note: 'plays only with AV1 hardware decoding; must otherwise reject',
+    expect: { outcome: ['played', 'failed'], errorCode: 'hardware-decoding-unavailable' },
+  },
+  {
+    file: 'ffv1-software-only.mkv',
+    expect: { outcome: 'failed', errorCode: 'hardware-decoding-unavailable' },
+  },
+  { file: 'h264-alac.mkv', expect: { outcome: 'played' } },
+  { file: 'h264-dts.mkv', expect: { outcome: 'played' } },
+  { file: 'h264-pcm.mkv', expect: { outcome: 'played' } },
+  {
+    file: 'subs-embedded.mkv',
+    expect: { outcome: 'played', subtitleCodecs: ['subrip', 'ass'] },
+  },
+  {
+    file: 'h264-sdr-aac.mp4',
+    label: 'external-srt',
+    subtitles: 'external.srt',
+    expect: { outcome: 'played', externalSubtitle: true },
+  },
+  {
+    file: 'h264-sdr-aac.mp4',
+    label: 'external-vtt',
+    subtitles: 'external.vtt',
+    expect: { outcome: 'played', externalSubtitle: true },
+  },
+  { file: 'chapters-intro.mkv', expect: { outcome: 'played', minChapters: 2 } },
+  { file: 'corrupt.mp4', expect: { outcome: 'failed' } },
+  { file: 'missing.mkv', missing: true, expect: { outcome: 'failed' } },
+];
+
+function runProbe(fixture) {
+  const mediaPath = join(fixturesDir, fixture.file);
+  const env = { ...process.env, KINO_PLAYBACK_PROBE: mediaPath };
+  if (fixture.subtitles) env.KINO_PLAYBACK_PROBE_SUBS = join(fixturesDir, fixture.subtitles);
+  const run = spawnSync(appBinary, [], { encoding: 'utf8', env, timeout: 60_000 });
+  const line = (run.stdout ?? '')
+    .split('\n')
+    .findLast((candidate) => candidate.startsWith('KINO_PROBE_RESULT '));
+  if (!line) {
+    const detail = run.error ? run.error.message : `exit ${run.status}`;
+    return { failure: `no probe verdict (${detail})`, stderr: run.stderr };
+  }
+  return { result: JSON.parse(line.slice('KINO_PROBE_RESULT '.length)) };
+}
+
+function assertExpectations(fixture, result) {
+  const problems = [];
+  const { expect } = fixture;
+  const outcomes = Array.isArray(expect.outcome) ? expect.outcome : [expect.outcome];
+  if (!outcomes.includes(result.outcome)) {
+    problems.push(
+      `outcome ${result.outcome} (${result.errorCode ?? 'no code'}), expected ${outcomes.join(' or ')}`,
+    );
+  }
+  if (expect.errorCode && result.outcome === 'failed' && result.errorCode !== expect.errorCode) {
+    problems.push(`error code ${result.errorCode}, expected ${expect.errorCode}`);
+  }
+  if (expect.minChapters && result.chapters < expect.minChapters) {
+    problems.push(`${result.chapters} chapters, expected at least ${expect.minChapters}`);
+  }
+  const codecs = (result.subtitleTracks ?? []).map((track) => track.codec);
+  for (const codec of expect.subtitleCodecs ?? []) {
+    if (!codecs.includes(codec))
+      problems.push(`missing ${codec} subtitle track (saw: ${codecs.join(', ') || 'none'})`);
+  }
+  if (expect.externalSubtitle && !(result.subtitleTracks ?? []).some((track) => track.external)) {
+    problems.push('no external subtitle track appeared');
+  }
+  return problems;
+}
+
+if (!existsSync(appBinary)) {
+  console.error(`Kino binary not found at ${appBinary}. Run "pnpm macos:build" first.`);
+  process.exit(1);
+}
+try {
+  execFileSync('ffmpeg', ['-version'], { stdio: 'ignore' });
+} catch {
+  console.error('ffmpeg is required to generate playback fixtures: brew install ffmpeg');
+  process.exit(1);
+}
+
+console.log('Generating playback fixtures…');
+generateFixtures();
+
+let failures = 0;
+for (const fixture of fixtures) {
+  const name = fixture.label ?? fixture.file;
+  const { failure, result, stderr } = runProbe(fixture);
+  if (failure) {
+    failures += 1;
+    console.log(`✗ ${name}: ${failure}`);
+    if (stderr) console.log(stderr.split('\n').slice(-8).join('\n'));
+    continue;
+  }
+  const problems = assertExpectations(fixture, result);
+  if (problems.length > 0) {
+    failures += 1;
+    console.log(`✗ ${name}: ${problems.join('; ')}`);
+  } else {
+    const detail =
+      result.outcome === 'failed' ? `rejected with ${result.errorCode}` : result.outcome;
+    console.log(`✓ ${name}: ${detail}${fixture.note ? ` (${fixture.note})` : ''}`);
+  }
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} playback fixture(s) failed.`);
+  process.exit(1);
+}
+console.log(`\nAll ${fixtures.length} playback fixtures satisfied the contract.`);


### PR DESCRIPTION
Satisfies the Phase 2 exit criterion "passes representative playback fixtures" (docs/ROADMAP.md).

## Probe mode
- `KINO_PLAYBACK_PROBE=<file>` boots a minimal scene around the production `MpvItem`, plays the file, and prints a JSON verdict: outcome, error code, playback position, subtitle tracks, chapter count.
- `MpvItem` now emits a `hardwareDecoding` event so the probe positively confirms hardware decode instead of inferring it; playback must run past the stall-detection window before a fixture counts as played.
- Probe start waits for the scene graph's first frame — mpv's render context is created lazily and loading earlier leaves the player without a video output.

## Fixture runner (`pnpm macos:check-playback`)
Generates 15 small legal fixtures with FFmpeg (synthesized test patterns and tones) and asserts the playback contract:
- H.264/HEVC SDR play; HDR10 and HLG are accepted for GPU tone mapping
- AV1 plays only with hardware decoding, otherwise must reject
- FFV1 (software-only codec) must be rejected via `hardware-decoding-unavailable` — proves the no-software-decode rule
- AC-3, E-AC-3, FLAC, ALAC, DTS, and PCM audio tracks play
- Embedded SRT + ASS tracks and external SRT/VTT files surface as subtitle tracks
- Matroska chapters surface (intro-marker input path)
- Corrupt and missing sources fail cleanly

PGS, TrueHD, DTS-HD, Atmos, and Dolby Vision cannot be synthesized with FFmpeg encoders and remain manual real-device release gates (noted in the runner).

## Validation
- All 15 fixtures pass on Apple Silicon (AV1 hardware-decoded on this machine)
- `pnpm check`, `pnpm macos:build`, and `pnpm macos:check-launch` green
- README documents the ffmpeg requirement and the new command; CONTEXT.md gains the "Playback fixture" term