### PR TITLE
Play header-dependent direct media without Stremio Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ Run the native property-event regression tests after building with:
 
 ```sh
 ctest --test-dir build/macos --output-on-failure
+pnpm macos:check-request-headers
 ```
+
+Direct media uses the add-on's original HTTPS URL and required request headers in libmpv, independent of any Stremio Service URL saved in the account. TLS certificate verification is required. The native header check drives the production WebChannel and player through a protected media request, external subtitles, and a second source. It verifies literal header values, prevents headers from carrying into subtitles or later sources, rejects header injection and untrusted certificates, and checks diagnostic output for synthetic credentials. It uses `openssl` for the untrusted certificate and generates a short H.264 fixture with `ffmpeg`, or uses `KINO_PLAYBACK_FIXTURE` when provided.
 
 ### Streaming engine
 

--- a/apps/desktop/src/core/types.ts
+++ b/apps/desktop/src/core/types.ts
@@ -130,6 +130,10 @@ export interface CoreStream {
   behaviorHints?: {
     filename?: string | null;
     notWebReady?: boolean;
+    proxyHeaders?: {
+      request?: Record<string, string>;
+      response?: Record<string, string>;
+    };
     videoHash?: string | null;
     videoSize?: number | null;
   };

--- a/apps/desktop/src/native/player.ts
+++ b/apps/desktop/src/native/player.ts
@@ -10,7 +10,7 @@ export interface NativeEngineEvent {
 
 export interface NativePlayer {
   addSubtitles(url: string, title: string, lang: string): void;
-  load(url: string, forceStereo: boolean): void;
+  load(url: string, forceStereo: boolean, headers: Record<string, string>): void;
   platform: string;
   playerEvent: NativePlayerEvent;
   seek(seconds: number): void;

--- a/apps/desktop/src/screens/PlayerScreen.test.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.test.tsx
@@ -1,0 +1,92 @@
+import { render, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CoreContext } from '../core/context';
+import type { CoreTransport } from '../core/transport';
+import { defaultSettings } from '../settings';
+import { PlayerScreen } from './PlayerScreen';
+
+const native = vi.hoisted(() => ({
+  load: vi.fn(),
+  stop: vi.fn(),
+  playerEvent: { connect: vi.fn(), disconnect: vi.fn() },
+  setSubtitleScale: vi.fn(),
+  setSubtitlePosition: vi.fn(),
+  setNowPlayingMetadata: vi.fn(),
+}));
+vi.mock('../native/player', () => ({
+  nativeShellPresent: () => true,
+  connectNativePlayer: async () => native,
+}));
+
+describe('native direct sources', () => {
+  it.each(['http://127.0.0.1:11470', 'https://stale-service.invalid'])(
+    'passes the original media URL and headers instead of the Core proxy at %s',
+    async (service) => {
+      const headers = {
+        Referer: 'https://required.invalid/',
+        Authorization: 'Bearer synthetic-test-value',
+      };
+      const stream = {
+        url: 'https://media.invalid/video.mp4',
+        behaviorHints: { proxyHeaders: { request: headers } },
+        deepLinks: { player: '' },
+      };
+      const state = {
+        selected: { stream },
+        stream: {
+          type: 'Ready',
+          content: {
+            url: `${service}/proxy/d=https%3A%2F%2Fmedia.invalid&h=Referer%3Ahttps%3A%2F%2Frequired.invalid%2F/video.mp4`,
+            deepLinks: { player: '' },
+          },
+        },
+      };
+      const transport: CoreTransport = {
+        destroy: vi.fn(),
+        dispatch: vi.fn().mockResolvedValue(undefined),
+        getState: async <State,>() => state as State,
+        init: vi.fn().mockResolvedValue(undefined),
+        subscribe: () => () => {},
+      };
+      native.load.mockClear();
+      render(
+        <CoreContext.Provider
+          value={{
+            error: null,
+            status: 'ready',
+            session: 'guest',
+            selectSession: vi.fn(),
+            transport,
+          }}
+        >
+          <PlayerScreen
+            selection={{
+              meta: {
+                id: 'fixture',
+                name: 'Fixture',
+                type: 'movie',
+                inLibrary: false,
+                watched: false,
+              },
+              metaTransportUrl: 'https://addon.invalid/manifest.json',
+              stream,
+              streamTransportUrl: 'https://addon.invalid/manifest.json',
+              video: null,
+              nextVideo: null,
+            }}
+            settings={defaultSettings}
+            preferredSubtitleLanguage={null}
+            onBack={vi.fn()}
+            onSettingsChange={vi.fn()}
+            onSourceFailure={vi.fn()}
+            onUpNext={vi.fn()}
+          />
+        </CoreContext.Provider>,
+      );
+      await waitFor(() =>
+        expect(native.load).toHaveBeenCalledExactlyOnceWith(stream.url, false, headers),
+      );
+    },
+  );
+});

--- a/apps/desktop/src/screens/PlayerScreen.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.tsx
@@ -163,7 +163,17 @@ export function PlayerScreen({
   const [engineUrl, setEngineUrl] = useState<string | null>(null);
   const stream = result.state?.stream?.type === 'Ready' ? result.state.stream.content : null;
   const isTorrent = stream ? classifySource(stream) === 'torrent' : false;
-  const streamUrl = (isTorrent ? torrentUrl : stream?.url) ?? null;
+  // Core wraps direct streams with proxy headers in a URL for the account's
+  // Stremio Service. The native backend can send those headers itself, using
+  // the original source URL independently of that service's address.
+  const directSource = selection.stream.url?.startsWith('https://') ? selection.stream : null;
+  const streamUrl = stream
+    ? ((isTorrent ? torrentUrl : (directSource?.url ?? stream.url)) ?? null)
+    : null;
+  const requestHeaders = useMemo(
+    () => (!isTorrent ? directSource?.behaviorHints?.proxyHeaders?.request : undefined) ?? {},
+    [directSource, isTorrent],
+  );
   const resumeTime = result.state?.libraryItem?.state.timeOffset ?? 0;
   const nativeShell = nativeShellPresent();
   const addonSubtitles = useMemo(
@@ -452,7 +462,7 @@ export function PlayerScreen({
     };
 
     nativePlayer.playerEvent.connect(onEvent);
-    nativePlayer.load(streamUrl, settings.audioOutput === 'stereo');
+    nativePlayer.load(streamUrl, settings.audioOutput === 'stereo', requestHeaders);
 
     return () => {
       nativePlayer.playerEvent.disconnect(onEvent);
@@ -463,6 +473,7 @@ export function PlayerScreen({
     nativePlayer,
     reportFailure,
     reportProgress,
+    requestHeaders,
     settings.audioOutput,
     streamUrl,
     updateDuration,

--- a/apps/macos-shell/qml/Main.qml
+++ b/apps/macos-shell/qml/Main.qml
@@ -69,8 +69,8 @@ ApplicationWindow {
             player.addSubtitles(url, title, lang)
         }
 
-        function load(url, forceStereo) {
-            player.load(url, forceStereo)
+        function load(url, forceStereo, headers) {
+            player.load(url, forceStereo, headers || {})
         }
 
         function seek(seconds) {

--- a/apps/macos-shell/src/mpvitem.cpp
+++ b/apps/macos-shell/src/mpvitem.cpp
@@ -8,6 +8,9 @@
 #include <QOpenGLContext>
 #include <QOpenGLFramebufferObject>
 #include <QQuickOpenGLUtils>
+#include <QRegularExpression>
+#include <QSet>
+#include <QUrl>
 #include <QVariantList>
 
 #include <algorithm>
@@ -223,6 +226,7 @@ void MpvItem::initialize() {
         {"tone-mapping", "auto"},
         {"hdr-compute-peak", "auto"},
         {"cache", "yes"},
+        {"tls-verify", "yes"},
         {"demuxer-readahead-secs", "10"},
         {"audio-fallback-to-null", "yes"},
         {"audio-client-name", "Kino"},
@@ -253,7 +257,47 @@ void MpvItem::initialize() {
     mpv_observe_property(handle_, 9, "track-list", MPV_FORMAT_NODE);
 }
 
-void MpvItem::load(const QString &url, bool forceStereo) {
+void MpvItem::load(const QString &url, bool forceStereo, const QVariantMap &headers) {
+    // mpv can log arbitrary header values. Keep its free-form messages private
+    // for the rest of this instance, including late events from an earlier load.
+    suppressMpvLogDetails_ = suppressMpvLogDetails_ || !headers.isEmpty();
+    static const QRegularExpression headerName(QStringLiteral("^[!#$%&'*+.^_`|~0-9A-Za-z-]+$"));
+    static const QRegularExpression control(QStringLiteral("[\\x00-\\x08\\x0a-\\x1f\\x7f]"));
+    static const QSet<QString> reserved{
+        QStringLiteral("host"), QStringLiteral("range"), QStringLiteral("content-length"),
+        QStringLiteral("transfer-encoding"), QStringLiteral("connection")};
+    QSet<QString> names;
+    QByteArray headerFields;
+    bool valid = headers.size() <= 64;
+    const QString scheme = QUrl(url).scheme();
+    valid = valid && (headers.isEmpty() || scheme == QLatin1String("https") ||
+                      scheme == QLatin1String("http"));
+    for (auto it = headers.cbegin(); valid && it != headers.cend(); ++it) {
+        const QString name = it.key().toLower();
+        const QString value = it.value().toString();
+        valid = it.value().metaType().id() == QMetaType::QString &&
+                headerName.match(it.key()).hasMatch() && !control.match(value).hasMatch() &&
+                !reserved.contains(name) && !names.contains(name);
+        names.insert(name);
+        // loadfile's options map accepts strings. Escape the string-list
+        // separators so commas remain literal. mpv leaves other backslashes
+        // untouched. HTTP whitespace keeps a trailing backslash from escaping
+        // the separator before the next header.
+        QByteArray field = (it.key() + QStringLiteral(": ") + value).toUtf8();
+        field.replace(",", "\\,");
+        if (field.endsWith('\\')) {
+            field.append(' ');
+        }
+        if (!headerFields.isEmpty()) {
+            headerFields.append(',');
+        }
+        headerFields.append(field);
+        valid = valid && headerFields.size() <= 64 * 1024;
+    }
+    if (!valid) {
+        emitError(QStringLiteral("invalid-request-headers"));
+        return;
+    }
     failed_ = false;
     hardwareDecoderActive_ = false;
     hardwareDecoderTimer_.stop();
@@ -272,9 +316,31 @@ void MpvItem::load(const QString &url, bool forceStereo) {
     mpv_set_property_async(handle_, 0, "sub-delay", MPV_FORMAT_DOUBLE, &subtitleDelay);
     int unpaused = 0;
     mpv_set_property_async(handle_, 0, "pause", MPV_FORMAT_FLAG, &unpaused);
-    const QByteArray encodedUrl = url.toUtf8();
-    const char *command[] = {"loadfile", encodedUrl.constData(), "replace", nullptr};
-    const int result = mpv_command_async(handle_, 0, command);
+    QByteArray encodedUrl = url.toUtf8();
+    char loadfile[] = "loadfile";
+    char replace[] = "replace";
+    char headerOption[] = "http-header-fields";
+    char *optionNames[] = {headerOption};
+    mpv_node optionValue{};
+    optionValue.format = MPV_FORMAT_STRING;
+    optionValue.u.string = headerFields.data();
+    mpv_node_list options{1, &optionValue, optionNames};
+    mpv_node arguments[5]{};
+    for (int index = 0; index < 3; ++index) {
+        arguments[index].format = MPV_FORMAT_STRING;
+    }
+    arguments[0].u.string = loadfile;
+    arguments[1].u.string = encodedUrl.data();
+    arguments[2].u.string = replace;
+    arguments[3].format = MPV_FORMAT_INT64;
+    arguments[3].u.int64 = -1;
+    arguments[4].format = MPV_FORMAT_NODE_MAP;
+    arguments[4].u.list = &options;
+    mpv_node_list commandArguments{5, arguments, nullptr};
+    mpv_node command{};
+    command.format = MPV_FORMAT_NODE_ARRAY;
+    command.u.list = &commandArguments;
+    const int result = mpv_command_node_async(handle_, 0, &command);
     if (result < 0) {
         emitError(QStringLiteral("source-load-failed"));
         return;
@@ -378,6 +444,10 @@ void MpvItem::handleEvent(mpv_event *event) {
         emit playerEvent(QStringLiteral("buffering"), {{QStringLiteral("active"), true}});
         break;
     case MPV_EVENT_FILE_LOADED:
+        // The media demuxer owns its request headers after opening. Clear the
+        // option before an external subtitle can open a separate connection.
+        // Auto-loading sidecar subtitles is disabled during initialization.
+        mpv_set_property_string(handle_, "http-header-fields", "");
         qInfo("[kino:mpv] source metadata loaded");
         break;
     case MPV_EVENT_PLAYBACK_RESTART:
@@ -457,7 +527,9 @@ void MpvItem::handleEvent(mpv_event *event) {
     }
     case MPV_EVENT_LOG_MESSAGE: {
         const auto *entry = static_cast<mpv_event_log_message *>(event->data);
-        if (entry) {
+        if (entry && suppressMpvLogDetails_) {
+            qWarning("[kino:mpv] message omitted for media with request headers");
+        } else if (entry) {
             qWarning("[kino:mpv] message module=%s level=%s detail=%s", entry->prefix,
                      entry->level, entry->text);
         }

--- a/apps/macos-shell/src/mpvitem.h
+++ b/apps/macos-shell/src/mpvitem.h
@@ -24,7 +24,7 @@ public:
     Renderer *createRenderer() const override;
 
     Q_INVOKABLE void addSubtitles(const QString &url, const QString &title, const QString &lang);
-    Q_INVOKABLE void load(const QString &url, bool forceStereo);
+    Q_INVOKABLE void load(const QString &url, bool forceStereo, const QVariantMap &headers = {});
     Q_INVOKABLE void seek(double seconds);
     Q_INVOKABLE void setMuted(bool muted);
     Q_INVOKABLE void setPaused(bool paused);
@@ -60,6 +60,7 @@ private:
     bool failed_ = false;
     bool hardwareDecoderActive_ = false;
     bool paused_ = true;
+    bool suppressMpvLogDetails_ = false;
     bool videoPresent_ = false;
     mpv_handle *handle_ = nullptr;
     mpv_render_context *renderContext_ = nullptr;

--- a/apps/macos-shell/tests/mpvitem_test.cpp
+++ b/apps/macos-shell/tests/mpvitem_test.cpp
@@ -29,6 +29,44 @@ class MpvItemTest : public QObject {
     }
 
 private slots:
+    void invalidRequestHeaders_data() {
+        QTest::addColumn<QVariantMap>("headers");
+        QTest::newRow("header-name-injection") << QVariantMap{{"X-Test\r\nInjected", "value"}};
+        QTest::newRow("header-value-injection") << QVariantMap{{"X-Test", "value\r\nInjected: value"}};
+        QTest::newRow("non-string") << QVariantMap{{"X-Test", 42}};
+        QTest::newRow("host-override") << QVariantMap{{"Host", "another.invalid"}};
+        QTest::newRow("range-override") << QVariantMap{{"Range", "bytes=0-10"}};
+        QTest::newRow("duplicate-name") << QVariantMap{{"X-Test", "one"}, {"x-test", "two"}};
+        QTest::newRow("oversized") << QVariantMap{{"X-Test", QString(65537, QLatin1Char('x'))}};
+    }
+
+    void invalidRequestHeaders() {
+        QFETCH(QVariantMap, headers);
+        MpvItem player;
+        QSignalSpy events(&player, &MpvItem::playerEvent);
+        player.load(QStringLiteral("https://media.invalid/fixture.mp4"), false, headers);
+        QVERIFY(!player.active());
+        QCOMPARE(events.size(), 1);
+        QCOMPARE(events.first().at(0).toString(), QStringLiteral("error"));
+        QCOMPARE(events.first().at(1).toMap().value("code").toString(),
+                 QStringLiteral("invalid-request-headers"));
+    }
+
+    void requestHeaderLogsStayPrivateAfterStop() {
+        MpvItem player;
+        // A rejected request also protects late free-form logs. The structured
+        // error code remains available without including any header contents.
+        player.load(QStringLiteral("https://media.invalid/fixture.mp4"), false,
+                    {{"X-Private", "synthetic credential\r\n"}});
+        player.stop();
+        mpv_event_log_message message{"ffmpeg", "warn", "synthetic credential, continuation", MPV_LOG_LEVEL_WARN};
+        mpv_event event{};
+        event.event_id = MPV_EVENT_LOG_MESSAGE;
+        event.data = &message;
+        QTest::ignoreMessage(QtWarningMsg, "[kino:mpv] message omitted for media with request headers");
+        player.handleEvent(&event);
+    }
+
     void hardwareDecoderProperties_data() {
         QTest::addColumn<QByteArray>("value");
         QTest::addColumn<bool>("expected");

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "macos:check-engine-ui": "node scripts/check-macos-engine-ui.mjs",
     "macos:check-launch": "./scripts/check-macos-launch.sh",
     "macos:check-playback": "node scripts/check-macos-playback.mjs",
+    "macos:check-request-headers": "node scripts/check-macos-request-headers.mjs",
     "macos:package": "node scripts/package-macos.mjs",
     "test": "pnpm --filter @kino/desktop test",
     "typecheck": "pnpm --filter @kino/desktop typecheck"

--- a/scripts/check-macos-request-headers.mjs
+++ b/scripts/check-macos-request-headers.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { execFileSync, spawn } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { once } from 'node:events';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { createServer as createHttpsServer } from 'node:https';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const binary = resolve(process.env.KINO_APP_BINARY ?? 'build/macos/Kino.app/Contents/MacOS/Kino');
+assert.ok(existsSync(binary), 'Build the native app first.');
+const root = mkdtempSync(join(tmpdir(), 'kino-header-check-'));
+const secret = `kino-header-${randomBytes(12).toString('hex')}`;
+const headers = {
+  Authorization: `Bearer ${secret}`,
+  Cookie: `session=${secret}`,
+  Referer: 'https://required.invalid/',
+  'X-Kino-Probe': `${secret},literal\\backslash`,
+  'X-Trailing': `${secret}\\`,
+  'Z-Probe': 'after-trailing-backslash',
+};
+let child;
+let server;
+let untrustedServer;
+let timeout;
+try {
+  const fixture = process.env.KINO_PLAYBACK_FIXTURE ?? join(root, 'fixture.mp4');
+  if (!existsSync(fixture)) {
+    execFileSync('ffmpeg', [
+      '-hide_banner',
+      '-loglevel',
+      'error',
+      '-f',
+      'lavfi',
+      '-i',
+      'testsrc2=size=640x360:rate=24:duration=6',
+      '-c:v',
+      'libx264',
+      '-preset',
+      'veryfast',
+      '-pix_fmt',
+      'yuv420p',
+      fixture,
+    ]);
+  }
+  const bytes = readFileSync(fixture);
+  const key = join(root, 'untrusted-key.pem');
+  const cert = join(root, 'untrusted-cert.pem');
+  execFileSync(
+    'openssl',
+    [
+      'req',
+      '-x509',
+      '-newkey',
+      'rsa:2048',
+      '-nodes',
+      '-subj',
+      '/CN=localhost',
+      '-days',
+      '1',
+      '-addext',
+      'subjectAltName=DNS:localhost,IP:127.0.0.1',
+      '-keyout',
+      key,
+      '-out',
+      cert,
+    ],
+    { stdio: 'ignore' },
+  );
+  let untrustedRequests = 0;
+  untrustedServer = createHttpsServer(
+    { key: readFileSync(key), cert: readFileSync(cert) },
+    (_request, response) => {
+      untrustedRequests += 1;
+      response.writeHead(403).end();
+    },
+  );
+  untrustedServer.listen(0, '127.0.0.1');
+  await once(untrustedServer, 'listening');
+  const untrustedOrigin = `https://127.0.0.1:${untrustedServer.address().port}`;
+  let report;
+  let protectedRequests = 0;
+  let plainRequests = 0;
+  let subtitleRequests = 0;
+  let leakedHeaders = false;
+  let incorrectHeaders = false;
+  const hasPrivateHeader = (request) =>
+    Object.keys(headers).some((key) => request.headers[key.toLowerCase()] !== undefined);
+  server = createServer((request, response) => {
+    if (request.url === '/result') {
+      let body = '';
+      request.on('data', (chunk) => {
+        body += chunk;
+      });
+      request.on('end', () => {
+        response.end();
+        report(JSON.parse(body));
+      });
+      return;
+    }
+    if (request.url === '/subtitle.srt') {
+      subtitleRequests += 1;
+      leakedHeaders ||= hasPrivateHeader(request);
+      response.end('1\n00:00:00,000 --> 00:00:05,000\nSynthetic subtitle\n');
+      return;
+    }
+    if (request.url === '/protected.mp4') {
+      protectedRequests += 1;
+      if (
+        !Object.entries(headers).every(
+          ([key, value]) => request.headers[key.toLowerCase()] === value,
+        )
+      ) {
+        incorrectHeaders = true;
+        response.writeHead(403).end();
+        return;
+      }
+    } else if (request.url === '/plain.mp4') {
+      plainRequests += 1;
+      leakedHeaders ||= hasPrivateHeader(request);
+    } else {
+      response.writeHead(404).end();
+      return;
+    }
+    const range = request.headers.range?.match(/^bytes=(\d+)-(\d*)$/);
+    const start = range ? Number(range[1]) : 0;
+    const end = range?.[2] ? Math.min(Number(range[2]), bytes.length - 1) : bytes.length - 1;
+    response.writeHead(range ? 206 : 200, {
+      'Content-Type': 'video/mp4',
+      'Content-Length': end - start + 1,
+      'Accept-Ranges': 'bytes',
+      ...(range ? { 'Content-Range': `bytes ${start}-${end}/${bytes.length}` } : {}),
+    });
+    response.end(bytes.subarray(start, end + 1));
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const origin = `http://127.0.0.1:${server.address().port}`;
+  const document = join(root, 'check.html');
+  writeFileSync(
+    document,
+    `<!doctype html><meta charset="utf-8"><title>Kino header check</title>
+<style>body{background:#09090a;color:#f4f4f5;font:16px sans-serif;padding:40px}</style>
+<p>Checking native media requests.</p><script src="qrc:///qtwebchannel/qwebchannel.js"></script><script>
+const origin = ${JSON.stringify(origin)};
+const untrustedOrigin = ${JSON.stringify(untrustedOrigin)};
+const headers = ${JSON.stringify(headers)};
+function finish(value) { fetch(origin + '/result', {method:'POST',mode:'no-cors',body:JSON.stringify(value)}); }
+new QWebChannel(qt.webChannelTransport, function(channel) {
+  const native = channel.objects.kinoNative;
+  let stage = 'protected', hardware = false, reported = false;
+  native.playerEvent.connect(function(name, payload) {
+    if (reported) return;
+    if (name === 'hardwareDecoding') hardware = payload.active;
+    if (name === 'error') {
+      if (stage === 'tls') {
+        stage = 'invalid';
+        native.load(origin + '/protected.mp4', false, {'X-Bad': headers.Authorization + '\\r\\nInjected: value'});
+        return;
+      }
+      reported = true;
+      finish({ok:stage === 'invalid' && payload.code === 'invalid-request-headers', stage, code:payload.code});
+    } else if (name === 'time' && payload.milliseconds >= 1000 && hardware) {
+      if (stage === 'protected') {
+        stage = 'subtitle';
+        native.addSubtitles(origin + '/subtitle.srt', 'Synthetic subtitle', 'en');
+      } else if (stage === 'plain') {
+        stage = 'tls';
+        native.load(untrustedOrigin + '/protected.mp4', false, headers);
+      }
+    } else if (name === 'subtitleTracks' && stage === 'subtitle' && payload.items.some(item => item.external)) {
+      stage = 'plain'; hardware = false;
+      native.load(origin + '/plain.mp4', false, {});
+    }
+  });
+  native.load(origin + '/protected.mp4', false, headers);
+});
+</script>`,
+  );
+  const verdict = new Promise((resolveReport, reject) => {
+    report = resolveReport;
+    timeout = setTimeout(() => reject(new Error('Native header probe timed out.')), 20000);
+  });
+  child = spawn(binary, [], {
+    env: { ...process.env, KINO_UI_URL: document },
+    stdio: ['ignore', 'ignore', 'pipe'],
+  });
+  let diagnostics = '';
+  child.stderr.on('data', (data) => {
+    diagnostics += data;
+  });
+  const result = await verdict;
+  assert.ok(result.ok, `Native header probe failed at ${result.stage}: ${result.code}`);
+  assert.ok(protectedRequests > 0 && plainRequests > 0 && subtitleRequests > 0);
+  assert.equal(incorrectHeaders, false, 'The protected source must receive exact header values.');
+  assert.equal(leakedHeaders, false, 'Subtitles and later media must not receive source headers.');
+  assert.equal(untrustedRequests, 0, 'An untrusted TLS server must not receive request headers.');
+  assert.equal(
+    diagnostics.includes(secret),
+    false,
+    'Request credentials must not enter diagnostics.',
+  );
+  console.log(
+    'WebChannel -> libmpv header playback, subtitle isolation, next-source reset, TLS verification, and injection rejection passed.',
+  );
+} finally {
+  clearTimeout(timeout);
+  if (child && child.exitCode === null) {
+    const exited = once(child, 'exit');
+    child.kill('SIGTERM');
+    const force = setTimeout(() => child.kill('SIGKILL'), 3000);
+    await exited;
+    clearTimeout(force);
+  }
+  server?.closeAllConnections();
+  server?.close();
+  untrustedServer?.closeAllConnections();
+  untrustedServer?.close();
+  rmSync(root, { recursive: true, force: true });
+}


### PR DESCRIPTION
Direct sources with required HTTP headers were rewritten by Core into a proxy URL for the account's Stremio Service. Kino played that URL without starting a compatible service, so these sources failed on a fresh installation or used a stale account service address.

Pass the selected source's original HTTPS URL and request headers through WebChannel to libmpv. Validate header names, values and size; reject injection, duplicate names and routing overrides; and apply headers to the loaded media. Clear the player option after the media connection opens so external subtitles cannot inherit credentials. Subsequent sources receive their own header set. Enable TLS certificate verification before sending credentials, and omit free-form mpv message details after custom headers have been used while retaining structured playback events and failure codes.

Validation:

- Two real PlayerScreen/hook regressions failed with the old default and stale-service paths and now pass. Full `pnpm check` passes with 49 tests.
- The production QML/WebChannel/libmpv check plays a protected H.264 source, preserves literal comma/backslash header values, loads subtitles without source headers, plays a second source without header carryover, rejects CRLF injection, and finds no synthetic credentials in diagnostics.
- That native check caught subtitle header leakage and the disabled TLS verification default before their fixes. An untrusted TLS server now receives no HTTP request.
- CTest passes, including malformed-header cases and late-log privacy. All 15 existing native playback fixtures pass.

Closes #39.
