### PR TITLE
feat: store Stremio auth in app data instead of Keychain

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pnpm macos:build
 open build/macos/Kino.app
 ```
 
-The shell loads the packaged Kino UI, keeps Stremio authentication material in macOS Keychain, and hands playback to libmpv with VideoToolbox hardware decoding, forced SDR output, and optional stereo downmixing. Playback integrates with macOS media keys and Now Playing, blocks display sleep only while video plays, and exposes embedded and add-on subtitles with delay, size, and position controls. It is a local validation build, not yet a signed or self-contained distribution. Run the short native launch regression probe with:
+The shell loads the packaged Kino UI, keeps Stremio authentication material in an owner-only file under Kino's application data, and hands playback to libmpv with VideoToolbox hardware decoding, forced SDR output, and optional stereo downmixing. Playback integrates with macOS media keys and Now Playing, blocks display sleep only while video plays, and exposes embedded and add-on subtitles with delay, size, and position controls. It is a local validation build, not yet a signed or self-contained distribution. Run the short native launch regression probe with:
 
 ```sh
 pnpm macos:check-launch

--- a/apps/macos-shell/CMakeLists.txt
+++ b/apps/macos-shell/CMakeLists.txt
@@ -25,7 +25,6 @@ pkg_check_modules(MPV REQUIRED IMPORTED_TARGET mpv)
 find_library(FOUNDATION_FRAMEWORK Foundation REQUIRED)
 find_library(IOKIT_FRAMEWORK IOKit REQUIRED)
 find_library(MEDIAPLAYER_FRAMEWORK MediaPlayer REQUIRED)
-find_library(SECURITY_FRAMEWORK Security REQUIRED)
 
 qt_standard_project_setup(REQUIRES 6.8)
 
@@ -64,7 +63,6 @@ target_link_libraries(
     ${FOUNDATION_FRAMEWORK}
     ${IOKIT_FRAMEWORK}
     ${MEDIAPLAYER_FRAMEWORK}
-    ${SECURITY_FRAMEWORK}
     Qt6::Concurrent
     Qt6::Core
     Qt6::Gui

--- a/apps/macos-shell/src/securestore.cpp
+++ b/apps/macos-shell/src/securestore.cpp
@@ -1,80 +1,63 @@
 #include "securestore.h"
 
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QSaveFile>
+#include <QStandardPaths>
 #include <QtConcurrentRun>
-
-#include <Security/Security.h>
 
 namespace {
 
-CFMutableDictionaryRef makeQuery() {
-    CFMutableDictionaryRef query = CFDictionaryCreateMutable(
-        kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks,
-        &kCFTypeDictionaryValueCallBacks);
-    CFDictionarySetValue(query, kSecClass, kSecClassGenericPassword);
-    CFDictionarySetValue(query, kSecAttrService, CFSTR("com.chriscorbell.kino"));
-    CFDictionarySetValue(query, kSecAttrAccount, CFSTR("stremio-account-auth-v1"));
-    return query;
+// Stremio auth lives in an owner-only file under Kino's app data instead of
+// the macOS Keychain: unsigned development builds change code signature every
+// rebuild, which makes Keychain re-prompt for access each time (ADR 0016).
+QString authFilePath() {
+    const QString dataDir =
+        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    return QDir(dataDir).absoluteFilePath(QStringLiteral("stremio-auth-v1"));
 }
 
 QVariantMap readAuth() {
-    CFMutableDictionaryRef query = makeQuery();
-    CFDictionarySetValue(query, kSecMatchLimit, kSecMatchLimitOne);
-    CFDictionarySetValue(query, kSecReturnData, kCFBooleanTrue);
-
-    CFTypeRef result = nullptr;
-    const OSStatus status = SecItemCopyMatching(query, &result);
-    CFRelease(query);
-    if (status == errSecItemNotFound) {
+    QFile file(authFilePath());
+    if (!file.exists()) {
         return {{QStringLiteral("ok"), true}, {QStringLiteral("value"), QString{}}};
     }
-    if (status != errSecSuccess || !result || CFGetTypeID(result) != CFDataGetTypeID()) {
-        if (result) {
-            CFRelease(result);
-        }
-        qWarning("[kino:keychain] read failed status=%d", static_cast<int>(status));
+    if (!file.open(QIODevice::ReadOnly)) {
+        qWarning("[kino:authstore] read failed");
         return {{QStringLiteral("ok"), false}, {QStringLiteral("value"), QString{}}};
     }
-
-    const auto data = static_cast<CFDataRef>(result);
-    const QString value = QString::fromUtf8(
-        reinterpret_cast<const char *>(CFDataGetBytePtr(data)), CFDataGetLength(data));
-    CFRelease(result);
+    const QString value = QString::fromUtf8(file.readAll());
     return {{QStringLiteral("ok"), true}, {QStringLiteral("value"), value}};
 }
 
 bool writeAuth(const QString &value) {
-    const QByteArray encoded = value.toUtf8();
-    CFDataRef data = CFDataCreate(kCFAllocatorDefault,
-                                  reinterpret_cast<const UInt8 *>(encoded.constData()),
-                                  encoded.size());
-    CFMutableDictionaryRef query = makeQuery();
-    CFMutableDictionaryRef attributes = CFDictionaryCreateMutable(
-        kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks,
-        &kCFTypeDictionaryValueCallBacks);
-    CFDictionarySetValue(attributes, kSecValueData, data);
-
-    OSStatus status = SecItemUpdate(query, attributes);
-    if (status == errSecItemNotFound) {
-        CFDictionarySetValue(query, kSecValueData, data);
-        status = SecItemAdd(query, nullptr);
+    const QString path = authFilePath();
+    if (!QDir().mkpath(QFileInfo(path).absolutePath())) {
+        qWarning("[kino:authstore] data directory unavailable");
+        return false;
     }
-
-    CFRelease(attributes);
-    CFRelease(query);
-    CFRelease(data);
-    if (status != errSecSuccess) {
-        qWarning("[kino:keychain] write failed status=%d", static_cast<int>(status));
+    QSaveFile file(path);
+    if (!file.open(QIODevice::WriteOnly)) {
+        qWarning("[kino:authstore] write failed");
+        return false;
+    }
+    file.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner);
+    file.write(value.toUtf8());
+    if (!file.commit()) {
+        qWarning("[kino:authstore] write failed");
         return false;
     }
     return true;
 }
 
 bool clearAuth() {
-    CFMutableDictionaryRef query = makeQuery();
-    const OSStatus status = SecItemDelete(query);
-    CFRelease(query);
-    if (status != errSecSuccess && status != errSecItemNotFound) {
-        qWarning("[kino:keychain] delete failed status=%d", static_cast<int>(status));
+    QFile file(authFilePath());
+    if (!file.exists()) {
+        return true;
+    }
+    if (!file.remove()) {
+        qWarning("[kino:authstore] delete failed");
         return false;
     }
     return true;

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -18,7 +18,7 @@ The first public macOS package will be a signed and notarized universal build fo
 ## Version-one experience
 
 - Sign in with Stremio or continue with a device-local guest profile.
-- Open account creation in the system browser. Send passwords only to Stremio during authentication and store only the resulting auth token in platform secure storage.
+- Open account creation in the system browser. Send passwords only to Stremio during authentication and store only the resulting auth token, in device-local storage readable by the signed-in user account alone.
 - On TV, prefer a QR or device-link flow rather than remote-entered passwords.
 - Keep guest state separate from account state. Never merge or overwrite it implicitly.
 - Provide Home, Discover, Search, Library, media details, source selection, playback, add-on management, and Settings.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,7 +23,7 @@ Exit: Chris can launch the local client on the Mac and complete the agreed first
 ## Phase 2: native macOS validation
 
 - Introduce the narrow `stremio-shell` fork and load Kino's client from packaged local assets.
-- Rebrand the shell, secure authentication in Keychain, and modernize the build for Apple Silicon.
+- Rebrand the shell, keep authentication material in owner-only local storage, and modernize the build for Apple Silicon.
 - Implement the full SDR, hardware-decoding, audio, subtitle, source-failure, and playback-lifecycle contract.
 - Validate the open torrent engine. A separately installed Stremio Service remains development-only.
 

--- a/docs/adr/0016-store-stremio-auth-in-app-data-instead-of-keychain.md
+++ b/docs/adr/0016-store-stremio-auth-in-app-data-instead-of-keychain.md
@@ -1,0 +1,3 @@
+# Store Stremio auth in app data instead of Keychain
+
+The macOS shell keeps the Stremio auth key in an owner-only (0600) file under Kino's application data directory rather than the macOS Keychain. Keychain access is tied to the app's code signature, so unsigned development builds re-trigger access prompts on every rebuild, and signed releases would still prompt across updates until users click "Always Allow". The auth key is a revocable session token, never a password, and stock Stremio stores the same token in plain browser storage, so the file's user-account boundary matches the ecosystem's existing protection level. The shell's bridge API (`kinoSecureStore`) is unchanged, keeping the client and any future platform storage backends decoupled from this choice.


### PR DESCRIPTION
Replaces the macOS Keychain auth storage with an owner-only (0600) file at `~/Library/Application Support/Kino/stremio-auth-v1`, written atomically via QSaveFile. Rationale recorded in ADR 0016: Keychain access follows the code signature, so unsigned dev builds re-prompt on every rebuild (and signed releases would prompt across updates); the stored value is a revocable session token that stock Stremio keeps in plain browser storage, so the user-account boundary matches the ecosystem's existing protection level.

- `kinoSecureStore` bridge API unchanged — no client changes
- Security framework dependency removed from the shell
- README, PRODUCT.md contract line, and ROADMAP wording updated

Validation: `pnpm macos:build`, `pnpm macos:check-launch`, and `pnpm check` all green.

Note for local setups: any existing session needs one re-sign-in, and the old Keychain item can be removed with `security delete-generic-password -s com.chriscorbell.kino`.