### PR TITLE
docs: resolve the open torrent engine gate

### DIFF
--- a/docs/adr/0015-adopt-stream-server-with-a-locked-down-embedded-profile.md
+++ b/docs/adr/0015-adopt-stream-server-with-a-locked-down-embedded-profile.md
@@ -1,0 +1,10 @@
+# Adopt stream-server with a locked-down embedded profile
+
+The open torrent engine gate from ADR 0013 passed a hands-on macOS audit of `stremio-native/stream-server` (MIT, Rust, libtorrent-rasterbar backend, BSD-3): its embedded library profile binds the Stremio-compatible HTTP API to loopback only, serves byte-identical original media over HTTP ranges (cold start to first bytes ~9 s, cold deep seek ~12 s via piece reprioritization, ~80–120 MB resident while streaming, 10 GB capped cache with a cleaner), and its dependencies are pinned by checksummed lock file. Kino will embed it as a pinned, built-from-source component using that embedded profile — never the standalone binary, whose defaults (bind on all interfaces, SSDP, background auto-update, runtime FFmpeg download) violate Kino's network-exposure and no-unverified-blob rules.
+
+Conditions carried into integration: pin the audited commit, keep FFmpeg setup and auto-update disabled (Kino never transcodes), point the engine at a Kino-owned cache directory, and surface the seeding and download-limit settings (both default to on/unlimited). Known upstream defects to track: the advertised pure-Rust librqbit backend does not compile and is unmaintained, linking against a shared system libtorrent needs a one-line `from_hex` patch (upstream assumes static vcpkg builds), and the engine trusts BitTorrent resume state without checking that cache files still exist. Android validation of the same engine happens with the Phase 4 Shield prototype through its existing JNI surface.
+
+References:
+
+- [stream-server](https://github.com/stremio-native/stream-server) (audited at commit f585ab6)
+- [Gate torrent support on an open streaming engine](0013-gate-torrent-support-on-an-open-streaming-engine.md)


### PR DESCRIPTION
Resolves the "Open torrent engine" validation gate (docs/RISKS.md) with ADR 0015, closing out the last Phase 2 item.

## Audit summary (stremio-native/stream-server @ f585ab6)
Built from source and exercised live on macOS against a Creative Commons torrent (Big Buck Bunny):

- **License**: MIT over a BSD-3 libtorrent-rasterbar backend; dependencies pinned by checksummed lock file
- **Network exposure**: embedded profile binds the Stremio-compatible HTTP API to 127.0.0.1 only; peer port and local discovery are inherent BitTorrent behavior and configurable
- **Original media**: byte-identical HTTP range responses (206, correct Content-Range) — no transcoding involved
- **Seeking**: cold start to first bytes ~9 s, cold deep seek ~12 s via piece reprioritization, instant when warm
- **Resource use**: ~80–120 MB resident while streaming; 10 GB capped cache with a cleaner

## Conditions and defects recorded in the ADR
- Embed the library profile, never the standalone binary (its defaults — all-interface bind, SSDP, background auto-update, runtime FFmpeg download — violate Kino's network-exposure and no-unverified-blob rules)
- Keep FFmpeg setup and auto-update disabled, use a Kino-owned cache directory, surface seeding/download-limit settings
- Upstream defects to track: the librqbit backend does not compile, shared-libtorrent linking needs a one-line patch, and resume state is trusted without checking cache files exist
- Android validation happens with the Phase 4 Shield prototype via the engine's existing JNI surface

Engine integration into Kino is Phase 3 work per the roadmap.