### PR TITLE
Preserve torrent trackers from Core through peer discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Torrent sources play through a pinned build of the open [stream-server](https://
 brew install rust libtorrent-rasterbar boost
 pnpm engine:build
 pnpm engine:check-profile
+pnpm engine:check-trackers
 pnpm macos:build
 pnpm macos:check-engine
 pnpm macos:check-engine-ui
@@ -68,6 +69,8 @@ Engine diagnostics pass through Kino's sanitizer before entering the shell's rot
 The embedded HTTP API requires a fresh 256-bit token in its base URL, shared with Kino over the helper's private stdout pipe. Every request checks that token, the bound loopback Host, and the configured UI Origin. Only health, torrent creation/removal/media reads, and Kino's seeding/download-limit settings are exposed. The URL works directly with libmpv's byte-range requests and is never included in diagnostics or the startup probe's output. `pnpm macos:check-engine-ui` verifies the production WebChannel and WebEngine path with both local-file and HTTP development UI documents, using disposable engine caches.
 
 The engine profile check streams a private torrent from a local web seed and compares returned range bytes. Set `KINO_ENGINE_MEDIA_FIXTURE` to a legal playback fixture and `KINO_ENGINE_PLAYER_BINARY` to the built Kino executable to include actual libmpv playback in that check.
+
+`pnpm core:check-streams` runs the pinned Core WASM serializer and verifies that add-on torrent trackers survive resolution into the engine request. It runs in CI as part of `pnpm check`. `pnpm engine:check-trackers` also runs a local tracker and a libtorrent seeder with DHT, local discovery, and peer exchange disabled. A random unpublished torrent must transfer through the actual engine using only the tracker supplied through Core. This native check requires the engine build, a C++ compiler, and `pkg-config` for libtorrent.
 
 Run the complete local validation suite with:
 

--- a/apps/desktop/src/core/types.ts
+++ b/apps/desktop/src/core/types.ts
@@ -147,6 +147,13 @@ export interface CoreStream {
   ytId?: string;
 }
 
+// Core's Player serializer resolves add-on streams and renames torrent sources
+// to announce. Keep that output separate from the add-on input used by Load.
+export interface CorePlayerStream extends Omit<CoreStream, 'sources'> {
+  announce?: string[];
+  sources?: never;
+}
+
 export interface CoreMetaItem extends CoreMetaPreview {
   videos: CoreVideo[];
 }
@@ -182,7 +189,7 @@ export interface PlayerState {
     state: { timeOffset: number; video_id?: string | null };
   } | null;
   selected: { stream: CoreStream } | null;
-  stream: Loadable<CoreStream> | null;
+  stream: Loadable<CorePlayerStream> | null;
   subtitles?: unknown;
   title?: string | null;
 }

--- a/apps/desktop/src/player/torrent.test.ts
+++ b/apps/desktop/src/player/torrent.test.ts
@@ -11,18 +11,35 @@ describe('torrent streaming', () => {
       ...base,
       fileIdx: 1,
       infoHash: 'DD8255ECDC7CA55FB0BBF81323D87062DB1F6D1C',
-      sources: ['tracker:udp://tracker.example:1337/announce', 'dht:abc'],
+      announce: ['tracker:udp://tracker.example:1337/announce', 'dht:abc'],
     });
 
     expect(request.createUrl).toBe(`${engine}/dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c/create`);
-    expect(request.body.announce).toEqual(['udp://tracker.example:1337/announce']);
+    expect(request.body.peerSearch.sources).toEqual(['udp://tracker.example:1337/announce']);
     expect(request.body.guessFileIdx).toBe(false);
   });
 
   it('asks the engine to guess when the source omits a file index', () => {
     const request = torrentCreateRequest(engine, { ...base, infoHash: 'abc' });
     expect(request.body.guessFileIdx).toBe(true);
-    expect(request.body.announce).toEqual([]);
+    expect(request.body.peerSearch.sources).toEqual([]);
+  });
+
+  it('retains bare tracker URLs and removes duplicate or unsupported peer sources', () => {
+    const request = torrentCreateRequest(engine, {
+      ...base,
+      infoHash: 'abc',
+      announce: [
+        'https://tracker.invalid/announce?key=synthetic',
+        'tracker:https://tracker.invalid/announce?key=synthetic',
+        'tracker:',
+        'dht:abc',
+        'file:///invalid',
+      ],
+    });
+    expect(request.body.peerSearch.sources).toEqual([
+      'https://tracker.invalid/announce?key=synthetic',
+    ]);
   });
 
   it('prefers the declared file index over a guess', () => {

--- a/apps/desktop/src/player/torrent.ts
+++ b/apps/desktop/src/player/torrent.ts
@@ -1,7 +1,7 @@
-import type { CoreStream } from '../core/types';
+import type { CorePlayerStream } from '../core/types';
 
 export interface TorrentRequest {
-  body: { announce: string[]; guessFileIdx: boolean };
+  body: { peerSearch: { sources: string[] }; guessFileIdx: boolean };
   createUrl: string;
 }
 
@@ -13,24 +13,26 @@ export interface TorrentStats {
 
 // The engine speaks Stremio's streaming-server API: create the engine for an
 // infoHash, then read the chosen file over HTTP ranges (ADR 0015).
-export function torrentCreateRequest(engineUrl: string, stream: CoreStream): TorrentRequest {
+export function torrentCreateRequest(engineUrl: string, stream: CorePlayerStream): TorrentRequest {
   const infoHash = String(stream.infoHash).toLowerCase();
-  const announce = (stream.sources ?? []).filter((source) => source.startsWith('tracker:'));
+  const trackers = (stream.announce ?? [])
+    .map((source) => (source.startsWith('tracker:') ? source.slice('tracker:'.length) : source))
+    .filter((source) => /^(https?|udp):\/\//.test(source));
   return {
     body: {
-      announce: announce.map((source) => source.slice('tracker:'.length)),
+      peerSearch: { sources: [...new Set(trackers)] },
       guessFileIdx: stream.fileIdx === undefined || stream.fileIdx === null,
     },
     createUrl: `${engineUrl.replace(/\/$/, '')}/${infoHash}/create`,
   };
 }
 
-export function torrentMediaUrl(engineUrl: string, stream: CoreStream, fileIdx: number) {
+export function torrentMediaUrl(engineUrl: string, stream: CorePlayerStream, fileIdx: number) {
   const infoHash = String(stream.infoHash).toLowerCase();
   return `${engineUrl.replace(/\/$/, '')}/${infoHash}/${fileIdx}`;
 }
 
-export function resolveFileIndex(stream: CoreStream, stats: TorrentStats): number | null {
+export function resolveFileIndex(stream: CorePlayerStream, stats: TorrentStats): number | null {
   if (typeof stream.fileIdx === 'number' && stream.fileIdx >= 0) return stream.fileIdx;
   if (typeof stats.guessedFileIdx === 'number' && stats.guessedFileIdx >= 0) {
     return stats.guessedFileIdx;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "build": "pnpm --filter @kino/desktop build",
-    "check": "pnpm format:check && pnpm lint && pnpm typecheck && pnpm test && pnpm engine:check-vendor && pnpm build",
+    "check": "pnpm format:check && pnpm lint && pnpm typecheck && pnpm test && pnpm core:check-streams && pnpm engine:check-vendor && pnpm build",
+    "core:check-streams": "node scripts/check-core-streams.mjs",
     "dev": "pnpm --filter @kino/desktop dev",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
@@ -19,6 +20,7 @@
     "engine:build": "./scripts/build-engine.sh",
     "engine:check-vendor": "node scripts/check-engine-vendor.mjs",
     "engine:check-profile": "node scripts/check-engine-profile.mjs",
+    "engine:check-trackers": "node scripts/check-engine-trackers.mjs",
     "macos:build": "./scripts/build-macos.sh",
     "macos:check-engine": "./scripts/check-macos-engine.sh",
     "macos:check-engine-ui": "node scripts/check-macos-engine-ui.mjs",

--- a/scripts/check-core-streams.mjs
+++ b/scripts/check-core-streams.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+
+import { torrentCreateRequest } from '../apps/desktop/src/player/torrent.ts';
+import { initializeCore, resolveCoreStream } from './test-support/core-stream.mjs';
+
+const core = await initializeCore();
+const tracker = 'https://tracker.invalid/announce';
+const resolved = await resolveCoreStream(core, {
+  infoHash: '0123456789abcdef0123456789abcdef01234567',
+  fileIdx: 0,
+  sources: [`tracker:${tracker}`, 'dht:0123456789abcdef0123456789abcdef01234567'],
+});
+assert.equal(resolved.sources, undefined, 'Core serializes sources as announce.');
+assert.deepEqual(resolved.announce, [
+  `tracker:${tracker}`,
+  'dht:0123456789abcdef0123456789abcdef01234567',
+]);
+const request = torrentCreateRequest('http://127.0.0.1:1234/kino/test-capability', resolved);
+assert.deepEqual(
+  request.body.peerSearch?.sources,
+  [tracker],
+  'The resolved Core trackers must reach the magnet endpoint in peerSearch.sources.',
+);
+assert.equal(request.body.guessFileIdx, false);
+console.log('Pinned Core torrent resolution preserves trackers in the engine request.');
+process.exit(0);

--- a/scripts/check-engine-trackers.mjs
+++ b/scripts/check-engine-trackers.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { execFileSync, spawn } from 'node:child_process';
+import { createHash, randomBytes } from 'node:crypto';
+import { once } from 'node:events';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { torrentCreateRequest, torrentMediaUrl } from '../apps/desktop/src/player/torrent.ts';
+import { initializeCore, resolveCoreStream } from './test-support/core-stream.mjs';
+
+const fetchEngine = globalThis.fetch;
+const binary = resolve(
+  process.env.KINO_ENGINE_BINARY ?? 'build/engine-target/release/kino-stream-engine',
+);
+assert.ok(existsSync(binary), 'Build the native helper with pnpm engine:build first.');
+const root = mkdtempSync(join(tmpdir(), 'kino-tracker-check-'));
+const processes = [];
+const servers = [];
+
+function bencode(value) {
+  if (typeof value === 'number') return Buffer.from(`i${value}e`);
+  if (typeof value === 'string') value = Buffer.from(value);
+  if (Buffer.isBuffer(value)) return Buffer.concat([Buffer.from(`${value.length}:`), value]);
+  return Buffer.concat([
+    Buffer.from('d'),
+    ...Object.keys(value)
+      .sort()
+      .flatMap((key) => [bencode(key), bencode(value[key])]),
+    Buffer.from('e'),
+  ]);
+}
+
+async function startProcess(command, args, env, pattern) {
+  const child = spawn(command, args, { env, stdio: ['pipe', 'pipe', 'pipe'] });
+  const exit = once(child, 'exit');
+  processes.push({ child, exit });
+  child.stderr.resume();
+  return new Promise((resolveReady, reject) => {
+    let output = '';
+    child.on('error', reject);
+    child.on('exit', () => reject(new Error('Fixture process exited before readiness.')));
+    child.stdout.on('data', (data) => {
+      output += data;
+      const match = output.match(pattern);
+      if (match) resolveReady(match[1]);
+    });
+  });
+}
+
+const timeout = setTimeout(() => {
+  for (const { child } of processes) child.kill('SIGKILL');
+}, 30000);
+
+try {
+  const seeder = join(root, 'seeder');
+  const flags = execFileSync('pkg-config', ['--cflags', '--libs', 'libtorrent-rasterbar'], {
+    encoding: 'utf8',
+  })
+    .trim()
+    .split(/\s+/);
+  if (process.platform === 'darwin') {
+    flags.push(
+      `-I${execFileSync('brew', ['--prefix', 'boost'], { encoding: 'utf8' }).trim()}/include`,
+    );
+  }
+  execFileSync(
+    process.env.CXX ?? 'c++',
+    ['-std=c++17', 'scripts/test-support/torrent-seeder.cpp', '-o', seeder, ...flags],
+    { stdio: 'inherit' },
+  );
+  const bytes = randomBytes(65536);
+  const pieceLength = 16384;
+  const info = {
+    length: bytes.length,
+    name: 'fixture.mp4',
+    'piece length': pieceLength,
+    pieces: Buffer.concat(
+      Array.from({ length: bytes.length / pieceLength }, (_, index) =>
+        createHash('sha1')
+          .update(bytes.subarray(index * pieceLength, (index + 1) * pieceLength))
+          .digest(),
+      ),
+    ),
+  };
+  const hash = createHash('sha1').update(bencode(info)).digest('hex');
+  const torrentFile = join(root, 'fixture.torrent');
+  writeFileSync(torrentFile, bencode({ info }));
+  writeFileSync(join(root, 'fixture.mp4'), bytes);
+  const seedPort = Number(
+    await startProcess(seeder, [torrentFile, root], process.env, /^SEED_READY (\d+)$/m),
+  );
+  const peer = Buffer.from([127, 0, 0, 1, seedPort >> 8, seedPort & 255]);
+  let announces = 0;
+  const tracker = createServer((request, response) => {
+    const encodedHash = request.url.match(/[?&]info_hash=([^&]+)/)?.[1] ?? '';
+    const requestedHash = Buffer.from(
+      encodedHash.replace(/%([0-9a-f]{2})/gi, (_, hex) =>
+        String.fromCharCode(Number.parseInt(hex, 16)),
+      ),
+      'latin1',
+    ).toString('hex');
+    if (requestedHash !== hash) {
+      response.writeHead(400).end();
+      return;
+    }
+    announces += 1;
+    response.writeHead(200, { 'Content-Type': 'text/plain' });
+    response.end(bencode({ interval: 1, peers: peer }));
+  });
+  tracker.listen(0, '127.0.0.1');
+  servers.push(tracker);
+  await once(tracker, 'listening');
+  const trackerUrl = `http://127.0.0.1:${tracker.address().port}/announce`;
+
+  // Block the helper's upstream tracker-list downloads. This random unpublished
+  // torrent has no web seeds; only our tracker knows the seeder's address.
+  // Do not set the private flag: libtorrent disables magnet metadata exchange
+  // for private torrents. Discovery is disabled on the fixture seeder instead.
+  const proxy = createServer((_request, response) => response.writeHead(502).end());
+  proxy.on('connect', (_request, socket) => socket.end('HTTP/1.1 502 Blocked\r\n\r\n'));
+  proxy.listen(0, '127.0.0.1');
+  servers.push(proxy);
+  await once(proxy, 'listening');
+  const proxyUrl = `http://127.0.0.1:${proxy.address().port}`;
+  const engineUrl = await startProcess(
+    binary,
+    [],
+    {
+      ...process.env,
+      KINO_ENGINE_CACHE_DIR: join(root, 'engine'),
+      KINO_ENGINE_PORT: '0',
+      HTTP_PROXY: proxyUrl,
+      HTTPS_PROXY: proxyUrl,
+      ALL_PROXY: proxyUrl,
+      http_proxy: proxyUrl,
+      https_proxy: proxyUrl,
+      all_proxy: proxyUrl,
+      NO_PROXY: '127.0.0.1,localhost',
+      no_proxy: '127.0.0.1,localhost',
+    },
+    /^KINO_ENGINE_READY (http:\/\/127\.0\.0\.1:\d+\/kino\/[a-f0-9]{64})$/m,
+  );
+  const core = await initializeCore();
+  const stream = await resolveCoreStream(core, {
+    infoHash: hash,
+    fileIdx: 0,
+    sources: [`tracker:${trackerUrl}`],
+  });
+  const request = torrentCreateRequest(engineUrl, stream);
+  const created = await fetchEngine(request.createUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request.body),
+    signal: AbortSignal.timeout(15000),
+  });
+  assert.equal(created.status, 200);
+  const stats = await created.json();
+  assert.equal(stats.error, undefined, 'The helper must create the synthetic torrent.');
+  const media = await fetchEngine(torrentMediaUrl(engineUrl, stream, 0), {
+    headers: { Range: 'bytes=1024-2047' },
+    signal: AbortSignal.timeout(15000),
+  });
+  assert.equal(media.status, 206);
+  assert.deepEqual(Buffer.from(await media.arrayBuffer()), bytes.subarray(1024, 2048));
+  assert.ok(announces > 0, 'The supplied tracker must receive an announce from the real helper.');
+  console.log(
+    'Real Core -> engine -> tracker -> peer transfer returned the exact requested bytes.',
+  );
+} finally {
+  clearTimeout(timeout);
+  for (const { child, exit } of processes.reverse()) {
+    child.stdin.end();
+    const force = setTimeout(() => child.kill('SIGKILL'), 5000);
+    await exit;
+    clearTimeout(force);
+  }
+  for (const server of servers) server.closeAllConnections();
+  await Promise.all(servers.map((server) => new Promise((done) => server.close(done))));
+  rmSync(root, { recursive: true, force: true });
+}
+process.exit(0);

--- a/scripts/test-support/core-stream.mjs
+++ b/scripts/test-support/core-stream.mjs
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+import { loadPlayerAction } from '../../apps/desktop/src/core/actions.ts';
+
+const require = createRequire(new URL('../../apps/desktop/package.json', import.meta.url));
+
+// Run the pinned WASM serializer with synthetic metadata and in-memory storage.
+// Every Core fetch stays in this fixture; it never contacts an add-on or account.
+export async function initializeCore() {
+  Object.assign(globalThis, {
+    WorkerGlobalScope: { [Symbol.hasInstance]: () => true },
+    self: globalThis,
+    window: globalThis,
+    document: { baseURI: 'https://kino.invalid/' },
+    app_version: '0.0.0',
+    shell_version: null,
+    get_location_hash: async () => '',
+  });
+  const storage = new Map();
+  globalThis.local_storage_get_item = async (key) => storage.get(key) ?? null;
+  globalThis.local_storage_set_item = async (key, value) => storage.set(key, value);
+  globalThis.local_storage_remove_item = async (key) => storage.delete(key);
+  globalThis.fetch = async () => Response.json({ meta: fixtureMeta });
+  const core = require('@stremio/stremio-core-web/stremio_core_web.js');
+  await core.default({
+    module_or_path: readFileSync(
+      require.resolve('@stremio/stremio-core-web/stremio_core_web_bg.wasm'),
+    ),
+  });
+  await core.initialize_runtime(() => {});
+  return core;
+}
+
+const fixtureMeta = {
+  id: 'kino-fixture',
+  type: 'movie',
+  name: 'Synthetic fixture',
+  videos: [],
+  inLibrary: false,
+  watched: false,
+};
+
+export async function resolveCoreStream(core, stream) {
+  core.dispatch(
+    loadPlayerAction({
+      meta: fixtureMeta,
+      metaTransportUrl: 'https://addon.invalid/manifest.json',
+      stream: { deepLinks: { player: '' }, ...stream },
+      streamTransportUrl: 'https://addon.invalid/manifest.json',
+      video: null,
+      nextVideo: null,
+    }),
+    'player',
+    '',
+  );
+  await new Promise((resolve) => setImmediate(resolve));
+  const state = core.get_state('player').stream;
+  if (state?.type !== 'Ready') throw new Error('Core did not resolve the synthetic stream.');
+  return state.content;
+}

--- a/scripts/test-support/torrent-seeder.cpp
+++ b/scripts/test-support/torrent-seeder.cpp
@@ -1,0 +1,40 @@
+// Local-only seeder for the real Core -> tracker -> engine regression.
+#include <libtorrent/load_torrent.hpp>
+#include <libtorrent/session.hpp>
+#include <libtorrent/settings_pack.hpp>
+#include <libtorrent/torrent_flags.hpp>
+#include <libtorrent/torrent_handle.hpp>
+#include <libtorrent/torrent_status.hpp>
+
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+int main(int argc, char **argv) {
+    if (argc != 3) return 2;
+    namespace lt = libtorrent;
+    lt::settings_pack settings;
+    settings.set_str(lt::settings_pack::listen_interfaces, "127.0.0.1:0");
+    settings.set_str(lt::settings_pack::outgoing_interfaces, "127.0.0.1");
+    settings.set_bool(lt::settings_pack::enable_dht, false);
+    settings.set_bool(lt::settings_pack::enable_lsd, false);
+    settings.set_bool(lt::settings_pack::enable_upnp, false);
+    settings.set_bool(lt::settings_pack::enable_natpmp, false);
+    lt::session session(settings);
+    auto torrent = lt::load_torrent_file(argv[1]);
+    torrent.save_path = argv[2];
+    torrent.trackers.clear();
+    torrent.flags &= ~(lt::torrent_flags::paused | lt::torrent_flags::auto_managed);
+    torrent.flags |= lt::torrent_flags::seed_mode | lt::torrent_flags::disable_dht
+        | lt::torrent_flags::disable_lsd | lt::torrent_flags::disable_pex;
+    auto handle = session.add_torrent(std::move(torrent));
+    for (int attempt = 0; attempt < 100; ++attempt) {
+        if (session.listen_port() && handle.status().is_seeding) {
+            std::cout << "SEED_READY " << session.listen_port() << std::endl;
+            std::cin.get();
+            return 0;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    return 1;
+}


### PR DESCRIPTION
Core resolves add-on torrent `sources` into `announce`, while the embedded engine's magnet endpoint expects `peerSearch.sources`. The old adapter read the original field and sent a payload the endpoint ignored, losing supplied trackers at both boundaries.

Separate the resolved Player stream type from the add-on input and normalize tracker entries into the engine's accepted request. Keep HTTP, HTTPS and UDP trackers, remove duplicate entries and DHT markers, and preserve file-index selection.

Validation:

- The pinned Core WASM regression exercises the production Load action and adapter. It failed before the fix and now runs in `pnpm check`.
- A native regression starts a local tracker, a seeder with DHT/local discovery/peer exchange disabled, and the real helper. A random unpublished torrent transfers through the tracker supplied through Core, returning exact range bytes. This regression fails with the old adapter and passes with the fix.
- Full `pnpm check` passes, including 47 tests and the production build.

Closes #38.
