### PR TITLE
fix: key Home catalog sections by type

### DIFF
--- a/apps/desktop/src/screens/HomeScreen.tsx
+++ b/apps/desktop/src/screens/HomeScreen.tsx
@@ -128,7 +128,7 @@ export function HomeScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => void
         return (
           <section
             className={styles.homeSection}
-            key={`${catalog.addon.manifest.id}:${catalog.id}`}
+            key={`${catalog.addon.manifest.id}:${catalog.type}:${catalog.id}`}
           >
             <div className={styles.sectionHeading}>
               <h2>{catalog.name}</h2>


### PR DESCRIPTION
Home catalog sections were keyed by `addonId:catalogId`, but Cinemeta exposes the same catalog id ("top", "imdbRating") for both movie and series types, so React logged "Encountered two children with the same key" for every render of the Home screen and could misrender rows. The key now includes `catalog.type`.

Verified with the dev server in a fresh tab: both Cinemeta "Popular" rows (movie + series — the previously colliding pair) render and the console is clean. `pnpm check` green.