### PR TITLE
Prevent stale episode sources from starting mismatched playback

### DIFF
--- a/apps/desktop/src/core/types.ts
+++ b/apps/desktop/src/core/types.ts
@@ -162,7 +162,11 @@ interface CoreResource<Ready> {
 export interface MetaDetailsState {
   libraryItem: unknown | null;
   metaItem: CoreResource<CoreMetaItem> | null;
-  selected: unknown | null;
+  selected: {
+    metaPath: CatalogRequest['path'];
+    streamPath: CatalogRequest['path'] | null;
+    guessStream: boolean;
+  } | null;
   streams: Array<CoreResource<CoreStream[]>>;
   title?: string | null;
 }

--- a/apps/desktop/src/screens/MetaDetailsScreen.test.tsx
+++ b/apps/desktop/src/screens/MetaDetailsScreen.test.tsx
@@ -1,0 +1,180 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CoreContext } from '../core/context';
+import type { CoreTransport } from '../core/transport';
+import type { CoreMetaItem, CoreRuntimeEvent, MetaDetailsState } from '../core/types';
+import { MetaDetailsScreen } from './MetaDetailsScreen';
+
+const meta: CoreMetaItem = {
+  id: 'show',
+  name: 'Test series',
+  type: 'series',
+  inLibrary: false,
+  watched: false,
+  videos: [
+    { id: 'ep1', title: 'Episode one', season: 1, episode: 1 },
+    { id: 'ep2', title: 'Episode two', season: 1, episode: 2 },
+    { id: 'ep3', title: 'Episode three', season: 1, episode: 3 },
+  ],
+};
+const addon = {
+  manifest: { id: 'test', name: 'Test add-on' },
+  transportUrl: 'https://addon.invalid/manifest.json',
+};
+
+// Shape verified against the pinned Core 0.61.0 WASM serializer. The stream
+// resources omit their paths; selected identifies the request for this snapshot.
+function details(videoId: string, item = meta): MetaDetailsState {
+  return {
+    libraryItem: null,
+    selected: {
+      metaPath: { resource: 'meta', type: item.type, id: item.id, extra: [] },
+      streamPath: { resource: 'stream', type: item.type, id: videoId, extra: [] },
+      guessStream: true,
+    },
+    metaItem: { addon, content: { type: 'Ready', content: item } },
+    streams: [
+      {
+        addon,
+        content: {
+          type: 'Ready',
+          content: [
+            {
+              name: `${videoId} source`,
+              url: `https://media.invalid/${videoId}.mp4`,
+              deepLinks: { player: '' },
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+function mountDetails(
+  initial = details('ep1'),
+  item = meta,
+  initialVideoId: string | null = 'ep1',
+) {
+  let state = initial;
+  const listeners = new Set<(event: CoreRuntimeEvent) => void>();
+  const dispatch = vi.fn<CoreTransport['dispatch']>().mockResolvedValue(undefined);
+  const transport: CoreTransport = {
+    destroy: vi.fn(),
+    dispatch,
+    init: vi.fn().mockResolvedValue(undefined),
+    getState: async <State,>() => state as State,
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+  const onPlay = vi.fn();
+  render(
+    <CoreContext.Provider
+      value={{ error: null, status: 'ready', session: 'guest', transport, selectSession: vi.fn() }}
+    >
+      <MetaDetailsScreen
+        item={item}
+        initialVideoId={initialVideoId}
+        failedSources={new Map()}
+        onBack={vi.fn()}
+        onPlay={onPlay}
+      />
+    </CoreContext.Provider>,
+  );
+  return {
+    dispatch,
+    onPlay,
+    async publish(next: MetaDetailsState) {
+      await act(async () => {
+        state = next;
+        listeners.forEach((listener) => listener({ name: 'NewState', args: ['meta_details'] }));
+      });
+    },
+  };
+}
+
+describe('episode source identity', () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  it('prevents playing a retained source while the new Load is pending or still returns old state', async () => {
+    const { dispatch, onPlay, publish } = mountDetails();
+    const firstSource = await screen.findByRole('button', { name: /ep1 source/ });
+    expect(firstSource).toBeEnabled();
+    let finishLoad!: () => void;
+    const pending = new Promise<void>((resolve) => {
+      finishLoad = resolve;
+    });
+    dispatch.mockImplementation((action) =>
+      action.action === 'Load' ? pending : Promise.resolve(),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Episode two/ }));
+    fireEvent.click(firstSource);
+    expect(onPlay).not.toHaveBeenCalled();
+    expect(firstSource).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Episode three/ })).toBeInTheDocument();
+
+    await act(async () => {
+      finishLoad();
+    });
+    fireEvent.click(firstSource);
+    expect(onPlay).not.toHaveBeenCalled();
+    expect(firstSource).toBeDisabled();
+
+    await publish(details('ep2'));
+    fireEvent.click(screen.getByRole('button', { name: /ep2 source/ }));
+    expect(onPlay).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        video: meta.videos[1],
+        stream: expect.objectContaining({ url: 'https://media.invalid/ep2.mp4' }),
+      }),
+    );
+  });
+
+  it('rejects out-of-order snapshots after rapid episode changes', async () => {
+    const { onPlay, publish } = mountDetails();
+    await screen.findByRole('button', { name: /ep1 source/ });
+    fireEvent.click(screen.getByRole('button', { name: /Episode two/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Episode three/ }));
+
+    await publish(details('ep2'));
+    fireEvent.click(screen.getByRole('button', { name: /ep2 source/ }));
+    expect(onPlay).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /ep2 source/ })).toBeDisabled();
+
+    await publish(details('ep3'));
+    expect(screen.getByRole('button', { name: /ep3 source/ })).toBeEnabled();
+    await publish(details('ep1'));
+    fireEvent.click(screen.getByRole('button', { name: /ep1 source/ }));
+    expect(onPlay).not.toHaveBeenCalled();
+
+    await publish(details('ep3'));
+    fireEvent.click(screen.getByRole('button', { name: /ep3 source/ }));
+    expect(onPlay).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        video: meta.videos[2],
+        stream: expect.objectContaining({ url: 'https://media.invalid/ep3.mp4' }),
+      }),
+    );
+  });
+
+  it('keeps guessed movie streams playable and rejects snapshots for a different title', async () => {
+    const movie = { ...meta, id: 'movie', type: 'movie', videos: [] };
+    const { onPlay, publish } = mountDetails(details('movie', movie), movie, null);
+    const source = await screen.findByRole('button', { name: /movie source/ });
+    await waitFor(() => expect(source).toBeEnabled());
+    fireEvent.click(source);
+    expect(onPlay).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ meta: movie, video: null }),
+    );
+    onPlay.mockClear();
+    await publish(details('movie', { ...movie, id: 'another-title' }));
+    fireEvent.click(screen.getByRole('button', { name: /movie source/ }));
+    expect(onPlay).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/screens/MetaDetailsScreen.tsx
+++ b/apps/desktop/src/screens/MetaDetailsScreen.tsx
@@ -61,7 +61,12 @@ export function MetaDetailsScreen({
     `${item.type}:${item.id}:${videoId ?? 'guess'}`,
   );
   const resource = result.state?.metaItem;
-  const loadedMeta = resource?.content.type === 'Ready' ? resource.content.content : null;
+  const loadedMeta =
+    resource?.content.type === 'Ready' &&
+    resource.content.content.id === item.id &&
+    resource.content.content.type === item.type
+      ? resource.content.content
+      : null;
   // Choosing an episode reloads the model, and the reloaded state arrives with
   // its metadata still loading. Without the previous copy the episode list
   // unmounts, the page collapses to the hero, and the browser discards the
@@ -73,15 +78,6 @@ export function MetaDetailsScreen({
   const videos = useMemo(() => meta?.videos ?? [], [meta]);
   const sourcesRef = useRef<HTMLElement>(null);
   const episodeChosenRef = useRef(false);
-
-  // Picking an episode is a request to see its sources, so bring them into view.
-  // This waits for the reload to settle: the sources empty while it runs, which
-  // shrinks the page and would clamp an earlier scroll straight back.
-  useEffect(() => {
-    if (!episodeChosenRef.current || result.loading) return;
-    episodeChosenRef.current = false;
-    sourcesRef.current?.scrollIntoView({ behavior: 'auto', block: 'start' });
-  }, [result.loading, videoId]);
 
   useEffect(() => {
     if (item.type !== 'series' || videoId !== null || videos.length === 0) return;
@@ -102,6 +98,28 @@ export function MetaDetailsScreen({
     null;
   const activeSeason = activeVideo?.season ?? seasons[0];
   const visibleVideos = videos.filter((video) => video.season === activeSeason);
+  const selected = result.state?.selected;
+  // The hook retains old state during Load, and NewState reads can arrive late.
+  // Core's selected paths identify the streams in this snapshot. They must also
+  // match the identity that PlaybackSelection will send to the player.
+  const sourcesCurrent =
+    !result.loading &&
+    Boolean(loadedMeta) &&
+    selected?.metaPath.resource === 'meta' &&
+    selected.metaPath.type === item.type &&
+    selected.metaPath.id === item.id &&
+    selected.streamPath?.resource === 'stream' &&
+    selected.streamPath.type === item.type &&
+    selected.streamPath.id === (videoId ?? activeVideo?.id ?? item.id) &&
+    selected.streamPath.id === (activeVideo?.id ?? item.id);
+
+  // Wait for this episode's snapshot before moving the source list into view.
+  useEffect(() => {
+    if (!episodeChosenRef.current || !sourcesCurrent) return;
+    episodeChosenRef.current = false;
+    sourcesRef.current?.scrollIntoView({ behavior: 'auto', block: 'start' });
+  }, [sourcesCurrent, videoId]);
+
   const sources = useMemo<SourceChoice[]>(
     () =>
       result.state?.streams.flatMap((sourceResource) =>
@@ -218,14 +236,14 @@ export function MetaDetailsScreen({
         >
           <div className={styles.detailSectionHeading}>
             <h2 id="sources-heading">{enUS.details.sources}</h2>
-            {result.loading ? <span>{enUS.details.refreshing}</span> : null}
+            {!sourcesCurrent && !result.error ? <span>{enUS.details.refreshing}</span> : null}
           </div>
           {failedSources.size > 0 ? (
             <p className={styles.loadError} role="status">
               {[...failedSources.values()].at(-1)}
             </p>
           ) : null}
-          {!result.loading && sources.length === 0 ? (
+          {sourcesCurrent && sources.length === 0 ? (
             <p className={styles.inlineEmpty}>{enUS.details.noSources}</p>
           ) : null}
           <div className={styles.sourceList}>
@@ -237,10 +255,10 @@ export function MetaDetailsScreen({
               return (
                 <button
                   className={styles.sourceButton}
-                  disabled={!playable}
+                  disabled={!playable || !sourcesCurrent}
                   key={`${source.transportUrl}:${index}`}
                   onClick={() => {
-                    if (!playable || !resource?.addon.transportUrl) return;
+                    if (!sourcesCurrent || !playable || !resource?.addon.transportUrl) return;
                     onPlay({
                       meta: display,
                       metaTransportUrl: resource.addon.transportUrl,


### PR DESCRIPTION
Switching episodes retained the old Core snapshot while immediately changing the playback identity. A source click could therefore play episode 1's URL and record progress under episode 2.

Require the snapshot's selected title and stream paths to match the current selection and the video identity sent to the player. Retain metadata and disabled source rows during reloads, reject wrong-title metadata, and defer source scrolling until the matching snapshot arrives. The path shape was verified against the pinned Core 0.61.0 WASM serializer.

Validation: three real component/hook regressions failed before the fix and pass now. They cover pending dispatch, stale state after dispatch resolves, out-of-order episode updates, successful matching playback, and guessed movie sources. Full `pnpm check` passes, including all 46 tests and the production build.

Closes #35.
