### PR TITLE
Disable runtime yt-dlp downloads and execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,14 @@ Torrent sources play through a pinned build of the open [stream-server](https://
 ```sh
 brew install rust libtorrent-rasterbar boost
 pnpm engine:build
+pnpm engine:check-profile
 pnpm macos:build
 pnpm macos:check-engine
 ```
 
 Each engine build reconstructs `build/vendor/stream-server` from the pinned revision and current patches, then enforces Cargo's lockfile. Keep upstream changes in `apps/stream-engine/patches`; edits inside the generated vendor directory are discarded. `pnpm engine:check-vendor` checks patch changes and failed retries without requiring the native toolchain.
+
+Kino excludes the upstream YouTube resolver and yt-dlp downloader from its engine. `pnpm engine:check-profile` starts the helper with a fresh cache and a blocking HTTP proxy, then checks that startup and an unsupported YouTube request create no executable tools or release-download requests. The engine's tracker-list data refreshes remain allowed.
 
 Run the complete local validation suite with:
 

--- a/apps/stream-engine/patches/0002-exclude-youtube-tools.patch
+++ b/apps/stream-engine/patches/0002-exclude-youtube-tools.patch
@@ -1,0 +1,50 @@
+diff --git a/server/src/lib.rs b/server/src/lib.rs
+index 69db2f9..3e3e880 100644
+--- a/server/src/lib.rs
++++ b/server/src/lib.rs
+@@ -53,7 +53,6 @@ mod ssdp;
+ mod state;
+ mod tui;
+ mod updater;
+-pub mod ytdlp;
+ 
+ pub use ffmpeg_setup::MissingFfmpegError;
+ 
+@@ -361,19 +360,6 @@ async fn run_inner(
+         );
+     }
+ 
+-    // yt-dlp is only needed for YouTube trailers, but downloading it while a
+-    // hover preview waits is very visible. Warming it here off the startup path
+-    // means the first trailer usually finds it already installed, and a failure
+-    // only costs the trailer rather than the server.
+-    {
+-        let config_dir = config_dir.clone();
+-        tokio::spawn(async move {
+-            if let Err(error) = ytdlp::resolve(&config_dir).await {
+-                tracing::warn!(%error, "could not prepare yt-dlp; YouTube trailers will be unavailable");
+-            }
+-        });
+-    }
+-
+     let default_settings = routes::system::ServerSettings {
+         cache_root: cache_dir.to_string_lossy().to_string(),
+         ..routes::system::ServerSettings::default()
+@@ -830,7 +816,7 @@ pub fn build_router(state: AppState) -> Router {
+         .route("/device-info", get(routes::system::get_device_info))
+         .route("/hwaccel-profiler", get(routes::system::hwaccel_profiler))
+         .route("/get-https", get(routes::system::get_https))
+-        .nest("/yt", routes::youtube::router())
++        .route("/yt/{id}", get(|| async { StatusCode::NOT_FOUND }))
+         .nest("/rar", routes::archive::router())
+         .nest("/zip", routes::archive::router())
+         .nest("/7zip", routes::archive::router())
+diff --git a/server/src/routes/mod.rs b/server/src/routes/mod.rs
+index a2bd941..9e20696 100644
+--- a/server/src/routes/mod.rs
++++ b/server/src/routes/mod.rs
+@@ -13,4 +13,3 @@ pub mod stream;
+ pub mod subtitles;
+ pub mod system;
+ pub mod update;
+-pub mod youtube;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint": "eslint .",
     "engine:build": "./scripts/build-engine.sh",
     "engine:check-vendor": "node scripts/check-engine-vendor.mjs",
+    "engine:check-profile": "node scripts/check-engine-profile.mjs",
     "macos:build": "./scripts/build-macos.sh",
     "macos:check-engine": "./scripts/check-macos-engine.sh",
     "macos:check-launch": "./scripts/check-macos-launch.sh",

--- a/scripts/check-engine-profile.mjs
+++ b/scripts/check-engine-profile.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+// Probe a fresh engine through a blocking HTTP proxy. Tracker-list refreshes
+// are data fetches; release downloads and executable tools are forbidden.
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { once } from 'node:events';
+import { existsSync, mkdtempSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const binary = resolve(
+  process.env.KINO_ENGINE_BINARY ?? 'build/engine-target/release/kino-stream-engine',
+);
+assert.ok(existsSync(binary), 'Build the native helper with pnpm engine:build first.');
+const root = mkdtempSync(join(tmpdir(), 'kino-profile-check-'));
+const requests = [];
+const proxy = createServer((socket) => {
+  socket.once('data', (data) => {
+    requests.push(data.toString().split('\r\n')[0]);
+    socket.end('HTTP/1.1 502 Blocked by Kino test\r\nContent-Length: 0\r\n\r\n');
+  });
+  socket.on('error', () => {});
+});
+proxy.listen(0, '127.0.0.1');
+await once(proxy, 'listening');
+const proxyUrl = `http://127.0.0.1:${proxy.address().port}`;
+const env = {
+  ...process.env,
+  PATH: root,
+  KINO_ENGINE_CACHE_DIR: root,
+  KINO_ENGINE_PORT: '0',
+  HTTP_PROXY: proxyUrl,
+  HTTPS_PROXY: proxyUrl,
+  ALL_PROXY: proxyUrl,
+  http_proxy: proxyUrl,
+  https_proxy: proxyUrl,
+  all_proxy: proxyUrl,
+  NO_PROXY: '127.0.0.1,localhost',
+  no_proxy: '127.0.0.1,localhost',
+};
+delete env.STREMIO_YTDLP_PATH;
+const child = spawn(binary, [], {
+  env,
+  stdio: ['pipe', 'pipe', 'pipe'],
+});
+const exited = once(child, 'exit');
+let output = '';
+child.stderr.resume();
+const timeout = setTimeout(() => child.kill('SIGKILL'), 20000);
+try {
+  const address = await new Promise((resolveAddress, reject) => {
+    child.on('error', reject);
+    child.on('exit', () => reject(new Error('Engine exited before readiness.')));
+    child.stdout.on('data', (data) => {
+      output += data;
+      const match = output.match(/^KINO_ENGINE_READY (http:\/\/127\.0\.0\.1:\d+)$/m);
+      if (match) resolveAddress(match[1]);
+    });
+  });
+  assert.equal((await fetch(`${address}/heartbeat`)).status, 200);
+  const youtube = await fetch(`${address}/yt/abcdefghijk.json`);
+  await youtube.arrayBuffer();
+  await new Promise((resolveWait) => setTimeout(resolveWait, 1500));
+  const results = {
+    youtubeStatus: youtube.status,
+    outboundHttp: requests,
+    toolsDirectory: existsSync(join(root, 'tools')),
+  };
+  console.log(JSON.stringify(results));
+  const unexpectedRequests = requests.filter(
+    (request) => !/^CONNECT raw\.githubusercontent\.com:443 HTTP\/1\.1$/.test(request),
+  );
+  assert.deepEqual(unexpectedRequests, [], 'Only upstream tracker-list HTTP requests are allowed.');
+  assert.equal(youtube.status, 404, 'YouTube resolution must be unavailable.');
+  assert.equal(results.toolsDirectory, false, 'A clean start must not provision executable tools.');
+  function checkFiles(directory) {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) checkFiles(path);
+      else
+        assert.equal(statSync(path).mode & 0o111, 0, `Engine created an executable: ${entry.name}`);
+    }
+  }
+  checkFiles(root);
+
+  // Metadata-only private torrent with no trackers or public swarm traffic.
+  const piece = Buffer.from('Kino probe');
+  const info = Buffer.concat([
+    Buffer.from('d6:lengthi10e4:name11:fixture.bin12:piece lengthi16384e6:pieces20:'),
+    createHash('sha1').update(piece).digest(),
+    Buffer.from('7:privatei1ee'),
+  ]);
+  const infoHash = createHash('sha1').update(info).digest('hex');
+  const torrent = Buffer.concat([Buffer.from('d4:info'), info, Buffer.from('e')]);
+  const created = await fetch(`${address}/create`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ torrent: torrent.toString('hex') }),
+  });
+  assert.equal(created.status, 200);
+  const stats = await created.json();
+  assert.equal(stats.infoHash, infoHash, 'Torrent creation must still return the supplied media.');
+  assert.equal((await fetch(`${address}/${infoHash}/remove`)).status, 200);
+  console.log('Private torrent creation and removal passed.');
+} finally {
+  child.stdin.end();
+  await exited;
+  clearTimeout(timeout);
+  proxy.close();
+  rmSync(root, { recursive: true, force: true });
+}


### PR DESCRIPTION
Starting Kino's embedded engine could download an unpinned yt-dlp executable. The upstream YouTube route could trigger the same download and execute the result.

Apply a pinned Kino patch that removes the startup warm-up and excludes the YouTube resolver and yt-dlp modules from compilation. Requests under `/yt/{id}` return 404 so they cannot fall through to the generic torrent route.

Add `pnpm engine:check-profile`, which starts the real helper with a fresh cache, an empty executable search path, and a blocking HTTP proxy. It checks unsupported YouTube requests, absence of executable tools and release-download requests, and private torrent creation/removal. The upstream tracker-list data refresh remains allowed.

Validation:
- Before the patch, the isolated probe captured two blocked requests to github.com, creation of a tools directory, and a 503 from the resolver.
- After the patch, only tracker-list requests occurred, no tools directory or executable files appeared, `/yt` returned 404, and private torrent creation/removal passed.
- Locked native engine build, macOS build, bundled-engine startup probe, and `pnpm check` on Node 24 passed.

Closes #32.
