### PR TITLE
feat: package a self-contained signed macOS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ Run the complete local validation suite with:
 pnpm check
 ```
 
+### Packaging
+
+Produce a self-contained, signed disk image with checksums. Without a signing identity the build is ad-hoc signed for local validation only:
+
+```sh
+pnpm macos:package
+```
+
+Set `KINO_SIGNING_IDENTITY` to a Developer ID Application identity and `KINO_NOTARY_PROFILE` to a `notarytool` keychain profile to produce a distributable, notarized package. Packages are Apple Silicon only for now; see [ADR 0017](docs/adr/0017-ship-apple-silicon-first-and-defer-universal-packages.md).
+
 ## Project documents
 
 - [Product contract](docs/PRODUCT.md)

--- a/docs/adr/0017-ship-apple-silicon-first-and-defer-universal-packages.md
+++ b/docs/adr/0017-ship-apple-silicon-first-and-defer-universal-packages.md
@@ -1,0 +1,5 @@
+# Ship Apple Silicon first and defer universal packages
+
+Kino's first macOS packages are arm64-only rather than universal. The shell links Qt, libmpv, libtorrent, and Boost from Homebrew, which serves only native-architecture bottles, so a universal build needs a second complete x86_64 dependency set built from source — a large amount of work for hardware Kino's Apple Silicon target audience does not use. The packaging pipeline names its output by architecture (`Kino-<version>-arm64.dmg`) so an `x86_64` or `universal` artifact can join it later without changing how releases are published or verified.
+
+Signing and notarization are already wired: `pnpm macos:package` bundles Qt, the QML modules, and every remaining Homebrew library into the app, re-signs it from the inside out, optionally notarizes and staples it, and emits SHA-256 checksums. Credentials never live in the repository — the Developer ID identity comes from `KINO_SIGNING_IDENTITY` and notarization from a `notarytool` keychain profile named by `KINO_NOTARY_PROFILE`. Without them the pipeline produces an ad-hoc signed build for local validation.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "macos:check-engine": "./scripts/check-macos-engine.sh",
     "macos:check-launch": "./scripts/check-macos-launch.sh",
     "macos:check-playback": "node scripts/check-macos-playback.mjs",
+    "macos:package": "node scripts/package-macos.mjs",
     "test": "pnpm --filter @kino/desktop test",
     "typecheck": "pnpm --filter @kino/desktop typecheck"
   },

--- a/scripts/package-macos.mjs
+++ b/scripts/package-macos.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+// Packages Kino.app for distribution: bundles Qt and the remaining Homebrew
+// libraries into the app so it runs on a clean Mac, signs it, optionally
+// notarizes and staples it, then produces a DMG with SHA-256 checksums.
+//
+// Signing identity and notary credentials come from the environment and are
+// never stored in the repository:
+//   KINO_SIGNING_IDENTITY  Developer ID Application identity (default: ad-hoc)
+//   KINO_NOTARY_PROFILE    notarytool keychain profile name (skipped if unset)
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const sourceApp = join(repoRoot, 'build', 'macos', 'Kino.app');
+const distDir = join(repoRoot, 'build', 'dist');
+const stagedApp = join(distDir, 'Kino.app');
+const frameworksDir = join(stagedApp, 'Contents', 'Frameworks');
+const signingIdentity = process.env.KINO_SIGNING_IDENTITY ?? '-';
+const notaryProfile = process.env.KINO_NOTARY_PROFILE ?? '';
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, { encoding: 'utf8', ...options });
+}
+
+const qtPrefix = run('brew', ['--prefix', 'qt']).trim();
+
+function version() {
+  const plist = join(sourceApp, 'Contents', 'Info.plist');
+  return run('/usr/libexec/PlistBuddy', ['-c', 'Print :CFBundleShortVersionString', plist]).trim();
+}
+
+const homebrewPrefix = run('brew', ['--prefix']).trim();
+const searchPaths = [join(homebrewPrefix, 'lib'), join(qtPrefix, 'lib')];
+
+function isExternal(path) {
+  return (
+    path.startsWith(`${homebrewPrefix}/`) ||
+    path.startsWith('/usr/local/') ||
+    path.startsWith('/opt/homebrew/')
+  );
+}
+
+// Machine-specific dependencies must travel with the app. macdeployqt leaves
+// behind unresolved @rpath references for transitive Homebrew libraries, so
+// those are resolved against the Homebrew and Qt library directories.
+function dependencies(binary) {
+  return run('otool', ['-L', binary])
+    .split('\n')
+    .slice(1)
+    .map((line) => line.trim().split(' ')[0])
+    .filter(Boolean)
+    .filter((path) => path !== binary);
+}
+
+function resolveDependency(path) {
+  if (isExternal(path) && !path.includes('.framework/')) return path;
+  if (!path.startsWith('@rpath/')) return null;
+  const name = path.slice('@rpath/'.length);
+  if (name.includes('.framework/') || existsSync(join(frameworksDir, name))) return null;
+  for (const directory of searchPaths) {
+    const candidate = join(directory, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function machOFiles() {
+  const found = run('find', [stagedApp, '-type', 'f']).split('\n').filter(Boolean);
+  return found.filter((path) => {
+    if (/\.(dylib|so)$/.test(path)) return true;
+    if (/\.(plist|qml|png|svg|json|js|html|css|wasm|nib|icns|txt|woff2?)$/i.test(path))
+      return false;
+    try {
+      return run('file', ['-b', path]).includes('Mach-O');
+    } catch {
+      return false;
+    }
+  });
+}
+
+// Qt frameworks are copied by macdeployqt but some references keep their
+// absolute Homebrew paths. Rewrite those to the bundled copies.
+function frameworkSuffix(path) {
+  const match = /([^/]+\.framework\/.*)$/.exec(path);
+  return match ? match[1] : null;
+}
+
+function relativeRunpath(binary) {
+  const depth = binary.slice(join(stagedApp, 'Contents').length + 1).split('/').length - 1;
+  return `@loader_path/${'../'.repeat(depth)}Frameworks`;
+}
+
+// A bundled framework's own install name is its first otool entry; left at a
+// Homebrew path it makes dependents load the system copy instead.
+function installName(binary) {
+  return run('otool', ['-D', binary]).split('\n')[1]?.trim() ?? '';
+}
+
+function rewriteFrameworks() {
+  let rewritten = 0;
+  for (const binary of machOFiles()) {
+    let touched = false;
+    const ownName = installName(binary);
+    if (isExternal(ownName)) {
+      const ownSuffix = frameworkSuffix(ownName);
+      if (ownSuffix) {
+        run('install_name_tool', ['-id', `@rpath/${ownSuffix}`, binary]);
+        rewritten += 1;
+      }
+    }
+    for (const reference of dependencies(binary)) {
+      if (!isExternal(reference)) continue;
+      const suffix = frameworkSuffix(reference);
+      if (!suffix) continue;
+      const bundledPath = join(frameworksDir, suffix);
+      if (!existsSync(bundledPath)) {
+        const frameworkName = suffix.split('/')[0];
+        const sourceFramework = reference.slice(
+          0,
+          reference.indexOf(frameworkName) + frameworkName.length,
+        );
+        run('ditto', [sourceFramework, join(frameworksDir, frameworkName)]);
+      }
+      run('install_name_tool', ['-change', reference, `@rpath/${suffix}`, binary]);
+      touched = true;
+      rewritten += 1;
+    }
+    if (touched) addRunpath(binary, relativeRunpath(binary));
+  }
+  return rewritten;
+}
+
+function bundleDependencies() {
+  mkdirSync(frameworksDir, { recursive: true });
+  const bundled = new Set();
+  const queue = machOFiles();
+
+  while (queue.length > 0) {
+    const binary = queue.shift();
+    for (const reference of dependencies(binary)) {
+      const source = resolveDependency(reference);
+      if (!source) continue;
+      const name = basename(source);
+      const target = join(frameworksDir, name);
+      if (!bundled.has(name)) {
+        bundled.add(name);
+        if (!existsSync(target)) {
+          run('cp', ['-L', source, target]);
+          run('chmod', ['u+w', target]);
+        }
+        run('install_name_tool', ['-id', `@rpath/${name}`, target]);
+        queue.push(target);
+      }
+      if (reference !== `@rpath/${name}`) {
+        run('install_name_tool', ['-change', reference, `@rpath/${name}`, binary]);
+      }
+    }
+  }
+  return bundled;
+}
+
+function addRunpath(binary, runpath) {
+  try {
+    run('install_name_tool', ['-add_rpath', runpath, binary], { stdio: 'pipe' });
+  } catch {
+    // Already present; install_name_tool treats duplicates as an error.
+  }
+}
+
+function sign(target) {
+  // Ad-hoc signatures cannot carry a timestamp or the hardened runtime.
+  const distribution = signingIdentity === '-' ? [] : ['--timestamp', '--options', 'runtime'];
+  run('codesign', ['--force', ...distribution, '--sign', signingIdentity, target]);
+}
+
+// Rewriting load commands invalidates existing signatures, so everything is
+// re-signed from the inside out before the outer bundle.
+function signEverything() {
+  const byDepth = (left, right) => right.split('/').length - left.split('/').length;
+
+  const nested = run('find', [
+    stagedApp,
+    '-type',
+    'd',
+    '-name',
+    '*.framework',
+    '-o',
+    '-type',
+    'd',
+    '-name',
+    '*.app',
+  ])
+    .split('\n')
+    .filter((path) => path && path !== stagedApp)
+    .sort(byDepth);
+
+  const loose = machOFiles()
+    .filter((path) => !nested.some((bundle) => path.startsWith(`${bundle}/`)))
+    .sort(byDepth);
+
+  for (const target of loose) sign(target);
+  for (const bundle of nested) sign(bundle);
+  sign(stagedApp);
+}
+
+function checksum(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+if (!existsSync(sourceApp)) {
+  console.error('Build the app first: pnpm macos:build');
+  process.exit(1);
+}
+
+console.log('Staging the app bundle…');
+rmSync(distDir, { force: true, recursive: true });
+mkdirSync(distDir, { recursive: true });
+run('ditto', [sourceApp, stagedApp]);
+
+console.log('Bundling Qt…');
+// -qmldir lets macdeployqt discover the QML modules the shell imports; the
+// QML itself is compiled into the binary, so it cannot scan the bundle.
+run(
+  join(qtPrefix, 'bin', 'macdeployqt'),
+  [stagedApp, '-always-overwrite', `-qmldir=${join(repoRoot, 'apps', 'macos-shell', 'qml')}`],
+  { stdio: 'inherit' },
+);
+
+console.log('Bundling remaining libraries…');
+const mainBinary = join(stagedApp, 'Contents', 'MacOS', 'Kino');
+const engineBinary = join(stagedApp, 'Contents', 'MacOS', 'kino-stream-engine');
+const executables = [mainBinary, ...(existsSync(engineBinary) ? [engineBinary] : [])];
+const bundled = bundleDependencies();
+for (const executable of executables) addRunpath(executable, '@executable_path/../Frameworks');
+for (const library of machOFiles()) addRunpath(library, '@loader_path');
+const rewritten = rewriteFrameworks();
+console.log(`Bundled ${bundled.size} libraries and rewrote ${rewritten} framework references.`);
+
+const remaining = machOFiles()
+  .flatMap((binary) => dependencies(binary).map((path) => ({ binary, path })))
+  .filter(({ path }) => isExternal(path));
+if (remaining.length > 0) {
+  for (const { binary, path } of remaining.slice(0, 10)) {
+    console.error(`  ${basename(binary)} still links ${path}`);
+  }
+  console.error('Machine-specific libraries remain linked.');
+  process.exit(1);
+}
+
+console.log(
+  signingIdentity === '-'
+    ? 'Signing ad-hoc (set KINO_SIGNING_IDENTITY for a distributable build)…'
+    : `Signing with ${signingIdentity}…`,
+);
+signEverything();
+run('codesign', ['--verify', '--deep', '--strict', stagedApp]);
+
+if (notaryProfile) {
+  if (signingIdentity === '-') {
+    console.error('Notarization requires KINO_SIGNING_IDENTITY to be a Developer ID identity.');
+    process.exit(1);
+  }
+  console.log('Notarizing…');
+  const archive = join(distDir, 'Kino-notarize.zip');
+  run('ditto', ['-c', '-k', '--keepParent', stagedApp, archive]);
+  run('xcrun', ['notarytool', 'submit', archive, '--keychain-profile', notaryProfile, '--wait'], {
+    stdio: 'inherit',
+  });
+  run('xcrun', ['stapler', 'staple', stagedApp], { stdio: 'inherit' });
+  rmSync(archive);
+}
+
+console.log('Building the disk image…');
+const appVersion = version();
+const dmgPath = join(distDir, `Kino-${appVersion}-arm64.dmg`);
+run('hdiutil', [
+  'create',
+  '-quiet',
+  '-fs',
+  'HFS+',
+  '-format',
+  'UDZO',
+  '-volname',
+  `Kino ${appVersion}`,
+  '-srcfolder',
+  stagedApp,
+  '-ov',
+  dmgPath,
+]);
+if (signingIdentity !== '-') sign(dmgPath);
+
+const checksumPath = join(distDir, 'SHA256SUMS');
+writeFileSync(checksumPath, `${checksum(dmgPath)}  ${basename(dmgPath)}\n`);
+
+console.log(`\nPackaged ${dmgPath}`);
+console.log(readFileSync(checksumPath, 'utf8').trim());
+if (!notaryProfile) {
+  console.log('\nNot notarized. Set KINO_NOTARY_PROFILE to notarize and staple.');
+}


### PR DESCRIPTION
Final Phase 3 item. `pnpm macos:package` turns the local build into a distributable disk image.

## What it does
1. Stages the app, then runs macdeployqt with `-qmldir` so the QML modules the shell imports are bundled (without this the packaged app fails at launch on `QtQuick.Controls`).
2. Bundles every remaining machine-specific library — libmpv, libtorrent, Boost and their transitive dependencies — rewriting install names and framework references, including each bundled framework's own install ID, which macdeployqt leaves pointing at Homebrew.
3. Fails loudly if any Homebrew path is still linked, rather than shipping something that only runs on the build machine.
4. Re-signs everything inside out (load-command rewriting invalidates macdeployqt's signatures), verifies with `codesign --deep --strict`, optionally notarizes and staples, then builds the DMG and writes SHA-256 checksums.

Credentials never enter the repository: `KINO_SIGNING_IDENTITY` selects the Developer ID identity and `KINO_NOTARY_PROFILE` names a `notarytool` keychain profile. With neither set the build is ad-hoc signed for local validation.

## Verified
- Packaging completes: 385 MB app, 163 MB DMG, checksums written
- `codesign --verify --deep --strict` passes; zero Homebrew paths remain in any binary
- A copy relocated to `/tmp` passes both the launch probe and the engine probe, so the bundle carries its own Qt, mpv, and torrent stack

## Not verified
Developer ID signing and notarization need Chris's certificate and Apple credentials, so those paths are wired but unexercised. Packages are Apple Silicon only; ADR 0017 records why universal builds are deferred and how the artifact naming leaves room for them.