### PR TITLE
fix: keep place when choosing an episode

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -156,6 +156,7 @@ export function App() {
         return detail ? (
           <MetaDetailsScreen
             failedSources={failedSources}
+            key={detail.id}
             initialVideoId={detailVideoId}
             item={detail}
             onBack={() => setScreen(previousScreen)}

--- a/apps/desktop/src/core/useCoreModel.ts
+++ b/apps/desktop/src/core/useCoreModel.ts
@@ -97,7 +97,13 @@ export function useCoreModel<State>(
   if (status !== 'ready' || !transport) {
     return { error: null, loading: status === 'loading', state: null };
   }
-  return result.actionKey === actionKey && result.transport === transport
-    ? result
-    : { error: null, loading: true, state: null };
+  if (result.actionKey === actionKey && result.transport === transport) return result;
+  // A new selection reloads the model. Keeping the previous state while that
+  // happens stops the screen collapsing and losing its scroll position; a
+  // different transport is a different session, so that state is dropped.
+  return {
+    error: null,
+    loading: true,
+    state: result.transport === transport ? result.state : null,
+  };
 }

--- a/apps/desktop/src/screens/MetaDetailsScreen.tsx
+++ b/apps/desktop/src/screens/MetaDetailsScreen.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft, Check, Play, Plus } from '@phosphor-icons/react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import styles from '../App.module.css';
 import {
@@ -61,8 +61,27 @@ export function MetaDetailsScreen({
     `${item.type}:${item.id}:${videoId ?? 'guess'}`,
   );
   const resource = result.state?.metaItem;
-  const meta = resource?.content.type === 'Ready' ? resource.content.content : null;
+  const loadedMeta = resource?.content.type === 'Ready' ? resource.content.content : null;
+  // Choosing an episode reloads the model, and the reloaded state arrives with
+  // its metadata still loading. Without the previous copy the episode list
+  // unmounts, the page collapses to the hero, and the browser discards the
+  // scroll position. The screen is keyed by title, so this cannot leak between
+  // titles, and a title's metadata does not change when only the episode does.
+  const [lastMeta, setLastMeta] = useState<CoreMetaItem | null>(null);
+  if (loadedMeta && loadedMeta !== lastMeta) setLastMeta(loadedMeta);
+  const meta = loadedMeta ?? lastMeta;
   const videos = useMemo(() => meta?.videos ?? [], [meta]);
+  const sourcesRef = useRef<HTMLElement>(null);
+  const episodeChosenRef = useRef(false);
+
+  // Picking an episode is a request to see its sources, so bring them into view.
+  // This waits for the reload to settle: the sources empty while it runs, which
+  // shrinks the page and would clamp an earlier scroll straight back.
+  useEffect(() => {
+    if (!episodeChosenRef.current || result.loading) return;
+    episodeChosenRef.current = false;
+    sourcesRef.current?.scrollIntoView({ behavior: 'auto', block: 'start' });
+  }, [result.loading, videoId]);
 
   useEffect(() => {
     if (item.type !== 'series' || videoId !== null || videos.length === 0) return;
@@ -172,7 +191,10 @@ export function MetaDetailsScreen({
                   aria-current={video.id === videoId ? 'true' : undefined}
                   className={video.id === videoId ? styles.episodeActive : styles.episodeButton}
                   key={video.id}
-                  onClick={() => setVideoId(video.id)}
+                  onClick={() => {
+                    episodeChosenRef.current = true;
+                    setVideoId(video.id);
+                  }}
                   type="button"
                 >
                   <span className={styles.episodeNumber}>
@@ -189,7 +211,11 @@ export function MetaDetailsScreen({
           </section>
         ) : null}
 
-        <section className={styles.detailSection} aria-labelledby="sources-heading">
+        <section
+          aria-labelledby="sources-heading"
+          className={styles.detailSection}
+          ref={sourcesRef}
+        >
           <div className={styles.detailSectionHeading}>
             <h2 id="sources-heading">{enUS.details.sources}</h2>
             {result.loading ? <span>{enUS.details.refreshing}</span> : null}


### PR DESCRIPTION
Choosing an episode threw you back to the top of the page instead of showing that episode's sources.

## Cause
Selecting an episode changes the details model's action key, which reloads it. Two things then emptied the page:

1. `useCoreModel` synchronously returned `state: null` the moment the key changed.
2. Even after fixing that, the reloaded state arrives from the core with its `metaItem` still `Loading`, so the episode list emptied anyway.

Either way the page collapsed to just the hero. Measured inside the running app, the scroll container's `scrollHeight` dropped to exactly its own height — there was nothing left to scroll, so the browser discarded the position and any scroll call was a no-op.

## Fix
- `useCoreModel` keeps the previous state while a new selection loads instead of blanking it. State from a different transport is still dropped, so switching between guest and account cannot show the other session's data.
- The details screen holds the last loaded metadata across a reload. A title's metadata does not change when only the episode does, and the screen is now keyed by title, so this cannot leak between titles.
- Once the reload settles, the sources are scrolled into view — picking an episode is a request to see how to watch it. Deliberately instant rather than smooth, and deliberately after the reload: an earlier or animated scroll gets cancelled by the reflow.

## Verified in the native app
Instrumented through the remote debugger. Scrolled partway down Ted Lasso season 3, chose episode 5: the position held at 613 across the whole reload (previously it was forced to 0), the page never collapsed (minimum height 1413 rather than 800), and the sources for s03e05 render in place. Season switching no longer collapses the list either.

`pnpm check` (43 tests), `macos:check-launch`, and all 15 playback fixtures pass.