### PR TITLE
Route sanitized engine diagnostics through Kino's rotating log

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Each engine build reconstructs `build/vendor/stream-server` from the pinned revi
 
 Kino excludes the upstream YouTube resolver and yt-dlp downloader from its engine. `pnpm engine:check-profile` starts the helper with a fresh cache and a blocking HTTP proxy, then checks that startup and an unsupported YouTube request create no executable tools or release-download requests. The engine's tracker-list data refreshes remain allowed.
 
+Engine diagnostics pass through Kino's sanitizer before entering the shell's rotating log, available through Open Log Folder. Request URLs, queries, headers, and sensitive details are omitted; event locations, levels, and safe failure details remain. The helper creates no separate log files. The engine profile check exercises synthetic credentials, and CTest checks forwarding and the five-file, 10 MB rotation limit.
+
 Run the complete local validation suite with:
 
 ```sh

--- a/apps/macos-shell/CMakeLists.txt
+++ b/apps/macos-shell/CMakeLists.txt
@@ -138,4 +138,15 @@ if(BUILD_TESTING)
   )
   add_test(NAME mpvitem_properties COMMAND kino_mpvitem_test)
   set_tests_properties(mpvitem_properties PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
+  qt_add_executable(
+    kino_logging_test
+    tests/logging_test.cpp
+    src/logging.cpp
+    src/streamengine.cpp
+  )
+  target_include_directories(kino_logging_test PRIVATE src)
+  target_link_libraries(kino_logging_test PRIVATE Qt6::Core Qt6::Qml)
+  add_test(NAME diagnostic_logging COMMAND kino_logging_test)
+  set_tests_properties(diagnostic_logging PROPERTIES TIMEOUT 30)
 endif()

--- a/apps/macos-shell/src/logging.cpp
+++ b/apps/macos-shell/src/logging.cpp
@@ -16,6 +16,21 @@ namespace {
 
 constexpr qint64 MaxLogSize = 10 * 1024 * 1024;
 constexpr int ArchivedLogCount = 4;
+constexpr qsizetype MaxRecordSize = 64 * 1024;
+
+QByteArray boundedRecord(QByteArray record) {
+    if (record.size() > MaxRecordSize) {
+        const QByteArray suffix(" [truncated]\n");
+        qsizetype end = MaxRecordSize - suffix.size();
+        // Move a cut inside a multibyte character back to its first byte.
+        while (end > 0 && (static_cast<unsigned char>(record.at(end)) & 0xc0) == 0x80) {
+            --end;
+        }
+        record.truncate(end);
+        record.append(suffix);
+    }
+    return record;
+}
 
 QString sanitize(QString message) {
     static const QRegularExpression urlPattern(
@@ -61,7 +76,7 @@ public:
     void write(QtMsgType type, const QMessageLogContext &context, const QString &message) {
         QMutexLocker locker(&mutex_);
         if (!file_.isOpen()) {
-            const QByteArray sanitized = sanitize(message).toUtf8();
+            const QByteArray sanitized = boundedRecord(sanitize(message).toUtf8());
             std::fprintf(stderr, "%s\n", sanitized.constData());
             return;
         }
@@ -77,7 +92,7 @@ public:
                                           QThread::currentThreadId()),
                                                       16),
                                       source, QString::number(context.line), sanitize(message));
-        const QByteArray encoded = line.toUtf8();
+        const QByteArray encoded = boundedRecord(line.toUtf8());
         if (file_.size() + encoded.size() > MaxLogSize) {
             rotate();
         }
@@ -126,6 +141,10 @@ void messageHandler(QtMsgType type, const QMessageLogContext &context, const QSt
 
 void installLocalLogger() {
     const QString dataDirectory = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
-    logger = std::make_unique<RotatingLogger>(dataDirectory + QStringLiteral("/logs"));
+    installLocalLogger(dataDirectory + QStringLiteral("/logs"));
+}
+
+void installLocalLogger(const QString &directory) {
+    logger = std::make_unique<RotatingLogger>(directory);
     qInstallMessageHandler(messageHandler);
 }

--- a/apps/macos-shell/src/logging.h
+++ b/apps/macos-shell/src/logging.h
@@ -1,3 +1,6 @@
 #pragma once
 
+#include <QString>
+
 void installLocalLogger();
+void installLocalLogger(const QString &directory);

--- a/apps/macos-shell/src/streamengine.cpp
+++ b/apps/macos-shell/src/streamengine.cpp
@@ -29,11 +29,15 @@ QString cacheDirectory() {
 StreamEngine::StreamEngine(QObject *parent) : QObject(parent) {
     connect(&process_, &QProcess::readyReadStandardOutput, this,
             &StreamEngine::readReadyLine);
+    connect(&process_, &QProcess::readyReadStandardError, this,
+            &StreamEngine::readDiagnostics);
     connect(&process_, &QProcess::errorOccurred, this, [this](QProcess::ProcessError) {
         fail(QStringLiteral("The streaming engine could not be started."));
     });
     connect(&process_, &QProcess::finished, this,
             [this](int exitCode, QProcess::ExitStatus) {
+                readDiagnostics();
+                consumeDiagnostics("\n");
                 if (url_.isEmpty()) {
                     fail(QStringLiteral("The streaming engine stopped during startup."));
                 } else {
@@ -83,7 +87,7 @@ void StreamEngine::start() {
     QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
     environment.insert(QStringLiteral("KINO_ENGINE_CACHE_DIR"), cacheDir);
     process_.setProcessEnvironment(environment);
-    process_.setProcessChannelMode(QProcess::ForwardedErrorChannel);
+    process_.setProcessChannelMode(QProcess::SeparateChannels);
     process_.start(path, {});
     qInfo("[kino:engine] streaming engine starting");
 }
@@ -98,6 +102,51 @@ void StreamEngine::readReadyLine() {
         error_.clear();
         qInfo("[kino:engine] streaming engine ready");
         emit changed();
+    }
+}
+
+void StreamEngine::readDiagnostics() {
+    consumeDiagnostics(process_.readAllStandardError());
+}
+
+void StreamEngine::consumeDiagnostics(const QByteArray &bytes) {
+    // A pipe read can split any record. Bound the pending record, then pass
+    // complete sanitized helper events through the same logger as the shell.
+    for (char byte : bytes) {
+        if (byte != '\n') {
+            if (diagnosticBuffer_.size() < 16 * 1024 && !droppingDiagnostic_) {
+                diagnosticBuffer_.append(byte);
+            } else {
+                diagnosticBuffer_.clear();
+                droppingDiagnostic_ = true;
+            }
+            continue;
+        }
+        const QByteArray line = std::move(diagnosticBuffer_);
+        diagnosticBuffer_.clear();
+        if (droppingDiagnostic_) {
+            qWarning("[kino:engine] oversized helper diagnostic omitted");
+        } else if (!line.isEmpty()) {
+            const QByteArray prefix("KINO_ENGINE_LOG ");
+            if (!line.startsWith(prefix)) {
+                qWarning("[kino:engine] unstructured helper diagnostic omitted");
+            } else {
+                const QByteArray event = line.mid(prefix.size());
+                const qsizetype separator = event.indexOf(' ');
+                const QByteArray level = event.left(separator);
+                const QByteArray detail = event.mid(separator + 1);
+                if (level == "ERROR") {
+                    qCritical("[kino:engine] %s", detail.constData());
+                } else if (level == "WARN") {
+                    qWarning("[kino:engine] %s", detail.constData());
+                } else if (level == "INFO") {
+                    qInfo("[kino:engine] %s", detail.constData());
+                } else {
+                    qWarning("[kino:engine] invalid helper diagnostic omitted");
+                }
+            }
+        }
+        droppingDiagnostic_ = false;
     }
 }
 

--- a/apps/macos-shell/src/streamengine.h
+++ b/apps/macos-shell/src/streamengine.h
@@ -28,8 +28,12 @@ signals:
 private:
     void fail(const QString &reason);
     void readReadyLine();
+    void readDiagnostics();
+    void consumeDiagnostics(const QByteArray &bytes);
 
     QProcess process_;
     QString error_;
     QString url_;
+    QByteArray diagnosticBuffer_;
+    bool droppingDiagnostic_ = false;
 };

--- a/apps/macos-shell/tests/logging_test.cpp
+++ b/apps/macos-shell/tests/logging_test.cpp
@@ -1,0 +1,104 @@
+#include "logging.h"
+#include "streamengine.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+#include <QTimer>
+#include <QUuid>
+
+#include <cstdio>
+#include <stdexcept>
+
+namespace {
+void require(bool condition, const char *message) {
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+QByteArray read(const QString &path) {
+    QFile file(path);
+    require(file.open(QIODevice::ReadOnly), "could not read test log");
+    return file.readAll();
+}
+} // namespace
+
+int main(int argc, char **argv) {
+    QCoreApplication app(argc, argv);
+    QStandardPaths::setTestModeEnabled(true);
+    app.setApplicationName("KinoLoggingTest-" + QUuid::createUuid().toString(QUuid::WithoutBraces));
+    const QString cachePath = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    QTemporaryDir directory;
+    try {
+        require(directory.isValid(), "could not create temporary directory");
+        const QString stderrPath = directory.filePath("stderr.txt");
+        require(std::freopen(qPrintable(stderrPath), "w", stderr) != nullptr,
+                "could not capture stderr");
+        const QString logs = directory.filePath("logs");
+        installLocalLogger(logs);
+
+        // Exercise the actual QProcess pipe forwarding, including split writes,
+        // levels, a trailing partial record, and unstructured sensitive output.
+        QFile helper(directory.filePath("helper.sh"));
+        require(helper.open(QIODevice::WriteOnly), "could not create helper fixture");
+        helper.write("#!/bin/sh\n"
+                     "printf 'KINO_ENGINE_LOG WAR' >&2\n"
+                     "/bin/sleep 0.03\n"
+                     "printf 'N engine:12 message=warning-detail\\n' >&2\n"
+                     "printf 'KINO_ENGINE_LOG ERROR engine:13 message=failure-detail\\n' >&2\n"
+                     "printf 'Authorization: Bearer SENTINEL_RAW\\n' >&2\n"
+                     "printf '");
+        helper.write(QByteArray(20000, 'x'));
+        helper.write("SENTINEL_LONG\\n' >&2\n"
+                     "printf 'KINO_ENGINE_LOG INFO engine:14 message=last-detail' >&2\n");
+        helper.close();
+        require(helper.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner |
+                                      QFileDevice::ExeOwner), "could not make helper executable");
+        qputenv("KINO_ENGINE_BINARY", helper.fileName().toUtf8());
+        {
+            StreamEngine engine;
+            QObject::connect(&engine, &StreamEngine::changed, &app, [&]() {
+                if (!engine.error().isEmpty()) app.quit();
+            });
+            QTimer::singleShot(5000, &app, &QCoreApplication::quit);
+            engine.start();
+            app.exec();
+        }
+        const QByteArray forwarded = read(logs + "/kino.log");
+        require(forwarded.contains("[WARN]") && forwarded.contains("warning-detail"),
+                "split warning did not reach the log");
+        require(forwarded.contains("[ERROR]") && forwarded.contains("failure-detail"),
+                "error did not reach the log");
+        require(forwarded.contains("last-detail"), "last partial diagnostic was lost");
+        require(!forwarded.contains("SENTINEL"), "raw stderr leaked into the log");
+        require(forwarded.contains("oversized helper diagnostic omitted"),
+                "oversized pipe record was not bounded");
+
+        qWarning("source=https://example.invalid/SENTINEL_URL token=SENTINEL_TOKEN");
+        std::fflush(stderr);
+        require(!read(logs + "/kino.log").contains("SENTINEL"), "credential leaked into file");
+        require(!read(stderrPath).contains("SENTINEL"), "credential leaked into stderr");
+
+        // One record larger than the file limit must be bounded before write.
+        qInfo("%s", QByteArray(11 * 1024 * 1024, 'x').constData());
+        require(QFileInfo(logs + "/kino.log").size() <= 10 * 1024 * 1024,
+                "one record exceeded the log file limit");
+        const QByteArray message(64 * 1024, 'z');
+        for (int index = 0; index < 1000; ++index) qInfo("%s", message.constData());
+        const QFileInfoList files = QDir(logs).entryInfoList(QDir::Files);
+        require(files.size() == 5, "rotation must retain exactly five files");
+        for (const QFileInfo &file : files) {
+            require(file.size() <= 10 * 1024 * 1024, "rotated log exceeded 10 MB");
+        }
+        QDir(cachePath).removeRecursively();
+        std::puts("Engine forwarding, redaction, record bounds, and five-file rotation passed.");
+        return 0;
+    } catch (const std::exception &error) {
+        QDir(cachePath).removeRecursively();
+        std::printf("Diagnostic logging check failed: %s\n", error.what());
+        return 1;
+    }
+}

--- a/apps/stream-engine/Cargo.lock
+++ b/apps/stream-engine/Cargo.lock
@@ -4022,8 +4022,11 @@ name = "kino-stream-engine"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "regex",
  "server",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/apps/stream-engine/Cargo.toml
+++ b/apps/stream-engine/Cargo.toml
@@ -9,7 +9,10 @@ publish = false
 # revision in engine.lock, with patches/ applied. See docs/adr/0015.
 [dependencies]
 anyhow = "1"
+regex = "1"
 stream-server = { path = "../../build/vendor/stream-server/server", package = "server" }
 tokio = { version = "1", features = ["io-std", "io-util", "macros", "rt-multi-thread"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
 
 [workspace]

--- a/apps/stream-engine/src/logging.rs
+++ b/apps/stream-engine/src/logging.rs
@@ -1,0 +1,207 @@
+//! Emit bounded, sanitized events to the shell, which owns the rotating files.
+//! Request values and potentially sensitive text never reach an output sink.
+
+use std::fmt;
+use std::io::Write;
+use std::sync::LazyLock;
+
+use regex::Regex;
+use tracing::field::{Field, Visit};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing_subscriber::Layer;
+
+static SENSITIVE_TEXT: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(concat!(
+        r"(?i)(?:[a-z][a-z0-9+.-]*://|magnet:|%[0-9a-f]{2}|",
+        r"authorization|bearer|cookie|password|passwd|token|secret|api.?key|",
+        r"auth.?key|credential|headers?|[?&][^\s=]+=|",
+        r"[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,})"
+    ))
+    .expect("fixed diagnostic pattern")
+});
+
+fn sensitive_field(name: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+    if matches!(
+        name.as_str(),
+        "host" | "range" | "content_type" | "content_length"
+    ) {
+        return true;
+    }
+    [
+        "url",
+        "uri",
+        "path",
+        "query",
+        "param",
+        "header",
+        "cookie",
+        "auth",
+        "password",
+        "passwd",
+        "session",
+        "email",
+        "token",
+        "secret",
+        "key",
+        "credential",
+        "referer",
+        "origin",
+        "user_agent",
+    ]
+    .iter()
+    .any(|part| name.contains(part))
+}
+
+fn safe_text(value: &str) -> String {
+    // Drop the whole detail when it contains sensitive syntax. Partial regex
+    // replacements cannot safely delimit quoted headers or encoded queries.
+    if SENSITIVE_TEXT.is_match(value) {
+        return "<redacted>".to_owned();
+    }
+    value
+        .chars()
+        .take(1024)
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect()
+}
+
+#[derive(Default)]
+struct Fields(String);
+
+impl Fields {
+    fn record(&mut self, field: &Field, value: &str) {
+        let value = if sensitive_field(field.name()) {
+            "<redacted>".to_owned()
+        } else {
+            safe_text(value)
+        };
+        self.0.push_str(&format!(" {}={value}", field.name()));
+    }
+}
+
+impl Visit for Fields {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.record(field, &format!("{value:?}"));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.record(field, value);
+    }
+}
+
+fn format_event(event: &Event<'_>) -> String {
+    let metadata = event.metadata();
+    let mut fields = Fields::default();
+    event.record(&mut fields);
+    let record = format!(
+        "KINO_ENGINE_LOG {} {}:{}{}",
+        metadata.level(),
+        metadata.target(),
+        metadata.line().unwrap_or_default(),
+        fields.0
+    );
+    // Bound by characters after redaction, preserving UTF-8 and line framing.
+    record.chars().take(2048).collect::<String>() + "\n"
+}
+
+struct DiagnosticLayer;
+
+impl<S: Subscriber> Layer<S> for DiagnosticLayer {
+    fn on_event(&self, event: &Event<'_>, _: Context<'_, S>) {
+        let _ = std::io::stderr()
+            .lock()
+            .write_all(format_event(event).as_bytes());
+    }
+}
+
+pub fn install() {
+    let subscriber = tracing_subscriber::registry()
+        .with(LevelFilter::INFO)
+        .with(DiagnosticLayer);
+    tracing::subscriber::set_global_default(subscriber).expect("one Kino diagnostic subscriber");
+    // Panic payloads can include arbitrary request data. Keep the location and
+    // omit the payload, including from the default stderr panic hook.
+    std::panic::set_hook(Box::new(|panic| {
+        if let Some(location) = panic.location() {
+            tracing::error!(
+                file = location.file(),
+                line = location.line(),
+                "engine panic"
+            );
+        } else {
+            tracing::error!("engine panic");
+        }
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    struct Capture(Arc<Mutex<String>>);
+    impl<S: Subscriber> Layer<S> for Capture {
+        fn on_event(&self, event: &Event<'_>, _: Context<'_, S>) {
+            self.0.lock().unwrap().push_str(&format_event(event));
+        }
+    }
+
+    #[test]
+    fn request_secrets_are_removed_before_formatting_output() {
+        let output = Arc::new(Mutex::new(String::new()));
+        let subscriber = tracing_subscriber::registry().with(Capture(output.clone()));
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::error!(
+                uri = "/missing?anything=SENTINEL_QUERY",
+                headers = ?[("X-Custom", "SENTINEL_HEADER"), ("Authorization", "Bearer SENTINEL_AUTH")],
+                referer = "https://test.invalid/SENTINEL_URL",
+                content_type = "application/x-SENTINEL_CONTENT",
+                range = "bytes=0-SENTINEL_RANGE",
+                passwd = "SENTINEL_PASSWORD",
+                token = 123456789_u64,
+                status = 404_u16,
+                "unhandled request"
+            );
+            tracing::warn!(
+                error = "https%3A%2F%2Ftest.invalid%2FSENTINEL_ENCODED",
+                "source failed"
+            );
+            tracing::warn!("request failed headers={{x-custom: SENTINEL_MESSAGE}}");
+        });
+        let text = output.lock().unwrap();
+        assert!(!text.contains("SENTINEL"));
+        assert!(!text.contains("123456789"));
+        assert!(text.contains("unhandled request"));
+        assert!(text.contains("status=404"));
+        assert!(text.contains("source failed"));
+    }
+
+    #[test]
+    fn events_have_one_bounded_line_even_with_large_or_multiline_values() {
+        let output = Arc::new(Mutex::new(String::new()));
+        let subscriber = tracing_subscriber::registry().with(Capture(output.clone()));
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(
+                error = "a\nb\r\nKINO_ENGINE_LOG ERROR forged",
+                "source failed"
+            );
+            tracing::info!(
+                first = "x".repeat(20000),
+                second = "y".repeat(20000),
+                "large detail"
+            );
+        });
+        let text = output.lock().unwrap();
+        assert_eq!(text.lines().count(), 2);
+        assert!(text.lines().all(|line| line.chars().count() <= 2048));
+    }
+}

--- a/apps/stream-engine/src/main.rs
+++ b/apps/stream-engine/src/main.rs
@@ -10,6 +10,8 @@ use std::path::PathBuf;
 
 use tokio::io::AsyncReadExt;
 
+mod logging;
+
 fn port_from_env() -> u16 {
     std::env::var("KINO_ENGINE_PORT")
         .ok()
@@ -22,12 +24,25 @@ fn cache_dir_from_env() -> Option<PathBuf> {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> std::process::ExitCode {
+    logging::install();
+    match run().await {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(error) => {
+            tracing::error!(%error, "streaming engine failed");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run() -> anyhow::Result<()> {
     let mut cfg = stream_server::ServerConfig::embedded();
     cfg.http_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port_from_env()));
     cfg.cache_dir = cache_dir_from_env();
     cfg.config_dir = cfg.cache_dir.clone();
-    cfg.init_logging = true;
+    // Kino owns the subscriber. Upstream writers bypass our redaction and
+    // produce unbounded files outside the folder exposed by Open Log Folder.
+    cfg.init_logging = false;
     cfg.enable_cache_cleaner = true;
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::mpsc::channel(1);

--- a/scripts/check-engine-profile.mjs
+++ b/scripts/check-engine-profile.mjs
@@ -6,7 +6,7 @@ import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { once } from 'node:events';
-import { existsSync, mkdtempSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
 import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -48,7 +48,10 @@ const child = spawn(binary, [], {
 });
 const exited = once(child, 'exit');
 let output = '';
-child.stderr.resume();
+let diagnostics = '';
+child.stderr.on('data', (data) => {
+  diagnostics += data;
+});
 const timeout = setTimeout(() => child.kill('SIGKILL'), 20000);
 try {
   const address = await new Promise((resolveAddress, reject) => {
@@ -63,6 +66,20 @@ try {
   assert.equal((await fetch(`${address}/heartbeat`)).status, 200);
   const youtube = await fetch(`${address}/yt/abcdefghijk.json`);
   await youtube.arrayBuffer();
+  const missing = await fetch(
+    `${address}/probe/missing/route/not/found?token=KINO_PROBE_QUERY_VALUE&stream=https%3A%2F%2Ftest.invalid%2FKINO_PROBE_URL_VALUE`,
+    {
+      headers: {
+        Authorization: 'Bearer KINO_PROBE_AUTH_VALUE',
+        'X-Custom-Credential': 'KINO_PROBE_HEADER_VALUE',
+        Cookie: 'session=KINO_PROBE_COOKIE_VALUE',
+        'Content-Type': 'application/x-KINO_PROBE_CONTENT_VALUE',
+        Range: 'bytes=0-KINO_PROBE_RANGE_VALUE',
+      },
+    },
+  );
+  assert.equal(missing.status, 404);
+  await missing.arrayBuffer();
   await new Promise((resolveWait) => setTimeout(resolveWait, 1500));
   const results = {
     youtubeStatus: youtube.status,
@@ -76,12 +93,30 @@ try {
   assert.deepEqual(unexpectedRequests, [], 'Only upstream tracker-list HTTP requests are allowed.');
   assert.equal(youtube.status, 404, 'YouTube resolution must be unavailable.');
   assert.equal(results.toolsDirectory, false, 'A clean start must not provision executable tools.');
+  assert.ok(
+    diagnostics.includes('unhandled request'),
+    'Engine failures must reach its diagnostic pipe.',
+  );
+  assert.ok(diagnostics.includes('status=404'), 'Diagnostics must preserve the failure status.');
+  assert.ok(
+    !diagnostics.includes('KINO_PROBE_'),
+    'Credentials must be removed before stderr output.',
+  );
   function checkFiles(directory) {
     for (const entry of readdirSync(directory, { withFileTypes: true })) {
       const path = join(directory, entry.name);
       if (entry.isDirectory()) checkFiles(path);
-      else
+      else {
         assert.equal(statSync(path).mode & 0o111, 0, `Engine created an executable: ${entry.name}`);
+        assert.ok(
+          !/\.(log|jsonl)$/.test(entry.name),
+          'The helper must not create separate log files.',
+        );
+        assert.ok(
+          !readFileSync(path).includes(Buffer.from('KINO_PROBE_')),
+          'Credentials must not reach engine files.',
+        );
+      }
     }
   }
   checkFiles(root);


### PR DESCRIPTION
The engine enabled upstream file logging, which stored request URLs, query values, and credentials in three unbounded files outside Kino's diagnostic folder.

Kino now owns the Rust tracing subscriber. It removes request fields and sensitive details before emitting bounded, single-line diagnostics. Error returns and panic reports use that path too. The shell reads complete helper records, preserves their severity, and writes them into the existing rotating Kino log exposed by Open Log Folder. Unstructured and oversized helper records are omitted. Individual shell records are capped before rotation so one large message cannot exceed the 10 MB file limit.

Validation:
- The original isolated probe found synthetic credentials in all three upstream log files. It passes with this change, with no credential output or separate engine log files.
- The real engine profile check verifies URL/query/header redaction, including Authorization, cookies, arbitrary headers, Content-Type, and Range. Safe event text and HTTP status remain available; private torrent creation/removal still passes.
- Two Rust logging tests passed for redaction and bounded single-line output.
- CTest passed native property checks and actual QProcess diagnostic forwarding, including split writes, severity, partial final records, and oversized/unstructured records. The rotation exercise retained five files, each within 10 MB, after more than 60 MB of records.
- Locked engine build, native shell build, bundled-engine startup probe, and `pnpm check` on Node 24 passed.

Closes #33.
