### PR TITLE
feat: build the Discover catalog browser

### DIFF
--- a/apps/desktop/src/App.module.css
+++ b/apps/desktop/src/App.module.css
@@ -1056,6 +1056,106 @@
   background: var(--kino-accent);
 }
 
+.discoverFilters {
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  margin-bottom: 4px;
+}
+
+.catalogTabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 22px;
+  margin-right: auto;
+}
+
+.catalogTab,
+.catalogTabActive {
+  padding: 4px 0;
+  border: 0;
+  color: var(--kino-text-faint);
+  background: transparent;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color var(--kino-duration-fast) ease;
+}
+
+.catalogTab:hover {
+  color: var(--kino-text);
+}
+
+.catalogTabActive {
+  color: var(--kino-text);
+  box-shadow: inset 0 -2px 0 var(--kino-text);
+}
+
+.genreMenu {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.genreButton {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 32px;
+  padding: 0 14px;
+  border: 1px solid var(--kino-border);
+  border-radius: var(--kino-pill-radius);
+  color: var(--kino-text-muted);
+  background: transparent;
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  transition: border-color var(--kino-duration-fast) ease;
+}
+
+.genreButton:hover {
+  border-color: var(--kino-text-faint);
+}
+
+.genreList {
+  position: absolute;
+  z-index: var(--kino-layer-navigation);
+  top: calc(100% + 8px);
+  right: 0;
+  display: grid;
+  overflow-y: auto;
+  min-width: 180px;
+  max-height: 320px;
+  padding: 6px;
+  border: 1px solid var(--kino-border);
+  border-radius: var(--kino-panel-radius);
+  background: var(--kino-surface);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 50%);
+  animation: enter var(--kino-duration-fast) var(--kino-ease-out);
+}
+
+.genreList button {
+  min-height: 32px;
+  padding: 0 12px;
+  border: 0;
+  border-radius: var(--kino-control-radius);
+  color: var(--kino-text-muted);
+  background: transparent;
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.genreList button:hover {
+  color: var(--kino-text);
+  background: var(--kino-border);
+}
+
+.genreList button[aria-pressed='true'] {
+  color: var(--kino-accent);
+}
+
 .settingsGroup {
   margin-top: 34px;
 }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -17,6 +17,7 @@ import { sourceKey } from './core/sources';
 import type { CoreMetaPreview, ProfileState } from './core/types';
 import { useCoreModel } from './core/useCoreModel';
 import { enUS } from './locales/en-US';
+import { DiscoverScreen } from './screens/DiscoverScreen';
 import { HomeScreen } from './screens/HomeScreen';
 import { MetaDetailsScreen } from './screens/MetaDetailsScreen';
 import { PlayerScreen } from './screens/PlayerScreen';
@@ -48,15 +49,6 @@ function EmptyState({ children }: { children: string }) {
     <div className={styles.emptyState}>
       <span>{enUS.status.unavailable}</span>
       <p>{children}</p>
-    </div>
-  );
-}
-
-function DiscoverScreen() {
-  return (
-    <div className={styles.page}>
-      <h1>{enUS.discover.title}</h1>
-      <EmptyState>{enUS.discover.empty}</EmptyState>
     </div>
   );
 }
@@ -283,7 +275,7 @@ export function App() {
       case 'search':
         return <SearchScreen onOpen={openDetail} />;
       case 'discover':
-        return <DiscoverScreen />;
+        return <DiscoverScreen onOpen={openDetail} />;
       case 'library':
         return <LibraryScreen />;
       case 'addons':

--- a/apps/desktop/src/core/actions.ts
+++ b/apps/desktop/src/core/actions.ts
@@ -1,4 +1,4 @@
-import type { CoreAction, CoreMetaPreview, CoreStream, CoreVideo } from './types';
+import type { CatalogRequest, CoreAction, CoreMetaPreview, CoreStream, CoreVideo } from './types';
 
 export interface PlaybackSelection {
   meta: CoreMetaPreview;
@@ -20,6 +20,13 @@ export function loadSearchAction(query: string): CoreAction {
       model: 'CatalogsWithExtra',
       args: { extra: [['search', query]] },
     },
+  };
+}
+
+export function loadCatalogAction(request: CatalogRequest | null): CoreAction {
+  return {
+    action: 'Load',
+    args: { model: 'CatalogWithFilters', args: request ? { request } : null },
   };
 }
 

--- a/apps/desktop/src/core/catalog.test.ts
+++ b/apps/desktop/src/core/catalog.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { catalogRequestFromDeepLink, catalogRequestKey } from './catalog';
+
+const manifest = 'https://v3-cinemeta.strem.io/manifest.json';
+const encoded = encodeURIComponent(manifest);
+
+describe('catalog deep links', () => {
+  it('parses a catalog selection without filters', () => {
+    expect(catalogRequestFromDeepLink(`#/discover/${encoded}/movie/top?`)).toEqual({
+      base: manifest,
+      path: { extra: [], id: 'top', resource: 'catalog', type: 'movie' },
+    });
+  });
+
+  it('keeps filter values from the query string', () => {
+    const request = catalogRequestFromDeepLink(`#/discover/${encoded}/movie/year?genre=Sci-Fi`);
+    expect(request?.path.extra).toEqual([['genre', 'Sci-Fi']]);
+    expect(request?.path.id).toBe('year');
+  });
+
+  it('rejects links that are not catalog selections', () => {
+    expect(catalogRequestFromDeepLink(undefined)).toBeNull();
+    expect(catalogRequestFromDeepLink('#/detail/movie/tt123')).toBeNull();
+    expect(catalogRequestFromDeepLink(`#/discover/${encoded}/movie`)).toBeNull();
+  });
+
+  it('keys distinct selections distinctly', () => {
+    const popular = catalogRequestFromDeepLink(`#/discover/${encoded}/movie/top?`);
+    const comedy = catalogRequestFromDeepLink(`#/discover/${encoded}/movie/top?genre=Comedy`);
+    expect(catalogRequestKey(popular)).not.toBe(catalogRequestKey(comedy));
+    expect(catalogRequestKey(null)).toBe('default');
+  });
+});

--- a/apps/desktop/src/core/catalog.ts
+++ b/apps/desktop/src/core/catalog.ts
@@ -1,0 +1,37 @@
+import type { CatalogRequest } from './types';
+
+const DISCOVER_PREFIX = '#/discover/';
+
+// Stremio Core offers catalog selections as deep links rather than raw
+// requests, e.g. "#/discover/{encoded manifest url}/movie/top?genre=Comedy".
+export function catalogRequestFromDeepLink(link: string | undefined): CatalogRequest | null {
+  if (!link?.startsWith(DISCOVER_PREFIX)) return null;
+
+  const [route, query] = link.slice(DISCOVER_PREFIX.length).split('?');
+  const segments = route?.split('/') ?? [];
+  if (segments.length < 3) return null;
+
+  const [encodedBase, type, id] = segments;
+  if (!encodedBase || !type || !id) return null;
+
+  const extra: Array<[string, string]> = [];
+  for (const [name, value] of new URLSearchParams(query ?? '')) {
+    extra.push([name, value]);
+  }
+
+  return {
+    base: decodeURIComponent(encodedBase),
+    path: {
+      extra,
+      id: decodeURIComponent(id),
+      resource: 'catalog',
+      type: decodeURIComponent(type),
+    },
+  };
+}
+
+export function catalogRequestKey(request: CatalogRequest | null) {
+  if (!request) return 'default';
+  const { extra, id, type } = request.path;
+  return `${request.base}:${type}:${id}:${extra.map((pair) => pair.join('=')).join(',')}`;
+}

--- a/apps/desktop/src/core/types.ts
+++ b/apps/desktop/src/core/types.ts
@@ -1,5 +1,50 @@
 export type CoreModelName =
-  'board' | 'continue_watching_preview' | 'ctx' | 'meta_details' | 'player' | 'search';
+  | 'board'
+  | 'continue_watching_preview'
+  | 'ctx'
+  | 'discover'
+  | 'installed_addons'
+  | 'library'
+  | 'meta_details'
+  | 'player'
+  | 'search';
+
+export interface CatalogRequest {
+  base: string;
+  path: {
+    extra: Array<[string, string]>;
+    id: string;
+    resource: string;
+    type: string;
+  };
+}
+
+interface DiscoverDeepLink {
+  deepLinks?: { discover?: string };
+  selected: boolean;
+}
+
+export interface CatalogWithFiltersState {
+  catalog: {
+    content: Loadable<CoreMetaPreview[], string> | null;
+  } | null;
+  selectable: {
+    catalogs: Array<
+      DiscoverDeepLink & {
+        addon: { manifest: { id: string; name: string } };
+        id: string;
+        name: string;
+      }
+    >;
+    extra: Array<{
+      isRequired: boolean;
+      name: string;
+      options: Array<DiscoverDeepLink & { value: string | null }>;
+    }>;
+    types: Array<DiscoverDeepLink & { type: string }>;
+  } | null;
+  selected: { request: CatalogRequest } | null;
+}
 
 export interface CoreAction {
   action: string;

--- a/apps/desktop/src/locales/en-US.ts
+++ b/apps/desktop/src/locales/en-US.ts
@@ -30,7 +30,12 @@ export const enUS = {
   },
   discover: {
     title: 'Discover',
-    empty: 'Catalogs from your installed add-ons will appear here.',
+    empty: 'This catalog returned no titles.',
+    error: 'This catalog could not be loaded.',
+    loading: 'Loading catalog…',
+    typeLabel: 'Media type',
+    catalogLabel: 'Catalog',
+    allGenres: 'All Genres',
   },
   library: {
     title: 'Library',

--- a/apps/desktop/src/screens/DiscoverScreen.tsx
+++ b/apps/desktop/src/screens/DiscoverScreen.tsx
@@ -1,0 +1,135 @@
+import { CaretDown } from '@phosphor-icons/react';
+import { useEffect, useRef, useState } from 'react';
+
+import styles from '../App.module.css';
+import { MediaCard } from '../components/MediaCard';
+import { loadCatalogAction } from '../core/actions';
+import { catalogRequestFromDeepLink, catalogRequestKey } from '../core/catalog';
+import type { CatalogRequest, CatalogWithFiltersState, CoreMetaPreview } from '../core/types';
+import { useCoreModel } from '../core/useCoreModel';
+import { enUS } from '../locales/en-US';
+
+function typeLabel(type: string) {
+  return type.charAt(0).toUpperCase() + type.slice(1);
+}
+
+export function DiscoverScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => void }) {
+  const [request, setRequest] = useState<CatalogRequest | null>(null);
+  const [genresOpen, setGenresOpen] = useState(false);
+  const genreRef = useRef<HTMLDivElement>(null);
+  const result = useCoreModel<CatalogWithFiltersState>(
+    'discover',
+    loadCatalogAction(request),
+    catalogRequestKey(request),
+  );
+  const selectable = result.state?.selectable;
+  const content = result.state?.catalog?.content ?? null;
+  const items = content?.type === 'Ready' ? content.content : [];
+  // Add-ons expose genre-style filters under varying names; the first
+  // non-required filter with options is the one worth surfacing.
+  const genreFilter = selectable?.extra.find(
+    (extra) => !extra.isRequired && extra.options.length > 0,
+  );
+  const selectedGenre = genreFilter?.options.find((option) => option.selected)?.value ?? null;
+
+  const select = (link: string | undefined) => {
+    const next = catalogRequestFromDeepLink(link);
+    if (next) setRequest(next);
+  };
+
+  useEffect(() => {
+    if (!genresOpen) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (!genreRef.current?.contains(event.target as Node)) setGenresOpen(false);
+    };
+    window.addEventListener('pointerdown', onPointerDown);
+    return () => window.removeEventListener('pointerdown', onPointerDown);
+  }, [genresOpen]);
+
+  return (
+    <div className={styles.page}>
+      <h1>{enUS.discover.title}</h1>
+
+      {selectable && selectable.types.length > 0 ? (
+        <div className={styles.pills} aria-label={enUS.discover.typeLabel} role="group">
+          {selectable.types.map((option) => (
+            <button
+              aria-pressed={option.selected}
+              className={option.selected ? styles.pillActive : styles.pill}
+              key={option.type}
+              onClick={() => select(option.deepLinks?.discover)}
+              type="button"
+            >
+              {typeLabel(option.type)}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      {selectable && selectable.catalogs.length > 0 ? (
+        <div className={styles.discoverFilters}>
+          <div className={styles.catalogTabs} aria-label={enUS.discover.catalogLabel} role="group">
+            {selectable.catalogs.map((option) => (
+              <button
+                aria-pressed={option.selected}
+                className={option.selected ? styles.catalogTabActive : styles.catalogTab}
+                key={`${option.addon.manifest.id}:${option.id}:${option.name}`}
+                onClick={() => select(option.deepLinks?.discover)}
+                type="button"
+              >
+                {option.name}
+              </button>
+            ))}
+          </div>
+
+          {genreFilter ? (
+            <div className={styles.genreMenu} ref={genreRef}>
+              <button
+                aria-expanded={genresOpen}
+                className={styles.genreButton}
+                onClick={() => setGenresOpen((open) => !open)}
+                type="button"
+              >
+                {selectedGenre ?? enUS.discover.allGenres}
+                <CaretDown aria-hidden size={13} />
+              </button>
+              {genresOpen ? (
+                <div className={styles.genreList}>
+                  {genreFilter.options.map((option) => (
+                    <button
+                      aria-pressed={option.selected}
+                      key={option.value ?? 'all'}
+                      onClick={() => {
+                        select(option.deepLinks?.discover);
+                        setGenresOpen(false);
+                      }}
+                      type="button"
+                    >
+                      {option.value ?? enUS.discover.allGenres}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {result.loading ? <p className={styles.inlineEmpty}>{enUS.discover.loading}</p> : null}
+      {result.error || content?.type === 'Err' ? (
+        <p className={styles.loadError}>{enUS.discover.error}</p>
+      ) : null}
+      {!result.loading && items.length === 0 && content?.type !== 'Err' ? (
+        <p className={styles.inlineEmpty}>{enUS.discover.empty}</p>
+      ) : null}
+
+      {items.length > 0 ? (
+        <div className={styles.mediaGrid}>
+          {items.map((item) => (
+            <MediaCard item={item} key={`${item.type}:${item.id}`} onOpen={() => onOpen(item)} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
Second Phase 3 item. Discover was a placeholder; it is now a working catalog browser matching the mockup's layout — media type pills, catalog tabs, and a genre dropdown over a poster grid.

- Backed by the core's `CatalogWithFilters` model.
- The core offers selections as deep links (`#/discover/{encoded manifest}/{type}/{id}?genre=…`) rather than raw requests, so `core/catalog.ts` parses them into catalog requests; unit tested, including links that are not catalog selections.
- Genre filtering surfaces the first non-required filter an add-on exposes, since add-ons name these differently.

Verified live against Cinemeta: switching type Movie→Series reloads the catalog list and results; selecting the Horror genre swaps the grid to horror titles; a fresh tab's console is clean. `pnpm check` green (35 tests).