### PR TITLE
feat: add localization structure and accessibility affordances

### DIFF
--- a/apps/desktop/src/App.module.css
+++ b/apps/desktop/src/App.module.css
@@ -7,6 +7,26 @@
   background: var(--kino-bg);
 }
 
+.skipLink {
+  position: fixed;
+  z-index: calc(var(--kino-layer-dialog) + 2);
+  top: 12px;
+  left: 12px;
+  padding: 10px 16px;
+  border-radius: var(--kino-control-radius);
+  color: var(--kino-on-accent);
+  background: var(--kino-accent);
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  transform: translateY(-200%);
+  transition: transform var(--kino-duration-fast) var(--kino-ease-out);
+}
+
+.skipLink:focus-visible {
+  transform: translateY(0);
+}
+
 .sidebar {
   position: relative;
   z-index: var(--kino-layer-navigation);
@@ -1554,12 +1574,23 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .content {
+  .accountDialog,
+  .content,
+  .genreList,
+  .skipIntro,
+  .upNext {
     animation: none;
   }
 
+  .catalogTab,
+  .catalogTabActive,
+  .genreButton,
+  .libraryButton,
   .logoButton,
   .navButton,
+  .addonRemove,
+  .secondaryButton,
+  .skipLink,
   .switch,
   .switch span {
     transition: none;
@@ -1567,5 +1598,14 @@
 
   .mediaCard .posterFrame {
     transition: none;
+  }
+
+  .mediaCard:hover .posterFrame,
+  .mediaCard:focus-visible .posterFrame {
+    transform: none;
+  }
+
+  .mediaSkeleton {
+    animation: none;
   }
 }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -16,7 +16,7 @@ import type { PlaybackSelection } from './core/actions';
 import { sourceKey } from './core/sources';
 import type { CoreMetaPreview, ProfileState } from './core/types';
 import { useCoreModel } from './core/useCoreModel';
-import { enUS } from './locales/en-US';
+import { t as enUS } from './locales';
 import { AddonsScreen } from './screens/AddonsScreen';
 import { DiscoverScreen } from './screens/DiscoverScreen';
 import { HomeScreen } from './screens/HomeScreen';
@@ -160,6 +160,9 @@ export function App() {
 
   return (
     <div className={styles.shell}>
+      <a className={styles.skipLink} href="#main-content">
+        {enUS.navigation.skipToContent}
+      </a>
       <aside className={styles.sidebar} aria-label={enUS.navigation.primary}>
         <button
           aria-label={enUS.navigation.kinoHome}

--- a/apps/desktop/src/components/ErrorBoundary.tsx
+++ b/apps/desktop/src/components/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 
 import logo from '../assets/kino.svg';
-import { enUS } from '../locales/en-US';
+import { t as enUS } from '../locales';
 import styles from './ErrorBoundary.module.css';
 
 interface ErrorBoundaryProps {

--- a/apps/desktop/src/locales/en-US.ts
+++ b/apps/desktop/src/locales/en-US.ts
@@ -9,6 +9,7 @@ export const enUS = {
     addons: 'Add-ons',
     settings: 'Settings',
     kinoHome: 'Kino home',
+    skipToContent: 'Skip to content',
   },
   home: {
     title: 'Home',

--- a/apps/desktop/src/locales/index.test.ts
+++ b/apps/desktop/src/locales/index.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveLocaleTag } from './index';
+
+describe('locale resolution', () => {
+  it('matches an exact locale tag', () => {
+    expect(resolveLocaleTag(['en-US'])).toBe('en-US');
+  });
+
+  it('matches on language when the region differs', () => {
+    expect(resolveLocaleTag(['en-GB'])).toBe('en-US');
+  });
+
+  it('falls back when no locale is translated yet', () => {
+    expect(resolveLocaleTag(['de-DE', 'fr-FR'])).toBe('en-US');
+    expect(resolveLocaleTag([])).toBe('en-US');
+  });
+
+  it('prefers the earliest supported entry', () => {
+    expect(resolveLocaleTag(['de-DE', 'en-AU'])).toBe('en-US');
+  });
+});

--- a/apps/desktop/src/locales/index.ts
+++ b/apps/desktop/src/locales/index.ts
@@ -1,0 +1,25 @@
+import { enUS } from './en-US';
+
+export type Locale = typeof enUS;
+
+// Locales are registered here as they are translated. Kino resolves the
+// closest match for the device language and falls back to en-US, so a partial
+// locale set never leaves the interface without strings.
+const locales: Record<string, Locale> = { 'en-US': enUS };
+const fallbackTag = 'en-US';
+
+export function resolveLocaleTag(preferred: readonly string[]): string {
+  for (const candidate of preferred) {
+    if (locales[candidate]) return candidate;
+    const language = candidate.split('-')[0];
+    const match = Object.keys(locales).find((tag) => tag.split('-')[0] === language);
+    if (match) return match;
+  }
+  return fallbackTag;
+}
+
+export const localeTag = resolveLocaleTag(
+  typeof navigator === 'undefined' ? [] : navigator.languages,
+);
+
+export const t: Locale = locales[localeTag] ?? enUS;

--- a/apps/desktop/src/screens/AddonsScreen.tsx
+++ b/apps/desktop/src/screens/AddonsScreen.tsx
@@ -6,7 +6,7 @@ import { installAddonAction, uninstallAddonAction } from '../core/actions';
 import { useCore } from '../core/context';
 import type { CoreAddon, ProfileState } from '../core/types';
 import { useCoreModel } from '../core/useCoreModel';
-import { enUS } from '../locales/en-US';
+import { t as enUS } from '../locales';
 
 function isManifest(value: unknown): value is CoreAddon['manifest'] {
   return (
@@ -81,12 +81,13 @@ export function AddonsScreen() {
           {busy ? enUS.addons.installing : enUS.addons.install}
         </button>
       </form>
-      {error ? <p className={styles.loadError}>{error}</p> : null}
-
-      {profile.loading ? <p className={styles.inlineEmpty}>{enUS.addons.loading}</p> : null}
-      {!profile.loading && addons.length === 0 ? (
-        <p className={styles.inlineEmpty}>{enUS.addons.empty}</p>
-      ) : null}
+      <div aria-live="polite">
+        {error ? <p className={styles.loadError}>{error}</p> : null}
+        {profile.loading ? <p className={styles.inlineEmpty}>{enUS.addons.loading}</p> : null}
+        {!profile.loading && addons.length === 0 ? (
+          <p className={styles.inlineEmpty}>{enUS.addons.empty}</p>
+        ) : null}
+      </div>
 
       <div className={styles.addonList}>
         {addons.map((addon) => (

--- a/apps/desktop/src/screens/DiscoverScreen.tsx
+++ b/apps/desktop/src/screens/DiscoverScreen.tsx
@@ -7,7 +7,7 @@ import { loadCatalogAction } from '../core/actions';
 import { catalogRequestFromDeepLink, catalogRequestKey } from '../core/catalog';
 import type { CatalogRequest, CatalogWithFiltersState, CoreMetaPreview } from '../core/types';
 import { useCoreModel } from '../core/useCoreModel';
-import { enUS } from '../locales/en-US';
+import { t as enUS } from '../locales';
 
 function typeLabel(type: string) {
   return type.charAt(0).toUpperCase() + type.slice(1);
@@ -42,8 +42,17 @@ export function DiscoverScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => 
     const onPointerDown = (event: PointerEvent) => {
       if (!genreRef.current?.contains(event.target as Node)) setGenresOpen(false);
     };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      setGenresOpen(false);
+      genreRef.current?.querySelector('button')?.focus();
+    };
     window.addEventListener('pointerdown', onPointerDown);
-    return () => window.removeEventListener('pointerdown', onPointerDown);
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('pointerdown', onPointerDown);
+      window.removeEventListener('keydown', onKeyDown);
+    };
   }, [genresOpen]);
 
   return (
@@ -94,7 +103,7 @@ export function DiscoverScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => 
                 <CaretDown aria-hidden size={13} />
               </button>
               {genresOpen ? (
-                <div className={styles.genreList}>
+                <div className={styles.genreList} role="listbox">
                   {genreFilter.options.map((option) => (
                     <button
                       aria-pressed={option.selected}
@@ -115,13 +124,15 @@ export function DiscoverScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => 
         </div>
       ) : null}
 
-      {result.loading ? <p className={styles.inlineEmpty}>{enUS.discover.loading}</p> : null}
-      {result.error || content?.type === 'Err' ? (
-        <p className={styles.loadError}>{enUS.discover.error}</p>
-      ) : null}
-      {!result.loading && items.length === 0 && content?.type !== 'Err' ? (
-        <p className={styles.inlineEmpty}>{enUS.discover.empty}</p>
-      ) : null}
+      <div aria-live="polite">
+        {result.loading ? <p className={styles.inlineEmpty}>{enUS.discover.loading}</p> : null}
+        {result.error || content?.type === 'Err' ? (
+          <p className={styles.loadError}>{enUS.discover.error}</p>
+        ) : null}
+        {!result.loading && items.length === 0 && content?.type !== 'Err' ? (
+          <p className={styles.inlineEmpty}>{enUS.discover.empty}</p>
+        ) : null}
+      </div>
 
       {items.length > 0 ? (
         <div className={styles.mediaGrid}>

--- a/apps/desktop/src/screens/HomeScreen.tsx
+++ b/apps/desktop/src/screens/HomeScreen.tsx
@@ -12,7 +12,7 @@ import type {
   ProfileState,
 } from '../core/types';
 import { useCoreModel } from '../core/useCoreModel';
-import { enUS } from '../locales/en-US';
+import { t as enUS } from '../locales';
 
 const rowItemLimit = 12;
 

--- a/apps/desktop/src/screens/LibraryScreen.tsx
+++ b/apps/desktop/src/screens/LibraryScreen.tsx
@@ -3,7 +3,7 @@ import { MediaCard } from '../components/MediaCard';
 import { loadLibraryAction } from '../core/actions';
 import type { CoreMetaPreview, LibraryState, LibraryRequest } from '../core/types';
 import { useCoreModel } from '../core/useCoreModel';
-import { enUS } from '../locales/en-US';
+import { t as enUS } from '../locales';
 import { useState } from 'react';
 
 function typeLabel(type: string | null) {
@@ -41,11 +41,13 @@ export function LibraryScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => v
         </div>
       ) : null}
 
-      {result.loading ? <p className={styles.inlineEmpty}>{enUS.library.loading}</p> : null}
-      {result.error ? <p className={styles.loadError}>{enUS.library.error}</p> : null}
-      {!result.loading && !result.error && items.length === 0 ? (
-        <p className={styles.inlineEmpty}>{enUS.library.empty}</p>
-      ) : null}
+      <div aria-live="polite">
+        {result.loading ? <p className={styles.inlineEmpty}>{enUS.library.loading}</p> : null}
+        {result.error ? <p className={styles.loadError}>{enUS.library.error}</p> : null}
+        {!result.loading && !result.error && items.length === 0 ? (
+          <p className={styles.inlineEmpty}>{enUS.library.empty}</p>
+        ) : null}
+      </div>
 
       {items.length > 0 ? (
         <div className={styles.mediaGrid}>

--- a/apps/desktop/src/screens/MetaDetailsScreen.tsx
+++ b/apps/desktop/src/screens/MetaDetailsScreen.tsx
@@ -18,7 +18,7 @@ import type {
   MetaDetailsState,
 } from '../core/types';
 import { useCoreModel } from '../core/useCoreModel';
-import { enUS } from '../locales/en-US';
+import { t as enUS } from '../locales';
 
 interface SourceChoice {
   addonName: string;

--- a/apps/desktop/src/screens/PlayerScreen.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.tsx
@@ -23,7 +23,7 @@ import {
   type ChapterCue,
   type IntroMarker,
 } from '../intro/markers';
-import { enUS } from '../locales/en-US';
+import { t as enUS } from '../locales';
 import { connectNativePlayer, nativeShellPresent, type NativePlayer } from '../native/player';
 import {
   addonSubtitleLabel,
@@ -632,14 +632,16 @@ export function PlayerScreen({
         </div>
       </div>
 
-      {result.loading ? <div className={styles.playerStatus}>Preparing source…</div> : null}
-      {nativeShell && !nativePlayer ? (
-        <div className={styles.playerStatus}>Preparing native player…</div>
-      ) : null}
-      {isTorrent && nativePlayer && !streamUrl ? (
-        <div className={styles.playerStatus}>{enUS.player.preparingTorrent}</div>
-      ) : null}
-      {streamUrl && buffering ? <div className={styles.playerStatus}>Buffering…</div> : null}
+      <div aria-live="polite">
+        {result.loading ? <div className={styles.playerStatus}>Preparing source…</div> : null}
+        {nativeShell && !nativePlayer ? (
+          <div className={styles.playerStatus}>Preparing native player…</div>
+        ) : null}
+        {isTorrent && nativePlayer && !streamUrl ? (
+          <div className={styles.playerStatus}>{enUS.player.preparingTorrent}</div>
+        ) : null}
+        {streamUrl && buffering ? <div className={styles.playerStatus}>Buffering…</div> : null}
+      </div>
 
       {settings.skipIntroButton &&
       insideIntro &&

--- a/apps/desktop/src/screens/SearchScreen.tsx
+++ b/apps/desktop/src/screens/SearchScreen.tsx
@@ -6,7 +6,7 @@ import { loadSearchAction } from '../core/actions';
 import { useCore } from '../core/context';
 import type { BoardState, CoreMetaPreview } from '../core/types';
 import { useCoreModel } from '../core/useCoreModel';
-import { enUS } from '../locales/en-US';
+import { t as enUS } from '../locales';
 
 export function SearchScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => void }) {
   const { transport } = useCore();

--- a/apps/desktop/src/screens/SettingsScreen.tsx
+++ b/apps/desktop/src/screens/SettingsScreen.tsx
@@ -5,7 +5,7 @@ import { updateProfileSettingsAction } from '../core/actions';
 import { useCore } from '../core/context';
 import type { ProfileState } from '../core/types';
 import { useCoreModel } from '../core/useCoreModel';
-import { enUS } from '../locales/en-US';
+import { t as enUS } from '../locales';
 import { connectNativeDiagnostics, nativeShellPresent } from '../native/player';
 import { subtitleLanguages } from '../player/subtitles';
 import type { KinoSettings } from '../settings';


### PR DESCRIPTION
Seventh Phase 3 item.

## Localization structure
Screens no longer import `en-US` directly. `locales/index.ts` resolves the interface locale from `navigator.languages`, matching an exact tag first, then the language alone (`en-GB` → `en-US`), and falling back to en-US so a partial locale set never leaves the interface without strings. Adding a translation is now a one-line registration. Unit tested.

## Accessibility
- Skip to content link, visible on first Tab, targeting the existing `#main-content` landmark.
- Status and error messages on Discover, Library, Add-ons, and the player are wrapped in polite live regions so they are announced rather than silently swapped in.
- Escape closes the Discover genre menu and returns focus to its trigger; the menu is exposed as a listbox.
- Reduced-motion coverage extended to the animations and transitions added during this phase (genre menu, Up Next, Skip Intro, account dialog, add-on and settings controls, poster hover scaling, skeleton pulse).

Verified live: pressing Tab from a fresh load reveals the skip link with a focus ring. `pnpm check` green (39 tests).