### PR TITLE
feat: build the Library screen

### DIFF
--- a/apps/desktop/src/App.module.css
+++ b/apps/desktop/src/App.module.css
@@ -1056,6 +1056,28 @@
   background: var(--kino-accent);
 }
 
+.libraryButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 36px;
+  margin-top: 18px;
+  padding: 0 16px;
+  border: 1px solid var(--kino-border);
+  border-radius: var(--kino-pill-radius);
+  color: var(--kino-text);
+  background: rgb(20 20 23 / 76%);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color var(--kino-duration-fast) ease;
+}
+
+.libraryButton:hover {
+  border-color: var(--kino-text-faint);
+}
+
 .discoverFilters {
   display: flex;
   align-items: center;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -19,6 +19,7 @@ import { useCoreModel } from './core/useCoreModel';
 import { enUS } from './locales/en-US';
 import { DiscoverScreen } from './screens/DiscoverScreen';
 import { HomeScreen } from './screens/HomeScreen';
+import { LibraryScreen } from './screens/LibraryScreen';
 import { MetaDetailsScreen } from './screens/MetaDetailsScreen';
 import { PlayerScreen } from './screens/PlayerScreen';
 import { SearchScreen } from './screens/SearchScreen';
@@ -49,35 +50,6 @@ function EmptyState({ children }: { children: string }) {
     <div className={styles.emptyState}>
       <span>{enUS.status.unavailable}</span>
       <p>{children}</p>
-    </div>
-  );
-}
-
-function LibraryScreen() {
-  const [filter, setFilter] = useState<'all' | 'movies' | 'series'>('all');
-  const filters = [
-    { key: 'all', label: enUS.library.all },
-    { key: 'movies', label: enUS.library.movies },
-    { key: 'series', label: enUS.library.series },
-  ] as const;
-
-  return (
-    <div className={styles.page}>
-      <h1>{enUS.library.title}</h1>
-      <div className={styles.pills} aria-label={enUS.library.filterLabel} role="group">
-        {filters.map((item) => (
-          <button
-            aria-pressed={filter === item.key}
-            className={filter === item.key ? styles.pillActive : styles.pill}
-            key={item.key}
-            onClick={() => setFilter(item.key)}
-            type="button"
-          >
-            {item.label}
-          </button>
-        ))}
-      </div>
-      <EmptyState>{enUS.library.empty}</EmptyState>
     </div>
   );
 }
@@ -277,7 +249,7 @@ export function App() {
       case 'discover':
         return <DiscoverScreen onOpen={openDetail} />;
       case 'library':
-        return <LibraryScreen />;
+        return <LibraryScreen onOpen={openDetail} />;
       case 'addons':
         return <AddonsScreen />;
       case 'settings':

--- a/apps/desktop/src/core/actions.ts
+++ b/apps/desktop/src/core/actions.ts
@@ -1,4 +1,11 @@
-import type { CatalogRequest, CoreAction, CoreMetaPreview, CoreStream, CoreVideo } from './types';
+import type {
+  CatalogRequest,
+  CoreAction,
+  CoreMetaPreview,
+  CoreStream,
+  CoreVideo,
+  LibraryRequest,
+} from './types';
 
 export interface PlaybackSelection {
   meta: CoreMetaPreview;
@@ -27,6 +34,16 @@ export function loadCatalogAction(request: CatalogRequest | null): CoreAction {
   return {
     action: 'Load',
     args: { model: 'CatalogWithFilters', args: request ? { request } : null },
+  };
+}
+
+export function loadLibraryAction(request: LibraryRequest | null): CoreAction {
+  return {
+    action: 'Load',
+    args: {
+      model: 'LibraryWithFilters',
+      args: { request: request ?? { page: 1, sort: 'lastwatched', type: null } },
+    },
   };
 }
 
@@ -89,6 +106,14 @@ export function loadPlayerAction(selection: PlaybackSelection): CoreAction {
       },
     },
   };
+}
+
+export function addToLibraryAction(meta: CoreMetaPreview): CoreAction {
+  return { action: 'Ctx', args: { action: 'AddToLibrary', args: meta } };
+}
+
+export function removeFromLibraryAction(id: string): CoreAction {
+  return { action: 'Ctx', args: { action: 'RemoveFromLibrary', args: id } };
 }
 
 export function playerAction(action: string, args?: unknown): CoreAction {

--- a/apps/desktop/src/core/types.ts
+++ b/apps/desktop/src/core/types.ts
@@ -183,6 +183,31 @@ export interface PlayerState {
   title?: string | null;
 }
 
+export interface LibraryRequest {
+  page: number;
+  sort: string;
+  type: string | null;
+}
+
+export interface LibraryItem {
+  _id: string;
+  name: string;
+  poster?: string | null;
+  posterShape?: 'Landscape' | 'Poster' | 'Square';
+  progress?: number | null;
+  type: string;
+}
+
+export interface LibraryState {
+  catalog: LibraryItem[];
+  selectable: {
+    nextPage: { request: LibraryRequest } | null;
+    sorts: Array<{ request: LibraryRequest; selected: boolean; sort: string }>;
+    types: Array<{ request: LibraryRequest; selected: boolean; type: string | null }>;
+  } | null;
+  selected: { request: LibraryRequest } | null;
+}
+
 export interface ProfileState {
   profile: {
     addons: Array<{ manifest: { id: string; name: string }; transportUrl: string }>;

--- a/apps/desktop/src/core/useCoreModel.ts
+++ b/apps/desktop/src/core/useCoreModel.ts
@@ -16,7 +16,16 @@ interface CoreModelSnapshot<State> extends CoreModelResult<State> {
 }
 
 function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : 'The Stremio model failed to load.';
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string' && error.trim()) return error;
+  // Stremio Core rejects with plain values; keep them legible in the log.
+  try {
+    const serialized = JSON.stringify(error);
+    if (serialized && serialized !== '{}') return serialized;
+  } catch {
+    /* fall through to the generic message */
+  }
+  return 'The Stremio model failed to load.';
 }
 
 export function useCoreModel<State>(

--- a/apps/desktop/src/locales/en-US.ts
+++ b/apps/desktop/src/locales/en-US.ts
@@ -40,10 +40,10 @@ export const enUS = {
   library: {
     title: 'Library',
     empty: 'Nothing here yet. Add titles from their detail page.',
+    error: 'Your library could not be loaded.',
+    loading: 'Loading your library…',
     filterLabel: 'Library filter',
     all: 'All',
-    movies: 'Movies',
-    series: 'Series',
   },
   addons: {
     title: 'Add-ons',
@@ -85,6 +85,8 @@ export const enUS = {
     noSources: 'No sources were returned for this title.',
     unavailable: 'Not available',
     failed: 'Failed',
+    addToLibrary: 'Add to Library',
+    inLibrary: 'In Library',
   },
   player: {
     preparingTorrent: 'Finding peers for this torrent…',

--- a/apps/desktop/src/screens/LibraryScreen.tsx
+++ b/apps/desktop/src/screens/LibraryScreen.tsx
@@ -1,0 +1,74 @@
+import styles from '../App.module.css';
+import { MediaCard } from '../components/MediaCard';
+import { loadLibraryAction } from '../core/actions';
+import type { CoreMetaPreview, LibraryState, LibraryRequest } from '../core/types';
+import { useCoreModel } from '../core/useCoreModel';
+import { enUS } from '../locales/en-US';
+import { useState } from 'react';
+
+function typeLabel(type: string | null) {
+  if (!type) return enUS.library.all;
+  return `${type.charAt(0).toUpperCase()}${type.slice(1)}`;
+}
+
+export function LibraryScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => void }) {
+  const [request, setRequest] = useState<LibraryRequest | null>(null);
+  const result = useCoreModel<LibraryState>(
+    'library',
+    loadLibraryAction(request),
+    `${request?.type ?? 'all'}:${request?.sort ?? 'default'}`,
+  );
+  const selectable = result.state?.selectable;
+  const items = result.state?.catalog ?? [];
+
+  return (
+    <div className={styles.page}>
+      <h1>{enUS.library.title}</h1>
+
+      {selectable && selectable.types.length > 0 ? (
+        <div className={styles.pills} aria-label={enUS.library.filterLabel} role="group">
+          {selectable.types.map((option) => (
+            <button
+              aria-pressed={option.selected}
+              className={option.selected ? styles.pillActive : styles.pill}
+              key={option.type ?? 'all'}
+              onClick={() => setRequest(option.request)}
+              type="button"
+            >
+              {typeLabel(option.type)}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      {result.loading ? <p className={styles.inlineEmpty}>{enUS.library.loading}</p> : null}
+      {result.error ? <p className={styles.loadError}>{enUS.library.error}</p> : null}
+      {!result.loading && !result.error && items.length === 0 ? (
+        <p className={styles.inlineEmpty}>{enUS.library.empty}</p>
+      ) : null}
+
+      {items.length > 0 ? (
+        <div className={styles.mediaGrid}>
+          {items.map((item) => {
+            const preview: CoreMetaPreview = {
+              id: item._id,
+              inLibrary: true,
+              name: item.name,
+              ...(item.poster === undefined ? {} : { poster: item.poster }),
+              posterShape: item.posterShape ?? 'Poster',
+              type: item.type,
+              watched: false,
+            };
+            return (
+              <MediaCard
+                item={preview}
+                key={`${item.type}:${item._id}`}
+                onOpen={() => onOpen(preview)}
+              />
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/screens/MetaDetailsScreen.tsx
+++ b/apps/desktop/src/screens/MetaDetailsScreen.tsx
@@ -1,8 +1,14 @@
-import { ArrowLeft, Play } from '@phosphor-icons/react';
+import { ArrowLeft, Check, Play, Plus } from '@phosphor-icons/react';
 import { useEffect, useMemo, useState } from 'react';
 
 import styles from '../App.module.css';
-import { loadMetaDetailsAction, type PlaybackSelection } from '../core/actions';
+import {
+  addToLibraryAction,
+  loadMetaDetailsAction,
+  removeFromLibraryAction,
+  type PlaybackSelection,
+} from '../core/actions';
+import { useCore } from '../core/context';
 import { classifySource, sourceDetails, sourceKey, sourceSize, sourceTitle } from '../core/sources';
 import type {
   CoreMetaItem,
@@ -42,7 +48,9 @@ export function MetaDetailsScreen({
   onBack: () => void;
   onPlay: (selection: PlaybackSelection) => void;
 }) {
+  const { transport } = useCore();
   const [videoId, setVideoId] = useState<string | null>(() => defaultVideoId(item));
+  const [libraryOverride, setLibraryOverride] = useState<boolean | null>(null);
   const result = useCoreModel<MetaDetailsState>(
     'meta_details',
     loadMetaDetailsAction(item, videoId),
@@ -85,6 +93,22 @@ export function MetaDetailsScreen({
     [result.state],
   );
   const display = meta ?? item;
+  const inLibrary = libraryOverride ?? display.inLibrary;
+
+  const toggleLibrary = () => {
+    if (!transport) return;
+    const next = !inLibrary;
+    setLibraryOverride(next);
+    void transport
+      .dispatch(next ? addToLibraryAction(display) : removeFromLibraryAction(display.id))
+      .catch((error: unknown) => {
+        setLibraryOverride(!next);
+        console.error(
+          '[kino:library] update failed',
+          error instanceof Error ? error.message : error,
+        );
+      });
+  };
 
   return (
     <div className={styles.detailPage}>
@@ -103,6 +127,10 @@ export function MetaDetailsScreen({
           {display.description ? (
             <p className={styles.detailDescription}>{display.description}</p>
           ) : null}
+          <button className={styles.libraryButton} onClick={toggleLibrary} type="button">
+            {inLibrary ? <Check aria-hidden size={16} /> : <Plus aria-hidden size={16} />}
+            {inLibrary ? enUS.details.inLibrary : enUS.details.addToLibrary}
+          </button>
         </div>
       </header>
 


### PR DESCRIPTION
Third Phase 3 item. Library was a stub with hardcoded filters; it now lists real library items with the type filters the core offers, and titles can be added to or removed from the library on their detail page.

- Library is backed by the core's `LibraryWithFilters` model; type pills come from the model's selectable state rather than being hardcoded.
- The detail screen gains an Add to Library / In Library toggle (optimistic, reverting if the dispatch fails).
- `useCoreModel` now surfaces Stremio Core's rejection payloads instead of collapsing them to a generic message. This is a real diagnostic improvement and it is how both bugs below were caught.

Two bugs found and fixed by testing against the live core:
- Sort variants are lowercase (`lastwatched`), so the initial load was rejected outright.
- Library items are keyed by `_id`, not `id` (matching continue-watching items). Using `id` meant opening a library item failed its meta load and removal dispatched an undefined id.

Verified live: add a title from its detail page → it appears in Library with the type pills updating to All/Movie → opening it loads full details and sources → In Library removes it and the library returns to empty. `pnpm check` green (35 tests).