### PR TITLE
fix: trust TheIntroDB markers the API actually returns

### DIFF
--- a/apps/desktop/src/intro/markers.test.ts
+++ b/apps/desktop/src/intro/markers.test.ts
@@ -34,25 +34,28 @@ describe('intro marker trust', () => {
     ).toEqual({ source: 'chapter', startMs: 20_000, endMs: 87_000 });
   });
 
-  it('requires confidence, corroboration, and duration-safe community data', () => {
-    const base = {
-      durationMs: 80_000,
-      endMs: 92_000,
+  it('trusts a duration-safe community segment and rejects unsafe ones', () => {
+    const segment = {
+      durationMs: 22_000,
+      endMs: 367_458,
       endsAtMediaEnd: false,
-      startMs: 12_000,
+      startMs: 345_458,
       startsAtBeginning: false,
     };
+    expect(markerFromCommunity([segment], 2_940_000)).toEqual({
+      source: 'theintrodb',
+      startMs: 345_458,
+      endMs: 367_458,
+    });
     expect(
       markerFromCommunity(
         [
-          { ...base, confidence: 0.95, submissionCount: 1 },
-          { ...base, confidence: 0.8, submissionCount: 2 },
+          { ...segment, endMs: null, endsAtMediaEnd: true },
+          { ...segment, endMs: 348_000 },
+          { ...segment, endMs: 2_950_000 },
         ],
-        3_000_000,
+        2_940_000,
       ),
-    ).toEqual({ source: 'theintrodb', startMs: 12_000, endMs: 92_000 });
-    expect(
-      markerFromCommunity([{ ...base, confidence: 0.79, submissionCount: 3 }], 3_000_000),
     ).toBeNull();
   });
 });

--- a/apps/desktop/src/intro/markers.ts
+++ b/apps/desktop/src/intro/markers.ts
@@ -66,12 +66,11 @@ export function markerFromCommunity(
   candidates: NormalizedSegmentTimestamp[],
   durationMs: number,
 ): IntroMarker | null {
+  // The public API returns one already-weighted segment per type with no
+  // confidence or submission fields, so trust rests on the bounds checks and
+  // on the duration matching the service performs against `duration_ms`.
   const candidate = candidates.find(
-    (segment) =>
-      segment.endMs !== null &&
-      (segment.confidence ?? 0) >= 0.8 &&
-      (segment.submissionCount ?? 0) >= 2 &&
-      validBounds(segment.startMs, segment.endMs, durationMs),
+    (segment) => segment.endMs !== null && validBounds(segment.startMs, segment.endMs, durationMs),
   );
   return candidate?.endMs == null
     ? null

--- a/apps/desktop/src/screens/PlayerScreen.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.tsx
@@ -506,11 +506,19 @@ export function PlayerScreen({
 
     const controller = new AbortController();
     void lookupCommunityIntro(introIdentity(selection, duration), controller.signal)
-      .then(setCommunityMarker)
+      .then((communityMarker) => {
+        setCommunityMarker(communityMarker);
+        console.info(
+          communityMarker
+            ? '[kino:intro] trusted community marker'
+            : '[kino:intro] no trusted community marker',
+          communityMarker ?? '',
+        );
+      })
       .catch((error: unknown) => {
         if (error instanceof DOMException && error.name === 'AbortError') return;
         console.info(
-          '[kino:intro] no trusted community marker',
+          '[kino:intro] community lookup failed',
           error instanceof Error ? error.message : error,
         );
       });


### PR DESCRIPTION
Skip Intro never appeared for episodes whose marker comes from TheIntroDB. Ted Lasso S3E4 has a community intro at 5:45 to 6:07 and the button never showed.

## Cause

`markerFromCommunity` required `confidence >= 0.8` and `submissionCount >= 2`. The public API returns one already-weighted segment with only `start_ms` and `end_ms`, so both fields defaulted to 0 and every community marker was dropped. The old test passed only because it fabricated those fields.

## Fix

- Trust a community segment on the checks the API supports: valid bounds, the 5 s to 200 s length window, and the media duration Kino already sends as `duration_ms` for server-side matching. This still satisfies ADR 0004's duration-matching requirement.
- Rewrite the test against the real response shape.
- Log whether the lookup found a trusted marker, found none, or failed. Note these console lines do not yet reach the shell's diagnostic log; that is #29.

Closes #28

## Verified

`pnpm check` passes (43 tests). Rebuilt the native shell for a manual retest on Ted Lasso S3E4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrMeAPbcuU3NAxb6htfewV