### PR TITLE
feat: remove items from Continue Watching

### DIFF
--- a/apps/desktop/src/App.module.css
+++ b/apps/desktop/src/App.module.css
@@ -271,13 +271,49 @@
 }
 
 .continueCard {
+  position: relative;
   width: 264px;
   flex: 0 0 auto;
+}
+
+.continueOpen {
+  display: block;
+  width: 100%;
   padding: 0;
   border: 0;
   color: inherit;
   background: transparent;
   cursor: pointer;
+}
+
+.continueDismiss {
+  position: absolute;
+  z-index: 1;
+  top: 8px;
+  right: 8px;
+  display: grid;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  border: 1px solid rgb(255 255 255 / 14%);
+  border-radius: 50%;
+  opacity: 0;
+  color: var(--kino-text);
+  background: rgb(10 10 11 / 82%);
+  cursor: pointer;
+  transition:
+    opacity var(--kino-duration-fast) ease,
+    background-color var(--kino-duration-fast) ease;
+}
+
+/* Revealed on hover, and always for keyboard users so it stays reachable. */
+.continueCard:hover .continueDismiss,
+.continueDismiss:focus-visible {
+  opacity: 1;
+}
+
+.continueDismiss:hover {
+  background: var(--kino-danger);
 }
 
 .continueArtwork {
@@ -1584,6 +1620,7 @@
 
   .catalogTab,
   .catalogTabActive,
+  .continueDismiss,
   .genreButton,
   .libraryButton,
   .logoButton,

--- a/apps/desktop/src/core/actions.ts
+++ b/apps/desktop/src/core/actions.ts
@@ -126,6 +126,10 @@ export function addToLibraryAction(meta: CoreMetaPreview): CoreAction {
   return { action: 'Ctx', args: { action: 'AddToLibrary', args: meta } };
 }
 
+export function rewindLibraryItemAction(id: string): CoreAction {
+  return { action: 'Ctx', args: { action: 'RewindLibraryItem', args: id } };
+}
+
 export function removeFromLibraryAction(id: string): CoreAction {
   return { action: 'Ctx', args: { action: 'RemoveFromLibrary', args: id } };
 }

--- a/apps/desktop/src/locales/en-US.ts
+++ b/apps/desktop/src/locales/en-US.ts
@@ -15,6 +15,7 @@ export const enUS = {
     title: 'Home',
     continueWatching: 'Continue Watching',
     continueEmpty: 'Nothing to resume yet.',
+    dismiss: 'Remove from Continue Watching',
     movies: 'Movies',
     series: 'Series',
     catalogs: 'Catalogs',

--- a/apps/desktop/src/screens/HomeScreen.tsx
+++ b/apps/desktop/src/screens/HomeScreen.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useMemo } from 'react';
 
+import { X } from '@phosphor-icons/react';
+
 import styles from '../App.module.css';
 import { MediaCard } from '../components/MediaCard';
-import { loadBoardAction } from '../core/actions';
+import { loadBoardAction, rewindLibraryItemAction } from '../core/actions';
 import { useCore } from '../core/context';
 import type {
   BoardState,
@@ -80,6 +82,16 @@ export function HomeScreen({
     [continueWatching.state],
   );
 
+  const dismissContinueWatching = (id: string) => {
+    if (!core.transport) return;
+    void core.transport.dispatch(rewindLibraryItemAction(id)).catch((error: unknown) => {
+      console.error(
+        '[kino:home] could not dismiss the continue watching item',
+        error instanceof Error ? error.message : error,
+      );
+    });
+  };
+
   return (
     <div className={styles.homePage}>
       <h1 className={styles.visuallyHidden}>{enUS.home.title}</h1>
@@ -92,33 +104,43 @@ export function HomeScreen({
         {continueItems.length > 0 ? (
           <div className={styles.continueRow}>
             {continueItems.map((item) => (
-              <button
-                className={styles.continueCard}
-                key={item._id}
-                onClick={() =>
-                  onOpen(
-                    {
-                      id: item._id,
-                      inLibrary: true,
-                      name: item.name,
-                      ...(item.poster === undefined ? {} : { poster: item.poster }),
-                      posterShape: item.posterShape,
-                      type: item.type,
-                      watched: false,
-                    },
-                    item.state.videoId,
-                  )
-                }
-                type="button"
-              >
-                <span className={styles.continueArtwork}>
-                  {item.poster ? <img alt="" src={item.poster} /> : null}
-                  <span className={styles.continueLabel}>{item.name}</span>
-                  <span className={styles.progressTrack}>
-                    <span style={{ width: `${Math.max(0, Math.min(100, item.progress))}%` }} />
+              <div className={styles.continueCard} key={item._id}>
+                <button
+                  className={styles.continueOpen}
+                  onClick={() =>
+                    onOpen(
+                      {
+                        id: item._id,
+                        inLibrary: true,
+                        name: item.name,
+                        ...(item.poster === undefined ? {} : { poster: item.poster }),
+                        posterShape: item.posterShape,
+                        type: item.type,
+                        watched: false,
+                      },
+                      item.state.videoId,
+                    )
+                  }
+                  type="button"
+                >
+                  <span className={styles.continueArtwork}>
+                    {item.poster ? <img alt="" src={item.poster} /> : null}
+                    <span className={styles.continueLabel}>{item.name}</span>
+                    <span className={styles.progressTrack}>
+                      <span style={{ width: `${Math.max(0, Math.min(100, item.progress))}%` }} />
+                    </span>
                   </span>
-                </span>
-              </button>
+                </button>
+                <button
+                  aria-label={`${enUS.home.dismiss} ${item.name}`}
+                  className={styles.continueDismiss}
+                  onClick={() => dismissContinueWatching(item._id)}
+                  title={enUS.home.dismiss}
+                  type="button"
+                >
+                  <X aria-hidden size={14} weight="bold" />
+                </button>
+              </div>
             ))}
           </div>
         ) : null}


### PR DESCRIPTION
Each Continue Watching card gets a dismiss control in its top-right corner.

- Backed by the core's `RewindLibraryItem` action, which clears the item's saved progress rather than deleting it. That is the distinction that matters: a title you added to your library stays there, it just stops appearing in Continue Watching. A title you only played — never added — existed solely as a progress record, so clearing it removes it entirely.
- The card was a single button, so a nested dismiss button would have been invalid markup. It is now a wrapper holding two sibling buttons: the artwork opens the title, the corner control dismisses it.
- The control fades in on hover and is also revealed on keyboard focus, so it is reachable without a pointer. It carries the title in its accessible name ("Remove from Continue Watching {title}") and is covered by the reduced-motion rules.
- No confirmation prompt: the action is low-stakes and recoverable by playing the title again.

Verified in the native app against a real account: hovering a card reveals the control on that card only, dismissing removes the item immediately as the core refreshes the model, and the rest of the row is untouched.

I verified removal from Continue Watching directly. I did not separately dismiss a library-tracked title, so the "stays in your library" half follows from the action's semantics rather than from an observed run.

`pnpm check` green (43 tests).