### PR TITLE
Fix libmpv property decoding and hardware detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Validate the playback contract against generated legal fixtures — codecs, HDR 
 pnpm macos:check-playback
 ```
 
+Run the native property-event regression tests after building with:
+
+```sh
+ctest --test-dir build/macos --output-on-failure
+```
+
 ### Streaming engine
 
 Torrent sources play through a pinned build of the open [stream-server](https://github.com/stremio-native/stream-server) engine, which the shell starts on demand and binds to loopback. It is optional: without it Kino runs normally and reports torrent sources as unavailable. Build and bundle it with:

--- a/apps/macos-shell/CMakeLists.txt
+++ b/apps/macos-shell/CMakeLists.txt
@@ -121,3 +121,21 @@ add_custom_target(
   COMMENT "Packaging Kino streaming engine"
 )
 add_dependencies(kino_package_engine Kino)
+
+include(CTest)
+if(BUILD_TESTING)
+  find_package(Qt6 6.8 REQUIRED COMPONENTS Test)
+  qt_add_executable(
+    kino_mpvitem_test
+    tests/mpvitem_test.cpp
+    src/mpvitem.cpp
+    src/powerguard.cpp
+  )
+  target_include_directories(kino_mpvitem_test PRIVATE src)
+  target_link_libraries(
+    kino_mpvitem_test
+    PRIVATE PkgConfig::MPV ${IOKIT_FRAMEWORK} Qt6::Quick Qt6::Test
+  )
+  add_test(NAME mpvitem_properties COMMAND kino_mpvitem_test)
+  set_tests_properties(mpvitem_properties PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+endif()

--- a/apps/macos-shell/src/mpvitem.cpp
+++ b/apps/macos-shell/src/mpvitem.cpp
@@ -28,6 +28,15 @@ QVariantMap millisecondsPayload(double seconds) {
     return {{QStringLiteral("milliseconds"), std::llround(seconds * 1000.0)}};
 }
 
+QByteArray stringPropertyValue(const mpv_event_property &property) {
+    if (property.format != MPV_FORMAT_STRING || !property.data) {
+        return {};
+    }
+    // libmpv stores the address of the string pointer in property events.
+    const char *value = *static_cast<char *const *>(property.data);
+    return value ? QByteArray(value) : QByteArray();
+}
+
 QVariantList chapterPayload(const mpv_node &root) {
     QVariantList chapters;
     if (root.format != MPV_FORMAT_NODE_ARRAY || !root.u.list) {
@@ -377,31 +386,12 @@ void MpvItem::handleEvent(mpv_event *event) {
         break;
     case MPV_EVENT_PROPERTY_CHANGE: {
         auto *property = static_cast<mpv_event_property *>(event->data);
-        if (!property || !property->data) {
+        if (!property || !property->name) {
             break;
         }
         const QByteArray name(property->name);
-        if (name == "time-pos" || name == "duration") {
-            const double seconds = *static_cast<double *>(property->data);
-            emit playerEvent(name == "time-pos" ? QStringLiteral("time")
-                                                : QStringLiteral("duration"),
-                             millisecondsPayload(seconds));
-        } else if (name == "pause") {
-            paused_ = *static_cast<int *>(property->data) != 0;
-            updatePowerGuard();
-            emit playerEvent(QStringLiteral("paused"),
-                             {{QStringLiteral("paused"), paused_}});
-        } else if (name == "paused-for-cache") {
-            emit playerEvent(QStringLiteral("buffering"),
-                             {{QStringLiteral("active"),
-                               *static_cast<int *>(property->data) != 0}});
-        } else if (name == "mute") {
-            emit playerEvent(QStringLiteral("muted"),
-                             {{QStringLiteral("muted"),
-                               *static_cast<int *>(property->data) != 0}});
-        } else if (name == "hwdec-current") {
-            const auto *decoder = static_cast<const char *>(property->data);
-            hardwareDecoderActive_ = decoder && *decoder != '\0';
+        if (name == "hwdec-current") {
+            hardwareDecoderActive_ = stringPropertyValue(*property) == "videotoolbox";
             emit playerEvent(QStringLiteral("hardwareDecoding"),
                              {{QStringLiteral("active"), hardwareDecoderActive_}});
             if (hardwareDecoderActive_) {
@@ -409,22 +399,44 @@ void MpvItem::handleEvent(mpv_event *event) {
                 qInfo("[kino:mpv] hardware decoder active");
             } else if (videoPresent_) {
                 hardwareDecoderTimer_.start();
+            } else {
+                hardwareDecoderTimer_.stop();
             }
         } else if (name == "video-format") {
-            const auto *format = static_cast<const char *>(property->data);
-            videoPresent_ = format && *format != '\0';
+            videoPresent_ = !stringPropertyValue(*property).isEmpty();
             updatePowerGuard();
             if (videoPresent_ && !hardwareDecoderActive_) {
                 hardwareDecoderTimer_.start();
-            } else if (!videoPresent_) {
+            } else {
                 hardwareDecoderTimer_.stop();
             }
-        } else if (name == "chapter-list") {
+        } else if (!property->data) {
+            break;
+        } else if ((name == "time-pos" || name == "duration") &&
+                   property->format == MPV_FORMAT_DOUBLE) {
+            const double seconds = *static_cast<double *>(property->data);
+            emit playerEvent(name == "time-pos" ? QStringLiteral("time")
+                                                : QStringLiteral("duration"),
+                             millisecondsPayload(seconds));
+        } else if (name == "pause" && property->format == MPV_FORMAT_FLAG) {
+            paused_ = *static_cast<int *>(property->data) != 0;
+            updatePowerGuard();
+            emit playerEvent(QStringLiteral("paused"),
+                             {{QStringLiteral("paused"), paused_}});
+        } else if (name == "paused-for-cache" && property->format == MPV_FORMAT_FLAG) {
+            emit playerEvent(QStringLiteral("buffering"),
+                             {{QStringLiteral("active"),
+                               *static_cast<int *>(property->data) != 0}});
+        } else if (name == "mute" && property->format == MPV_FORMAT_FLAG) {
+            emit playerEvent(QStringLiteral("muted"),
+                             {{QStringLiteral("muted"),
+                               *static_cast<int *>(property->data) != 0}});
+        } else if (name == "chapter-list" && property->format == MPV_FORMAT_NODE) {
             const auto *chapters = static_cast<const mpv_node *>(property->data);
             emit playerEvent(
                 QStringLiteral("chapters"),
                 {{QStringLiteral("items"), chapterPayload(*chapters)}});
-        } else if (name == "track-list") {
+        } else if (name == "track-list" && property->format == MPV_FORMAT_NODE) {
             const auto *tracks = static_cast<const mpv_node *>(property->data);
             emit playerEvent(
                 QStringLiteral("subtitleTracks"),

--- a/apps/macos-shell/src/mpvitem.h
+++ b/apps/macos-shell/src/mpvitem.h
@@ -45,6 +45,7 @@ private slots:
 
 private:
     friend class MpvRenderer;
+    friend class MpvItemTest;
 
     static void onRenderUpdate(void *context);
     static void onWakeup(void *context);

--- a/apps/macos-shell/tests/mpvitem_test.cpp
+++ b/apps/macos-shell/tests/mpvitem_test.cpp
@@ -1,0 +1,155 @@
+#include "mpvitem.h"
+
+#include <QSignalSpy>
+#include <QtTest>
+
+#include <cstring>
+
+class MpvItemTest : public QObject {
+    Q_OBJECT
+
+    static void sendProperty(MpvItem &player, const char *name, mpv_format format,
+                             void *data) {
+        mpv_event_property property{name, format, data};
+        mpv_event event{};
+        event.event_id = MPV_EVENT_PROPERTY_CHANGE;
+        event.data = &property;
+        player.handleEvent(&event);
+    }
+
+    static void sendString(MpvItem &player, const char *name, const char *value) {
+        // A nonzero low address byte makes the old pointer-as-string read
+        // deterministically report true, even for "no" and empty strings.
+        alignas(256) char storage[256]{};
+        char *data = value ? storage + 1 : nullptr;
+        if (value) {
+            std::strcpy(data, value);
+        }
+        sendProperty(player, name, MPV_FORMAT_STRING, &data);
+    }
+
+private slots:
+    void hardwareDecoderProperties_data() {
+        QTest::addColumn<QByteArray>("value");
+        QTest::addColumn<bool>("expected");
+        QTest::newRow("videotoolbox") << QByteArray("videotoolbox") << true;
+        QTest::newRow("software") << QByteArray("no") << false;
+        QTest::newRow("empty") << QByteArray("") << false;
+        QTest::newRow("unknown-decoder") << QByteArray("unknown") << false;
+        QTest::newRow("null-string") << QByteArray() << false;
+    }
+
+    void hardwareDecoderProperties() {
+        QFETCH(QByteArray, value);
+        QFETCH(bool, expected);
+        MpvItem player;
+        player.setActive(true);
+        sendString(player, "video-format", "h264");
+        sendString(player, "hwdec-current", "videotoolbox");
+        QSignalSpy events(&player, &MpvItem::playerEvent);
+
+        sendString(player, "hwdec-current", value.isNull() ? nullptr : value.constData());
+
+        QCOMPARE(player.hardwareDecoderActive_, expected);
+        QCOMPARE(player.hardwareDecoderTimer_.isActive(), !expected);
+        QCOMPARE(events.size(), 1);
+        QCOMPARE(events.last().at(0).toString(), QStringLiteral("hardwareDecoding"));
+        QCOMPARE(events.last().at(1).toMap().value("active").toBool(), expected);
+    }
+
+    void missingProperties_data() {
+        QTest::addColumn<QByteArray>("name");
+        QTest::addColumn<int>("format");
+        QTest::addColumn<bool>("hasData");
+        for (const char *name : {"hwdec-current", "video-format"}) {
+            const QByteArray prefix(name);
+            QTest::newRow((prefix + "-unavailable").constData())
+                << prefix << int(MPV_FORMAT_NONE) << false;
+            QTest::newRow((prefix + "-wrong-format").constData())
+                << prefix << int(MPV_FORMAT_FLAG) << true;
+            QTest::newRow((prefix + "-null-data").constData())
+                << prefix << int(MPV_FORMAT_STRING) << false;
+        }
+    }
+
+    void missingProperties() {
+        QFETCH(QByteArray, name);
+        QFETCH(int, format);
+        QFETCH(bool, hasData);
+        MpvItem player;
+        player.setActive(true);
+        sendString(player, "video-format", "h264");
+        sendString(player, "hwdec-current",
+                   name == "hwdec-current" ? "videotoolbox" : "no");
+        int flag = 1;
+
+        sendProperty(player, name.constData(), mpv_format(format), hasData ? &flag : nullptr);
+
+        if (name == "hwdec-current") {
+            QVERIFY(!player.hardwareDecoderActive_);
+            QVERIFY(player.hardwareDecoderTimer_.isActive());
+        } else {
+            QVERIFY(!player.videoPresent_);
+            QVERIFY(!player.hardwareDecoderTimer_.isActive());
+        }
+    }
+
+    void noVideoCancelsRejection_data() {
+        QTest::addColumn<bool>("nullString");
+        QTest::newRow("empty") << false;
+        QTest::newRow("null-string") << true;
+    }
+
+    void noVideoCancelsRejection() {
+        QFETCH(bool, nullString);
+        MpvItem player;
+        player.setActive(true);
+        sendString(player, "video-format", "h264");
+        sendString(player, "hwdec-current", "no");
+
+        sendString(player, "video-format", nullString ? nullptr : "");
+
+        QVERIFY(!player.videoPresent_);
+        QVERIFY(!player.hardwareDecoderTimer_.isActive());
+        QSignalSpy events(&player, &MpvItem::playerEvent);
+        QVERIFY(QMetaObject::invokeMethod(&player.hardwareDecoderTimer_, "timeout",
+                                         Qt::DirectConnection));
+        QVERIFY(events.isEmpty());
+        QVERIFY(player.active());
+    }
+
+    void alignedStrings() {
+        MpvItem player;
+        alignas(256) char decoder[] = "videotoolbox";
+        alignas(256) char format[] = "h264";
+        char *decoderData = decoder;
+        char *formatData = format;
+
+        sendProperty(player, "hwdec-current", MPV_FORMAT_STRING, &decoderData);
+        sendProperty(player, "video-format", MPV_FORMAT_STRING, &formatData);
+
+        QVERIFY(player.hardwareDecoderActive_);
+        QVERIFY(player.videoPresent_);
+    }
+
+    void softwareVideoIsRejected() {
+        MpvItem player;
+        player.setActive(true);
+        sendString(player, "video-format", "h264");
+        sendString(player, "hwdec-current", "no");
+        QSignalSpy events(&player, &MpvItem::playerEvent);
+
+        QVERIFY(player.hardwareDecoderTimer_.isActive());
+        QVERIFY(QMetaObject::invokeMethod(&player.hardwareDecoderTimer_, "timeout",
+                                         Qt::DirectConnection));
+
+        QVERIFY(!player.active());
+        QCOMPARE(events.size(), 1);
+        QCOMPARE(events.last().at(0).toString(), QStringLiteral("error"));
+        QCOMPARE(events.last().at(1).toMap().value("code").toString(),
+                 QStringLiteral("hardware-decoding-unavailable"));
+    }
+};
+
+QTEST_MAIN(MpvItemTest)
+#include "mpvitem_test.moc"


### PR DESCRIPTION
libmpv property events store string values through a `char **`. Kino read the pointer bytes as text and treated `no` as a hardware decoder, which could bypass software-video rejection or reject valid playback.

Decode strings with the documented indirection and format checks. Only `videotoolbox`, the configured native backend, activates hardware decoding. Empty, missing, and unavailable properties clear hardware/video state and update the rejection timer. Other property reads now check their formats as well.

Validation:
- Native event regressions: 17 passed. Replacing the handler with the main-branch version produced 12 failures, including software-decoder rejection and aligned-pointer cases.
- Fresh macOS build, CTest, and native launch probe passed.
- All 15 native playback fixtures passed, including hardware H.264/HEVC/AV1 and rejection of software-only FFV1.
- `pnpm check` passed with Node 24, including all 43 web tests. The default local Node 26 fails the existing jsdom localStorage setup; CI uses Node 24.

Closes #31.
