### PR TITLE
Authenticate and restrict the embedded engine API

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ pnpm engine:build
 pnpm engine:check-profile
 pnpm macos:build
 pnpm macos:check-engine
+pnpm macos:check-engine-ui
 ```
 
 Each engine build reconstructs `build/vendor/stream-server` from the pinned revision and current patches, then enforces Cargo's lockfile. Keep upstream changes in `apps/stream-engine/patches`; edits inside the generated vendor directory are discarded. `pnpm engine:check-vendor` checks patch changes and failed retries without requiring the native toolchain.
@@ -63,6 +64,10 @@ Each engine build reconstructs `build/vendor/stream-server` from the pinned revi
 Kino excludes the upstream YouTube resolver and yt-dlp downloader from its engine. `pnpm engine:check-profile` starts the helper with a fresh cache and a blocking HTTP proxy, then checks that startup and an unsupported YouTube request create no executable tools or release-download requests. The engine's tracker-list data refreshes remain allowed.
 
 Engine diagnostics pass through Kino's sanitizer before entering the shell's rotating log, available through Open Log Folder. Request URLs, queries, headers, and sensitive details are omitted; event locations, levels, and safe failure details remain. The helper creates no separate log files. The engine profile check exercises synthetic credentials, and CTest checks forwarding and the five-file, 10 MB rotation limit.
+
+The embedded HTTP API requires a fresh 256-bit token in its base URL, shared with Kino over the helper's private stdout pipe. Every request checks that token, the bound loopback Host, and the configured UI Origin. Only health, torrent creation/removal/media reads, and Kino's seeding/download-limit settings are exposed. The URL works directly with libmpv's byte-range requests and is never included in diagnostics or the startup probe's output. `pnpm macos:check-engine-ui` verifies the production WebChannel and WebEngine path with both local-file and HTTP development UI documents, using disposable engine caches.
+
+The engine profile check streams a private torrent from a local web seed and compares returned range bytes. Set `KINO_ENGINE_MEDIA_FIXTURE` to a legal playback fixture and `KINO_ENGINE_PLAYER_BINARY` to the built Kino executable to include actual libmpv playback in that check.
 
 Run the complete local validation suite with:
 

--- a/apps/desktop/src/player/torrent.test.ts
+++ b/apps/desktop/src/player/torrent.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { resolveFileIndex, torrentCreateRequest, torrentMediaUrl } from './torrent';
 
 const base = { deepLinks: { player: 'stremio:///player/value' } };
-const engine = 'http://127.0.0.1:11470';
+const engine = 'http://127.0.0.1:11470/kino/test-session-capability';
 
 describe('torrent streaming', () => {
   it('builds a create request with trackers and normalized hash', () => {

--- a/apps/macos-shell/src/main.cpp
+++ b/apps/macos-shell/src/main.cpp
@@ -58,7 +58,9 @@ int main(int argc, char *argv[]) {
             std::printf("KINO_ENGINE_PROBE_RESULT %s\n",
                         qPrintable(streamEngine->url().isEmpty()
                                        ? QStringLiteral("error: %1").arg(streamEngine->error())
-                                       : streamEngine->url()));
+                                       : QUrl(streamEngine->url()).toString(
+                                             QUrl::RemovePath | QUrl::RemoveQuery |
+                                             QUrl::RemoveFragment | QUrl::RemoveUserInfo)));
             std::fflush(stdout);
             QCoreApplication::exit(streamEngine->url().isEmpty() ? 1 : 0);
         });

--- a/apps/macos-shell/src/streamengine.cpp
+++ b/apps/macos-shell/src/streamengine.cpp
@@ -4,6 +4,7 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QStandardPaths>
+#include <QUrl>
 
 namespace {
 
@@ -19,9 +20,33 @@ QString helperPath() {
 }
 
 QString cacheDirectory() {
+    const QString overridePath = qEnvironmentVariable("KINO_ENGINE_CACHE_DIR");
+    if (!overridePath.isEmpty()) {
+        return overridePath;
+    }
     const QString base =
         QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
     return QDir(base).absoluteFilePath(QStringLiteral("streaming-engine"));
+}
+
+QString uiOrigin() {
+    const QString overrideUrl = qEnvironmentVariable("KINO_UI_URL");
+    if (overrideUrl.isEmpty()) {
+        return QStringLiteral("file://");
+    }
+    QUrl url = QUrl::fromUserInput(overrideUrl);
+    if (url.isLocalFile()) {
+        return QStringLiteral("file://");
+    }
+    if (url.scheme() == "qrc") {
+        return QStringLiteral("qrc://");
+    }
+    if ((url.scheme() == "http" && url.port() == 80) ||
+        (url.scheme() == "https" && url.port() == 443)) {
+        url.setPort(-1);
+    }
+    return url.toString(QUrl::RemoveUserInfo | QUrl::RemovePath |
+                        QUrl::RemoveQuery | QUrl::RemoveFragment);
 }
 
 } // namespace
@@ -86,6 +111,7 @@ void StreamEngine::start() {
     error_.clear();
     QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
     environment.insert(QStringLiteral("KINO_ENGINE_CACHE_DIR"), cacheDir);
+    environment.insert(QStringLiteral("KINO_ENGINE_UI_ORIGIN"), uiOrigin());
     process_.setProcessEnvironment(environment);
     process_.setProcessChannelMode(QProcess::SeparateChannels);
     process_.start(path, {});

--- a/apps/stream-engine/Cargo.lock
+++ b/apps/stream-engine/Cargo.lock
@@ -4022,9 +4022,15 @@ name = "kino-stream-engine"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum",
+ "getrandom 0.4.3",
  "regex",
+ "serde",
+ "serde_json",
  "server",
+ "subtle",
  "tokio",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
 ]

--- a/apps/stream-engine/Cargo.toml
+++ b/apps/stream-engine/Cargo.toml
@@ -9,10 +9,16 @@ publish = false
 # revision in engine.lock, with patches/ applied. See docs/adr/0015.
 [dependencies]
 anyhow = "1"
+axum = "0.8.8"
+getrandom = "0.4"
 regex = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+subtle = "2.6"
 stream-server = { path = "../../build/vendor/stream-server/server", package = "server" }
 tokio = { version = "1", features = ["io-std", "io-util", "macros", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
+tower-http = { version = "0.7", features = ["cors"] }
 
 [workspace]

--- a/apps/stream-engine/patches/0003-allow-embedded-router-ownership.patch
+++ b/apps/stream-engine/patches/0003-allow-embedded-router-ownership.patch
@@ -1,0 +1,63 @@
+--- a/server/src/lib.rs
++++ b/server/src/lib.rs
+@@ -56,9 +56,32 @@
+ 
+ pub use ffmpeg_setup::MissingFfmpegError;
+ 
++// Embedders choose their own HTTP API without starting the standalone router.
++pub mod embedded_handlers {
++    pub use crate::routes::engine::{create_engine, create_magnet, remove_engine};
++    pub use crate::routes::stream::{stream_video, head_stream_video};
++    pub use crate::routes::system::{heartbeat, update_settings};
++}
++
++#[derive(Clone)]
++pub struct RouterFactory(Arc<dyn Fn(AppState, SocketAddr) -> Router + Send + Sync>);
++
++impl RouterFactory {
++    pub fn new(factory: impl Fn(AppState, SocketAddr) -> Router + Send + Sync + 'static) -> Self {
++        Self(Arc::new(factory))
++    }
++}
++
++impl std::fmt::Debug for RouterFactory {
++    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
++        f.write_str("RouterFactory")
++    }
++}
++
+ #[derive(Clone, Debug)]
+ pub struct ServerConfig {
+     pub http_addr: SocketAddr,
++    pub router_factory: Option<RouterFactory>,
+     pub https_addr: Option<SocketAddr>,
+     pub public_base_url: Option<String>,
+     pub config_dir: Option<PathBuf>,
+@@ -89,6 +112,7 @@
+     pub fn embedded() -> Self {
+         Self {
+             http_addr: SocketAddr::from((Ipv4Addr::LOCALHOST, DEFAULT_HTTP_PORT)),
++            router_factory: None,
+             https_addr: None,
+             public_base_url: None,
+             config_dir: None,
+@@ -113,6 +137,7 @@
+     pub fn binary_default() -> Self {
+         Self {
+             http_addr: SocketAddr::from(([0, 0, 0, 0], DEFAULT_HTTP_PORT)),
++            router_factory: None,
+             https_addr: Some(SocketAddr::from(([0, 0, 0, 0], DEFAULT_HTTPS_PORT))),
+             public_base_url: Some(format!("http://127.0.0.1:{DEFAULT_HTTP_PORT}")),
+             config_dir: None,
+@@ -571,7 +596,10 @@
+         tui::start_tui(Arc::new(state.clone()), rx, shutdown_tx);
+     }
+ 
+-    let app = build_router(state);
++    let app = match &cfg.router_factory {
++        Some(factory) => (factory.0)(state, bound_http_addr),
++        None => build_router(state),
++    };
+ 
+     tracing::info!("listening on {}", bound_http_addr);
+     if cfg.print_startup {

--- a/apps/stream-engine/patches/0004-retain-torrent-web-seeds.patch
+++ b/apps/stream-engine/patches/0004-retain-torrent-web-seeds.patch
@@ -1,0 +1,11 @@
+--- a/bindings/libtorrent-sys/cpp/wrapper.cpp
++++ b/bindings/libtorrent-sys/cpp/wrapper.cpp
+@@ -495,6 +495,8 @@
+     if (ec)
+       throw std::runtime_error("Failed to parse torrent: " + ec.message());
+     p.ti = std::move(loaded.ti);
++    p.url_seeds = std::move(loaded.url_seeds);
++    p.http_seeds = std::move(loaded.http_seeds);
+   }
+ 
+   p.save_path = rust_str_to_std(params.save_path);

--- a/apps/stream-engine/src/api.rs
+++ b/apps/stream-engine/src/api.rs
@@ -1,0 +1,258 @@
+//! Kino's authenticated loopback API. The URL capability also authorizes mpv's
+//! native range requests, which do not go through the web client's fetch calls.
+
+use std::net::SocketAddr;
+
+use axum::{
+    extract::{Request, State},
+    http::{header, HeaderValue, Method, StatusCode},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
+    routing::{delete, get, post},
+    Json, Router,
+};
+use serde::Deserialize;
+use serde_json::json;
+use stream_server::{embedded_handlers as handlers, AppState};
+use subtle::ConstantTimeEq;
+use tower_http::cors::CorsLayer;
+
+#[derive(Clone)]
+pub struct Access {
+    token: String,
+    origin: HeaderValue,
+}
+
+impl Access {
+    pub fn new(origin: &str) -> anyhow::Result<Self> {
+        if !matches!(origin, "null" | "file://" | "qrc://") {
+            let parsed: axum::http::Uri = origin.parse()?;
+            anyhow::ensure!(
+                matches!(parsed.scheme_str(), Some("http" | "https"))
+                    && parsed.authority().is_some()
+                    && parsed.query().is_none()
+                    && origin
+                        == format!(
+                            "{}://{}",
+                            parsed.scheme_str().unwrap(),
+                            parsed.authority().unwrap()
+                        ),
+                "UI origin must be an explicit origin"
+            );
+        }
+        let mut bytes = [0_u8; 32];
+        getrandom::fill(&mut bytes)
+            .map_err(|_| anyhow::anyhow!("session randomness unavailable"))?;
+        Ok(Self {
+            token: bytes.iter().map(|byte| format!("{byte:02x}")).collect(),
+            origin: HeaderValue::from_str(origin)?,
+        })
+    }
+
+    pub fn path_prefix(&self) -> String {
+        format!("/kino/{}", self.token)
+    }
+
+    pub fn router(&self, state: AppState, address: SocketAddr) -> Router {
+        let routes = Router::new()
+            .route("/heartbeat", get(handlers::heartbeat))
+            .route("/settings", get(settings).post(change_settings))
+            .route("/create", post(handlers::create_engine))
+            .route("/{infoHash}/create", post(handlers::create_magnet))
+            .route("/{infoHash}", delete(handlers::remove_engine))
+            .route(
+                "/{infoHash}/{fileIdx}",
+                get(handlers::stream_video).head(handlers::head_stream_video),
+            )
+            .with_state(state);
+        let access = self.clone();
+        let host = address.to_string();
+        Router::new()
+            .nest(&self.path_prefix(), routes)
+            .layer(
+                CorsLayer::new()
+                    .allow_origin(self.origin.clone())
+                    .allow_methods([Method::GET, Method::HEAD, Method::POST, Method::DELETE])
+                    .allow_headers([header::CONTENT_TYPE, header::RANGE])
+                    .expose_headers([
+                        header::CONTENT_LENGTH,
+                        header::CONTENT_RANGE,
+                        header::ACCEPT_RANGES,
+                    ]),
+            )
+            .layer(middleware::from_fn(move |request, next| {
+                let access = access.clone();
+                let host = host.clone();
+                async move { access.authorize(request, next, &host).await }
+            }))
+    }
+
+    async fn authorize(&self, request: Request, next: Next, host: &str) -> Response {
+        let headers = request.headers();
+        if headers.get_all(header::HOST).iter().count() != 1
+            || headers
+                .get(header::HOST)
+                .and_then(|value| value.to_str().ok())
+                != Some(host)
+            || headers.get_all(header::ORIGIN).iter().count() > 1
+            || headers
+                .get(header::ORIGIN)
+                .is_some_and(|value| value != self.origin)
+        {
+            return StatusCode::FORBIDDEN.into_response();
+        }
+        let Some((token, path)) = request
+            .uri()
+            .path()
+            .strip_prefix("/kino/")
+            .and_then(|value| value.split_once('/'))
+        else {
+            return StatusCode::UNAUTHORIZED.into_response();
+        };
+        if !same_token(token.as_bytes(), self.token.as_bytes()) {
+            return StatusCode::UNAUTHORIZED.into_response();
+        }
+        // Generic torrent routes must not turn unsupported namespaces such as
+        // /yt or /proxy into torrent operations. Reject them before dispatch.
+        if !supported_path(path) {
+            tracing::warn!(status = 404_u16, "unhandled request");
+            return StatusCode::NOT_FOUND.into_response();
+        }
+        let mut response = next.run(request).await;
+        response
+            .headers_mut()
+            .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+        response.headers_mut().insert(
+            header::REFERRER_POLICY,
+            HeaderValue::from_static("no-referrer"),
+        );
+        response
+    }
+}
+
+fn same_token(supplied: &[u8], expected: &[u8]) -> bool {
+    if supplied.len() != expected.len() {
+        return false;
+    }
+    bool::from(supplied.ct_eq(expected))
+}
+
+fn supported_path(path: &str) -> bool {
+    if matches!(path, "heartbeat" | "settings" | "create") {
+        return true;
+    }
+    let (hash, operation) = path
+        .split_once('/')
+        .map_or((path, None), |(hash, operation)| (hash, Some(operation)));
+    if hash.len() != 40 || !hash.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return false;
+    }
+    operation.is_none_or(|value| {
+        value == "create"
+            || (!value.is_empty()
+                && value.bytes().all(|byte| byte.is_ascii_digit())
+                && value.parse::<usize>().is_ok())
+    })
+}
+
+async fn settings(State(state): State<AppState>) -> impl IntoResponse {
+    let settings = state.settings.read().await;
+    Json(json!({ "values": {
+        "seedingEnabled": settings.seeding_enabled,
+        "btDownloadSpeedHardLimit": settings.bt_download_speed_hard_limit,
+        "cacheSize": settings.cache_size,
+    } }))
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SettingsChange {
+    seeding_enabled: Option<bool>,
+    bt_download_speed_hard_limit: Option<f64>,
+}
+
+async fn change_settings(
+    State(state): State<AppState>,
+    Json(change): Json<SettingsChange>,
+) -> Response {
+    let mut values = serde_json::Map::new();
+    if let Some(enabled) = change.seeding_enabled {
+        values.insert("seedingEnabled".to_owned(), json!(enabled));
+    }
+    if let Some(limit) = change.bt_download_speed_hard_limit {
+        if !limit.is_finite() || limit.fract() != 0.0 || !(0.0..=i32::MAX as f64).contains(&limit) {
+            return StatusCode::BAD_REQUEST.into_response();
+        }
+        values.insert("btDownloadSpeedHardLimit".to_owned(), json!(limit));
+    }
+    match handlers::update_settings(&state, &values.into()).await {
+        Ok(()) => Json(json!({ "success": true })).into_response(),
+        Err(error) => {
+            tracing::error!(%error, "engine settings could not be saved");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_torrent_and_supported_control_paths_are_allowed() {
+        let hash = "abcde01234abcde01234abcde01234abcde01234";
+        for path in [
+            "heartbeat",
+            "settings",
+            "create",
+            hash,
+            &format!("{hash}/create"),
+            &format!("{hash}/0"),
+        ] {
+            assert!(supported_path(path));
+        }
+        for path in [
+            "removeAll",
+            "proxy/https://test.invalid",
+            "yt/123",
+            "settings/0",
+            "diagnostics/logs",
+            &format!("{hash}/remove"),
+            &format!("{hash}/-1"),
+            &format!("{hash}/0/extra"),
+        ] {
+            assert!(!supported_path(path));
+        }
+    }
+
+    #[test]
+    fn each_session_has_a_fresh_token_and_matches_all_its_bytes() {
+        let first = Access::new("null").unwrap();
+        let second = Access::new("null").unwrap();
+        assert!(first.token.len() == 64 && first.token != second.token);
+        assert!(same_token(first.token.as_bytes(), first.token.as_bytes()));
+        assert!(!same_token(first.token.as_bytes(), second.token.as_bytes()));
+        assert!(!same_token(b"", first.token.as_bytes()));
+    }
+
+    #[test]
+    fn browser_origin_must_be_explicit() {
+        for origin in [
+            "null",
+            "file://",
+            "qrc://",
+            "http://localhost:5173",
+            "https://kino.example",
+        ] {
+            assert!(Access::new(origin).is_ok());
+        }
+        for origin in [
+            "*",
+            "",
+            "https://kino.example/path",
+            "https://kino.example?query=1",
+        ] {
+            assert!(Access::new(origin).is_err());
+        }
+    }
+}

--- a/apps/stream-engine/src/main.rs
+++ b/apps/stream-engine/src/main.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 
 use tokio::io::AsyncReadExt;
 
+mod api;
 mod logging;
 
 fn port_from_env() -> u16 {
@@ -36,7 +37,14 @@ async fn main() -> std::process::ExitCode {
 }
 
 async fn run() -> anyhow::Result<()> {
+    let access = api::Access::new(
+        &std::env::var("KINO_ENGINE_UI_ORIGIN").unwrap_or_else(|_| "null".to_owned()),
+    )?;
+    let prefix = access.path_prefix();
     let mut cfg = stream_server::ServerConfig::embedded();
+    cfg.router_factory = Some(stream_server::RouterFactory::new(move |state, address| {
+        access.router(state, address)
+    }));
     cfg.http_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port_from_env()));
     cfg.cache_dir = cache_dir_from_env();
     cfg.config_dir = cfg.cache_dir.clone();
@@ -50,8 +58,9 @@ async fn run() -> anyhow::Result<()> {
     let server = tokio::spawn(stream_server::run(cfg, shutdown_rx, Some(ready_tx)));
 
     let address = ready_rx.await?;
-    // The shell parses this line to learn the ephemeral port.
-    println!("KINO_ENGINE_READY http://{address}");
+    // This private pipe carries the capability to the shell. Never log this
+    // URL or persist it; it changes every time the helper starts.
+    println!("KINO_ENGINE_READY http://{address}{prefix}");
 
     // Closing stdin is the supervisor's graceful stop signal.
     tokio::spawn(async move {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "engine:check-profile": "node scripts/check-engine-profile.mjs",
     "macos:build": "./scripts/build-macos.sh",
     "macos:check-engine": "./scripts/check-macos-engine.sh",
+    "macos:check-engine-ui": "node scripts/check-macos-engine-ui.mjs",
     "macos:check-launch": "./scripts/check-macos-launch.sh",
     "macos:check-playback": "node scripts/check-macos-playback.mjs",
     "macos:package": "node scripts/package-macos.mjs",

--- a/scripts/check-engine-profile.mjs
+++ b/scripts/check-engine-profile.mjs
@@ -6,6 +6,7 @@ import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { once } from 'node:events';
+import { createServer as createHttpServer, request as httpRequest } from 'node:http';
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
 import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
@@ -17,6 +18,31 @@ const binary = resolve(
 assert.ok(existsSync(binary), 'Build the native helper with pnpm engine:build first.');
 const root = mkdtempSync(join(tmpdir(), 'kino-profile-check-'));
 const requests = [];
+let seedServer;
+
+function withHost(url, host) {
+  return new Promise((resolveStatus, reject) => {
+    const request = httpRequest(url, { headers: { Host: host } }, (response) => {
+      response.resume();
+      resolveStatus(response.statusCode);
+    });
+    request.on('error', reject);
+    request.end();
+  });
+}
+
+function bencode(value) {
+  if (typeof value === 'number') return Buffer.from(`i${value}e`);
+  if (typeof value === 'string') value = Buffer.from(value);
+  if (Buffer.isBuffer(value)) return Buffer.concat([Buffer.from(`${value.length}:`), value]);
+  return Buffer.concat([
+    Buffer.from('d'),
+    ...Object.keys(value)
+      .sort()
+      .flatMap((key) => [bencode(key), bencode(value[key])]),
+    Buffer.from('e'),
+  ]);
+}
 const proxy = createServer((socket) => {
   socket.once('data', (data) => {
     requests.push(data.toString().split('\r\n')[0]);
@@ -52,17 +78,91 @@ let diagnostics = '';
 child.stderr.on('data', (data) => {
   diagnostics += data;
 });
-const timeout = setTimeout(() => child.kill('SIGKILL'), 20000);
+const timeout = setTimeout(
+  () => child.kill('SIGKILL'),
+  process.env.KINO_ENGINE_PLAYER_BINARY ? 60000 : 20000,
+);
 try {
   const address = await new Promise((resolveAddress, reject) => {
     child.on('error', reject);
     child.on('exit', () => reject(new Error('Engine exited before readiness.')));
     child.stdout.on('data', (data) => {
       output += data;
-      const match = output.match(/^KINO_ENGINE_READY (http:\/\/127\.0\.0\.1:\d+)$/m);
+      const match = output.match(
+        /^KINO_ENGINE_READY (http:\/\/127\.0\.0\.1:\d+\/kino\/[a-f0-9]{64})$/m,
+      );
       if (match) resolveAddress(match[1]);
     });
   });
+  const origin = new URL(address).origin;
+  const token = new URL(address).pathname.split('/').at(-1);
+  const uiOrigin = env.KINO_ENGINE_UI_ORIGIN ?? 'null';
+  assert.equal((await fetch(`${origin}/settings`)).status, 401);
+  assert.equal((await fetch(`${origin}/kino/${'0'.repeat(64)}/settings`)).status, 401);
+  assert.equal(
+    (await fetch(`${address}/settings`, { headers: { Origin: 'https://untrusted.example' } }))
+      .status,
+    403,
+  );
+  assert.equal(await withHost(`${address}/settings`, 'untrusted.example'), 403);
+  const allowed = await fetch(`${address}/settings`, { headers: { Origin: uiOrigin } });
+  assert.equal(allowed.status, 200);
+  assert.equal(allowed.headers.get('Access-Control-Allow-Origin'), uiOrigin);
+  const initialSettings = await allowed.json();
+  const forbiddenWrite = await fetch(`${address}/settings`, {
+    method: 'POST',
+    headers: { Origin: 'https://untrusted.example', 'Content-Type': 'application/json' },
+    body: JSON.stringify({ seedingEnabled: !initialSettings.values.seedingEnabled }),
+  });
+  assert.equal(forbiddenWrite.status, 403);
+  assert.equal(
+    (await (await fetch(`${address}/settings`)).json()).values.seedingEnabled,
+    initialSettings.values.seedingEnabled,
+    'A foreign-origin write must not change settings.',
+  );
+  const preflight = await fetch(`${address}/settings`, {
+    method: 'OPTIONS',
+    headers: {
+      Origin: uiOrigin,
+      'Access-Control-Request-Method': 'POST',
+      'Access-Control-Request-Headers': 'content-type',
+    },
+  });
+  assert.equal(preflight.status, 200);
+  assert.equal(preflight.headers.get('Access-Control-Allow-Origin'), uiOrigin);
+  assert.ok(preflight.headers.get('Access-Control-Allow-Methods')?.includes('POST'));
+  const forbiddenPreflight = await fetch(`${address}/settings`, {
+    method: 'OPTIONS',
+    headers: { Origin: 'https://untrusted.example', 'Access-Control-Request-Method': 'POST' },
+  });
+  assert.equal(forbiddenPreflight.status, 403);
+  assert.equal(forbiddenPreflight.headers.get('Access-Control-Allow-Origin'), null);
+  for (const path of [
+    'removeAll',
+    'list',
+    'proxy/test',
+    'ftp/test',
+    'update/check',
+    'diagnostics/logs',
+    'rar/test',
+    'zip/test',
+    'nzb/test',
+    'anything/downloader',
+    'hlsv2/probe',
+  ]) {
+    assert.equal(
+      (await fetch(`${address}/${path}`)).status,
+      404,
+      `Unused route ${path} must be disabled.`,
+    );
+  }
+  const rejectedSettings = await fetch(`${address}/settings`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ autoUpdateEnabled: true }),
+  });
+  assert.equal(rejectedSettings.status, 422, 'Unsupported engine settings must be rejected.');
+  console.log('Authentication, exact Host/Origin, CORS, and disabled routes passed.');
   assert.equal((await fetch(`${address}/heartbeat`)).status, 200);
   const youtube = await fetch(`${address}/yt/abcdefghijk.json`);
   await youtube.arrayBuffer();
@@ -102,6 +202,7 @@ try {
     !diagnostics.includes('KINO_PROBE_'),
     'Credentials must be removed before stderr output.',
   );
+  assert.ok(!diagnostics.includes(token), 'The session capability must not appear in diagnostics.');
   function checkFiles(directory) {
     for (const entry of readdirSync(directory, { withFileTypes: true })) {
       const path = join(directory, entry.name);
@@ -121,15 +222,46 @@ try {
   }
   checkFiles(root);
 
-  // Metadata-only private torrent with no trackers or public swarm traffic.
-  const piece = Buffer.from('Kino probe');
-  const info = Buffer.concat([
-    Buffer.from('d6:lengthi10e4:name11:fixture.bin12:piece lengthi16384e6:pieces20:'),
-    createHash('sha1').update(piece).digest(),
-    Buffer.from('7:privatei1ee'),
-  ]);
+  // A private torrent with a local web seed exercises byte ranges without
+  // relying on a public swarm or fetching third-party media.
+  const media = process.env.KINO_ENGINE_MEDIA_FIXTURE
+    ? readFileSync(process.env.KINO_ENGINE_MEDIA_FIXTURE)
+    : Buffer.from(Array.from({ length: 32768 }, (_, index) => index % 251));
+  seedServer = createHttpServer((request, response) => {
+    const range = request.headers.range?.match(/^bytes=(\d+)-(\d*)$/);
+    const start = range ? Number(range[1]) : 0;
+    const end = range?.[2] ? Math.min(Number(range[2]), media.length - 1) : media.length - 1;
+    response.writeHead(range ? 206 : 200, {
+      'Content-Length': end - start + 1,
+      'Content-Type': 'application/octet-stream',
+      'Accept-Ranges': 'bytes',
+      ...(range ? { 'Content-Range': `bytes ${start}-${end}/${media.length}` } : {}),
+    });
+    response.end(request.method === 'HEAD' ? undefined : media.subarray(start, end + 1));
+  });
+  seedServer.listen(0, '127.0.0.1');
+  await once(seedServer, 'listening');
+  const pieces = [];
+  for (let offset = 0; offset < media.length; offset += 16384) {
+    pieces.push(
+      createHash('sha1')
+        .update(media.subarray(offset, offset + 16384))
+        .digest(),
+    );
+  }
+  const infoValue = {
+    length: media.length,
+    name: 'fixture.bin',
+    'piece length': 16384,
+    pieces: Buffer.concat(pieces),
+    private: 1,
+  };
+  const info = bencode(infoValue);
   const infoHash = createHash('sha1').update(info).digest('hex');
-  const torrent = Buffer.concat([Buffer.from('d4:info'), info, Buffer.from('e')]);
+  const torrent = bencode({
+    info: infoValue,
+    'url-list': `http://127.0.0.1:${seedServer.address().port}/fixture.bin`,
+  });
   const created = await fetch(`${address}/create`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -138,12 +270,64 @@ try {
   assert.equal(created.status, 200);
   const stats = await created.json();
   assert.equal(stats.infoHash, infoHash, 'Torrent creation must still return the supplied media.');
-  assert.equal((await fetch(`${address}/${infoHash}/remove`)).status, 200);
-  console.log('Private torrent creation and removal passed.');
+  const mediaUrl = `${address}/${infoHash}/0`;
+  assert.equal((await fetch(`${origin}/${infoHash}/0`)).status, 401);
+  const range = await fetch(mediaUrl, {
+    headers: { Range: 'bytes=1024-2047' },
+    signal: AbortSignal.timeout(15000),
+  });
+  assert.equal(range.status, 206, 'Native-style authenticated range read must succeed.');
+  assert.equal(range.headers.get('Content-Range'), `bytes 1024-2047/${media.length}`);
+  assert.ok(
+    Buffer.from(await range.arrayBuffer()).equals(media.subarray(1024, 2048)),
+    'Range bytes must match the source.',
+  );
+  const head = await fetch(mediaUrl, { method: 'HEAD' });
+  assert.equal(head.status, 200);
+  assert.equal(Number(head.headers.get('Content-Length')), media.length);
+  assert.equal(
+    (await fetch(`${address}/${infoHash}/create`)).status,
+    405,
+    'Torrent creation must require POST.',
+  );
+  assert.equal(
+    (await fetch(`${address}/${infoHash}/remove`)).status,
+    404,
+    'Legacy state-changing GET must be disabled.',
+  );
+  if (process.env.KINO_ENGINE_PLAYER_BINARY) {
+    assert.ok(
+      process.env.KINO_ENGINE_MEDIA_FIXTURE,
+      'Native playback requires a legal media fixture.',
+    );
+    const player = spawn(resolve(process.env.KINO_ENGINE_PLAYER_BINARY), [], {
+      env: { ...process.env, KINO_ENGINE_PROBE: '', KINO_PLAYBACK_PROBE: mediaUrl },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let verdictOutput = '';
+    player.stdout.on('data', (data) => {
+      verdictOutput += data;
+    });
+    player.stderr.resume();
+    const playerTimeout = setTimeout(() => player.kill('SIGKILL'), 20000);
+    try {
+      await once(player, 'close');
+      const line = verdictOutput.split('\n').find((line) => line.startsWith('KINO_PROBE_RESULT '));
+      assert.ok(line, 'Native player must produce a playback verdict.');
+      assert.equal(JSON.parse(line.slice('KINO_PROBE_RESULT '.length)).outcome, 'played');
+      console.log('Native libmpv playback over the authenticated torrent URL passed.');
+    } finally {
+      clearTimeout(playerTimeout);
+    }
+  }
+  assert.equal((await fetch(`${address}/${infoHash}`, { method: 'DELETE' })).status, 200);
+  console.log('Private torrent creation, authenticated byte ranges, and removal passed.');
 } finally {
   child.stdin.end();
   await exited;
   clearTimeout(timeout);
   proxy.close();
+  seedServer?.closeAllConnections();
+  seedServer?.close();
   rmSync(root, { recursive: true, force: true });
 }

--- a/scripts/check-macos-engine-ui.mjs
+++ b/scripts/check-macos-engine-ui.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+// Exercise production QML, WebChannel, and WebEngine CORS with an isolated
+// engine cache. The document reports only status values, never its capability.
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const binary = resolve(process.env.KINO_APP_BINARY ?? 'build/macos/Kino.app/Contents/MacOS/Kino');
+assert.ok(existsSync(binary), 'Build the native app first.');
+const root = mkdtempSync(join(tmpdir(), 'kino-engine-ui-'));
+let document = '';
+let report;
+const server = createServer((request, response) => {
+  if (request.url === '/ui') {
+    response.writeHead(200, { 'Content-Type': 'text/html' });
+    response.end(document);
+  } else if (request.url === '/result') {
+    let body = '';
+    request.on('data', (chunk) => {
+      body += chunk;
+    });
+    request.on('end', () => {
+      response.end();
+      try {
+        report?.(JSON.parse(body));
+      } catch {
+        report?.({ ok: false, error: 'invalid report' });
+      }
+    });
+  } else {
+    response.writeHead(404).end();
+  }
+});
+server.listen(0, '127.0.0.1');
+await once(server, 'listening');
+const serverOrigin = `http://127.0.0.1:${server.address().port}`;
+try {
+  for (const mode of ['file', 'http']) {
+    document = `<!doctype html><meta charset="utf-8"><title>Kino engine check</title>
+<style>body{background:#09090a;color:#f4f4f5;font:16px sans-serif;padding:40px}</style>
+<p>Checking the engine connection.</p><script src="qrc:///qtwebchannel/qwebchannel.js"></script><script>
+function finish(value) {
+  fetch(${JSON.stringify(serverOrigin + '/result')}, { method: 'POST', mode: 'no-cors', body: JSON.stringify(value) });
+}
+new QWebChannel(qt.webChannelTransport, function(channel) {
+  const native = channel.objects.kinoNative;
+  let handled = false;
+  native.streamingEngineChanged.connect(async function(url, error) {
+    if (handled) return;
+    if (error) { handled = true; finish({ok:false,error:'engine startup'}); return; }
+    if (!url) return;
+    handled = true;
+    try {
+      const read = await fetch(url + '/settings');
+      const write = await fetch(url + '/settings', {method:'POST',headers:{'Content-Type':'application/json'},body:'{}'});
+      const result = await write.json();
+      finish({ok:read.status === 200 && write.status === 200 && result.success === true, read:read.status, write:write.status});
+    } catch { finish({ok:false,error:'browser request'}); }
+  });
+  native.startStreamingEngine();
+});
+</script>`;
+    const path = join(root, `${mode}.html`);
+    writeFileSync(path, document);
+    let timeout;
+    const verdict = new Promise((resolveReport, reject) => {
+      report = resolveReport;
+      timeout = setTimeout(() => reject(new Error(`${mode} WebEngine probe timed out.`)), 25000);
+    });
+    const child = spawn(binary, [], {
+      env: {
+        ...process.env,
+        KINO_UI_URL: mode === 'file' ? path : `${serverOrigin}/ui`,
+        KINO_ENGINE_CACHE_DIR: join(root, `${mode}-cache`),
+      },
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    // Consume diagnostics so the child cannot block. Do not print arbitrary
+    // browser failures, which could contain the URL capability.
+    child.stderr.resume();
+    const exited = once(child, 'exit');
+    try {
+      const result = await verdict;
+      assert.ok(result.ok, `${mode} WebEngine API result: ${JSON.stringify(result)}`);
+      console.log(`${mode} UI: WebChannel capability, CORS read, and preflighted write passed.`);
+    } finally {
+      clearTimeout(timeout);
+      child.kill('SIGTERM');
+      const killTimeout = setTimeout(() => child.kill('SIGKILL'), 3000);
+      await exited;
+      clearTimeout(killTimeout);
+    }
+  }
+} finally {
+  server.closeAllConnections();
+  server.close();
+  rmSync(root, { recursive: true, force: true });
+}

--- a/scripts/check-macos-engine.sh
+++ b/scripts/check-macos-engine.sh
@@ -18,11 +18,11 @@ kino_probe_output="$(KINO_ENGINE_PROBE=1 "${kino_app_binary}" 2>/dev/null |
 kino_engine_url="${kino_probe_output#KINO_ENGINE_PROBE_RESULT }"
 
 if [[ -z "${kino_engine_url}" || "${kino_engine_url}" == error:* ]]; then
-  echo "The shell could not start the streaming engine: ${kino_engine_url:-no result}" >&2
+  echo "The shell could not start the streaming engine. Check Kino's diagnostic log." >&2
   exit 1
 fi
-if [[ "${kino_engine_url}" != http://127.0.0.1:* ]]; then
-  echo "The streaming engine is not bound to loopback: ${kino_engine_url}" >&2
+if [[ ! "${kino_engine_url}" =~ ^http://127\.0\.0\.1:[0-9]+$ ]]; then
+  echo "The engine probe did not return a sanitized loopback address." >&2
   exit 1
 fi
 


### PR DESCRIPTION
The embedded engine exposed the full upstream HTTP router without authentication and accepted every web origin. An unauthenticated request from a foreign origin could read settings or invoke control routes.

Kino now owns a minimal router for health, torrent creation/removal/media reads, and its seeding/download-limit settings. Each helper start creates a random 256-bit capability in the base URL, shared over the private supervisor pipe. Every request validates the token with constant-time comparison, the exact bound loopback Host, and the configured UI Origin. The URL also authenticates libmpv range requests. Legacy state-changing GETs and unsupported proxy, downloader, update, archive, FTP, YouTube, and diagnostics routes are unavailable.

The shell supplies the actual Qt origin (`file://` for packaged UI, or the explicit development origin), and startup probes expose only the loopback origin. Responses disable caching and referrers. An upstream router-factory patch keeps Kino's API implementation in Kino's own Rust module. The range fixture also exposed discarded web-seed fields in upstream torrent loading; a narrow patch preserves them so valid torrent metadata reaches libtorrent.

Validation:
- Before the fix, the read-only foreign-origin probe received 200 with wildcard CORS and no authentication.
- The real engine probe now verifies missing/wrong tokens, wrong Host, foreign reads/writes/preflights, unchanged settings after rejected writes, unsupported routes/settings, and removal of state-changing GETs.
- A private torrent served from a local web seed returned byte-identical authenticated ranges and correct HEAD metadata. Kino's actual libmpv playback probe played a legal H.264 fixture over that URL.
- The production QML/WebChannel/WebEngine integration passed CORS reads and preflighted writes with both local-file and HTTP development UI documents, using disposable caches.
- Locked engine build, five Rust tests, native build, both CTest checks, bundled startup probe, and `pnpm check` (43 web tests, Node 24) passed. Dependency lock changes only add existing transitive packages to the helper's direct dependencies.

Closes #34.
