### PR TITLE
Keep torrent failure badges specific to the file and episode

### DIFF
--- a/apps/desktop/src/App.sourceFailure.test.tsx
+++ b/apps/desktop/src/App.sourceFailure.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, expect, it, vi } from 'vitest';
+
+import { App } from './App';
+import { CoreContext } from './core/context';
+import type { CoreTransport } from './core/transport';
+import type { CoreMetaItem, CoreRuntimeEvent } from './core/types';
+
+const meta: CoreMetaItem = {
+  id: 'show',
+  name: 'Test series',
+  type: 'series',
+  inLibrary: false,
+  watched: false,
+  videos: [
+    { id: 'ep1', title: 'Episode one', season: 1, episode: 1 },
+    { id: 'ep2', title: 'Episode two', season: 1, episode: 2 },
+  ],
+};
+const addon = {
+  manifest: { id: 'test', name: 'Test add-on' },
+  transportUrl: 'https://addon.invalid/manifest.json',
+};
+
+vi.mock('./screens/HomeScreen', () => ({
+  HomeScreen: ({ onOpen }: { onOpen: (item: CoreMetaItem, videoId: string) => void }) => (
+    <button onClick={() => onOpen(meta, 'ep1')}>Open test series</button>
+  ),
+}));
+vi.mock('./screens/PlayerScreen', () => ({
+  PlayerScreen: ({ onSourceFailure }: { onSourceFailure: (message: string) => void }) => (
+    <button onClick={() => onSourceFailure('Synthetic source failure')}>Fail playback</button>
+  ),
+}));
+
+beforeEach(() => {
+  window.localStorage.clear();
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+it('marks only the failed torrent file and keeps another episode independent', async () => {
+  let videoId = 'ep1';
+  const listeners = new Set<(event: CoreRuntimeEvent) => void>();
+  const transport: CoreTransport = {
+    destroy: vi.fn(),
+    init: vi.fn().mockResolvedValue(undefined),
+    dispatch: async (action, model) => {
+      if (model === 'meta_details' && action.action === 'Load') {
+        videoId = (action.args as { args: { streamPath: { id: string } } }).args.streamPath.id;
+        listeners.forEach((listener) => listener({ name: 'NewState', args: ['meta_details'] }));
+      }
+    },
+    getState: async <State,>(model: string) =>
+      (model === 'ctx'
+        ? { profile: { addons: [] } }
+        : {
+            selected: {
+              metaPath: { resource: 'meta', type: 'series', id: meta.id, extra: [] },
+              streamPath: { resource: 'stream', type: 'series', id: videoId, extra: [] },
+              guessStream: true,
+            },
+            metaItem: { addon, content: { type: 'Ready', content: meta } },
+            streams: [
+              {
+                addon,
+                content: {
+                  type: 'Ready',
+                  content: [0, 1].map((fileIdx) => ({
+                    infoHash: '0123456789abcdef0123456789abcdef01234567',
+                    fileIdx,
+                    name: `Pack file ${fileIdx}`,
+                    deepLinks: { player: '' },
+                  })),
+                },
+              },
+            ],
+          }) as State,
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+  render(
+    <CoreContext.Provider
+      value={{ error: null, status: 'ready', session: 'guest', transport, selectSession: vi.fn() }}
+    >
+      <App />
+    </CoreContext.Provider>,
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'Open test series' }));
+  const first = await screen.findByRole('button', { name: /Pack file 0/ });
+  await waitFor(() => expect(first).toBeEnabled());
+  fireEvent.click(first);
+  fireEvent.click(screen.getByRole('button', { name: 'Fail playback' }));
+  await waitFor(() =>
+    expect(
+      within(screen.getByRole('button', { name: /Pack file 0/ })).getByText('Failed'),
+    ).toBeInTheDocument(),
+  );
+  expect(
+    within(screen.getByRole('button', { name: /Pack file 1/ })).queryByText('Failed'),
+  ).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /Episode two/ }));
+  await waitFor(() => expect(screen.getByRole('button', { name: /Pack file 0/ })).toBeEnabled());
+  expect(screen.queryByText('Failed')).not.toBeInTheDocument();
+  expect(screen.queryByText('Synthetic source failure')).not.toBeInTheDocument();
+});

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -112,7 +112,7 @@ export function App() {
   const reportSourceFailure = useCallback(
     (message: string) => {
       if (playback) {
-        const key = sourceKey(playback.stream, playback.streamTransportUrl);
+        const key = sourceKey(playback.stream, playback.streamTransportUrl, playback);
         setFailedSources((previous) => new Map(previous).set(key, message));
       }
       setPlayback(null);

--- a/apps/desktop/src/core/sources.test.ts
+++ b/apps/desktop/src/core/sources.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, it } from 'vitest';
 import { classifySource, sourceKey, sourceSize } from './sources';
 
 const base = { deepLinks: { player: 'stremio:///player/value' } };
+const selection = {
+  meta: { id: 'show', type: 'series', name: 'Test series', inLibrary: false, watched: false },
+  video: { id: 'ep1', title: 'Episode one' },
+};
 
 describe('source compatibility', () => {
   it('distinguishes direct, torrent, external, and unsupported sources', () => {
@@ -19,12 +23,51 @@ describe('source compatibility', () => {
 
   it('keys sources by transport and stream identity', () => {
     const transport = 'https://addon.example/manifest.json';
-    expect(sourceKey({ ...base, url: 'https://example.com/video.mp4' }, transport)).toBe(
-      `${transport}|https://example.com/video.mp4`,
+    expect(
+      sourceKey({ ...base, url: 'https://example.com/video.mp4' }, transport, selection),
+    ).not.toBe(sourceKey({ ...base, url: 'https://example.com/other.mp4' }, transport, selection));
+  });
+
+  it('distinguishes pack files, guessed episodes and external destinations', () => {
+    const key = (stream: Parameters<typeof sourceKey>[0], video = selection.video) =>
+      sourceKey(stream, 'https://addon.invalid/manifest.json', { ...selection, video });
+    const torrent = { ...base, infoHash: 'ABC' };
+    expect(key({ ...torrent, fileIdx: 0 })).not.toBe(key({ ...torrent, fileIdx: 1 }));
+    expect(key(torrent)).not.toBe(key(torrent, { id: 'ep2', title: 'Episode two' }));
+    expect(key(torrent)).toBe(key({ ...torrent, infoHash: 'abc' }));
+    expect(key({ ...base, externalUrl: 'https://example.invalid/a' })).not.toBe(
+      key({ ...base, externalUrl: 'https://example.invalid/b' }),
     );
-    expect(sourceKey({ ...base, infoHash: 'abc' }, transport)).toBe(`${transport}|abc`);
-    expect(sourceKey({ ...base, url: 'https://example.com/video.mp4' }, transport)).not.toBe(
-      sourceKey({ ...base, url: 'https://example.com/other.mp4' }, transport),
+  });
+
+  it('keeps distinct request credentials separate without depending on header order or display labels', () => {
+    const stream = {
+      ...base,
+      url: 'https://media.invalid/movie.mp4',
+      behaviorHints: {
+        proxyHeaders: {
+          request: { Referer: 'https://addon.invalid/', Authorization: 'Bearer synthetic' },
+        },
+      },
+    };
+    const key = (source: Parameters<typeof sourceKey>[0]) =>
+      sourceKey(source, 'https://addon.invalid/manifest.json', selection);
+    expect(key(stream)).toBe(
+      key({
+        ...stream,
+        name: 'New label',
+        behaviorHints: {
+          proxyHeaders: {
+            request: { authorization: 'Bearer synthetic', referer: 'https://addon.invalid/' },
+          },
+        },
+      }),
+    );
+    expect(key(stream)).not.toBe(
+      key({
+        ...stream,
+        behaviorHints: { proxyHeaders: { request: { Authorization: 'Bearer other-synthetic' } } },
+      }),
     );
   });
 });

--- a/apps/desktop/src/core/sources.ts
+++ b/apps/desktop/src/core/sources.ts
@@ -1,3 +1,4 @@
+import type { PlaybackSelection } from './actions';
 import type { CoreStream } from './types';
 
 export type SourceSupport = 'direct' | 'external' | 'torrent' | 'unsupported';
@@ -9,8 +10,35 @@ export function classifySource(stream: CoreStream): SourceSupport {
   return 'unsupported';
 }
 
-export function sourceKey(stream: CoreStream, transportUrl: string) {
-  return `${transportUrl}|${stream.url ?? stream.infoHash ?? 'unknown'}`;
+export function sourceKey(
+  stream: CoreStream,
+  transportUrl: string,
+  selection: Pick<PlaybackSelection, 'meta' | 'video'>,
+) {
+  const requestHeaders = Object.entries(stream.behaviorHints?.proxyHeaders?.request ?? {})
+    .map(([name, value]): [string, string] => [name.toLowerCase(), value])
+    .sort(([left], [right]) => left.localeCompare(right));
+  const identity = stream.url
+    ? ['direct', stream.url, requestHeaders]
+    : stream.infoHash
+      ? [
+          'torrent',
+          stream.infoHash.toLowerCase(),
+          stream.fileIdx ?? null,
+          [...new Set(stream.sources ?? [])].sort(),
+        ]
+      : stream.externalUrl
+        ? ['external', stream.externalUrl]
+        : ['unsupported', stream.ytId ?? null, stream.playerFrameUrl ?? null];
+  // Explicit files in a pack and guesses for different episodes are separate
+  // attempts. Display metadata and progress do not change the source identity.
+  return JSON.stringify([
+    transportUrl,
+    selection.meta.type,
+    selection.meta.id,
+    selection.video?.id ?? selection.meta.id,
+    identity,
+  ]);
 }
 
 export function sourceTitle(stream: CoreStream) {

--- a/apps/desktop/src/screens/MetaDetailsScreen.tsx
+++ b/apps/desktop/src/screens/MetaDetailsScreen.tsx
@@ -134,6 +134,13 @@ export function MetaDetailsScreen({
     [result.state],
   );
   const display = meta ?? item;
+  const sourceSelection = { meta: display, video: activeVideo };
+  const visibleSourceKeys = new Set(
+    sources.map((source) => sourceKey(source.stream, source.transportUrl, sourceSelection)),
+  );
+  const currentFailure = sourcesCurrent
+    ? [...failedSources].findLast(([key]) => visibleSourceKeys.has(key))?.[1]
+    : null;
   const activeIndex = activeVideo ? videos.findIndex((video) => video.id === activeVideo.id) : -1;
   const nextEpisode = activeIndex >= 0 ? (videos[activeIndex + 1] ?? null) : null;
   const inLibrary = libraryOverride ?? display.inLibrary;
@@ -238,9 +245,9 @@ export function MetaDetailsScreen({
             <h2 id="sources-heading">{enUS.details.sources}</h2>
             {!sourcesCurrent && !result.error ? <span>{enUS.details.refreshing}</span> : null}
           </div>
-          {failedSources.size > 0 ? (
+          {currentFailure ? (
             <p className={styles.loadError} role="status">
-              {[...failedSources.values()].at(-1)}
+              {currentFailure}
             </p>
           ) : null}
           {sourcesCurrent && sources.length === 0 ? (
@@ -251,7 +258,9 @@ export function MetaDetailsScreen({
               const support = classifySource(source.stream);
               const playable =
                 (support === 'direct' || support === 'torrent') && Boolean(source.transportUrl);
-              const failed = failedSources.has(sourceKey(source.stream, source.transportUrl));
+              const failed = failedSources.has(
+                sourceKey(source.stream, source.transportUrl, sourceSelection),
+              );
               return (
                 <button
                   className={styles.sourceButton}


### PR DESCRIPTION
A failed torrent source was identified only by add-on URL and info hash. Files 0 and 1 in the same season pack therefore shared a failure badge, including when switching episodes.

Include title/video identity, torrent file index and tracker inputs in the source key. Direct streams retain their URL and canonical request headers; external destinations have distinct keys. Use the same identity when recording and displaying failures, and limit the failure notice to the active selection's sources.

Validation: an App/MetaDetailsScreen regression failed before the fix and now proves that failing file 0 leaves file 1 unmarked and that episode 2 has no inherited badge or error notice. Focused tests cover guessed files, hash normalization, external destinations and request-header identity. Full `pnpm check` passes with 52 tests and the production build.

Closes #74.
