### PR TITLE
Save final playback progress before player and native shutdown

### DIFF
--- a/apps/desktop/src/App.sourceFailure.test.tsx
+++ b/apps/desktop/src/App.sourceFailure.test.tsx
@@ -43,6 +43,9 @@ it('marks only the failed torrent file and keeps another episode independent', a
   const listeners = new Set<(event: CoreRuntimeEvent) => void>();
   const transport: CoreTransport = {
     destroy: vi.fn(),
+    flush: vi.fn().mockResolvedValue(undefined),
+    prepareClose: vi.fn().mockResolvedValue(undefined),
+    onBeforeDestroy: () => () => {},
     init: vi.fn().mockResolvedValue(undefined),
     dispatch: async (action, model) => {
       if (model === 'meta_details' && action.action === 'Load') {

--- a/apps/desktop/src/core/CoreProvider.tsx
+++ b/apps/desktop/src/core/CoreProvider.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+
+import { connectNativeLifecycle } from '../native/player';
 
 import { ensureGuestCatalog } from './bootstrap';
 import { CoreContext, type CoreContextValue } from './context';
@@ -17,6 +19,8 @@ function errorMessage(error: unknown) {
 }
 
 export function CoreProvider({ children }: { children: ReactNode }) {
+  const teardown = useRef(Promise.resolve());
+  const activeTransport = useRef<CoreTransport | null>(null);
   const [session, setSession] = useState<CoreSession>(() =>
     typeof window === 'undefined' ? 'guest' : loadSession(window.localStorage),
   );
@@ -32,14 +36,45 @@ export function CoreProvider({ children }: { children: ReactNode }) {
   });
 
   useEffect(() => {
+    let disposed = false;
+    let disconnect = () => {};
+    void connectNativeLifecycle()
+      .then((lifecycle) => {
+        if (!lifecycle || disposed) return;
+        const onClose = (requestId: number) => {
+          void (async () => {
+            await teardown.current;
+            await activeTransport.current?.prepareClose();
+            lifecycle.acknowledgeClose(requestId, true);
+          })().catch(() => lifecycle.acknowledgeClose(requestId, false));
+        };
+        lifecycle.closeRequested.connect(onClose);
+        lifecycle.setReady(true);
+        disconnect = () => {
+          lifecycle.setReady(false);
+          lifecycle.closeRequested.disconnect(onClose);
+        };
+      })
+      .catch(() => console.error('[kino:shutdown] native close service unavailable'));
+    return () => {
+      disposed = true;
+      disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
     if (typeof Worker === 'undefined') return;
 
     let disposed = false;
     const transport = createCoreTransport(session);
-    void transport
-      .init()
+    activeTransport.current = transport;
+    const previousTeardown = teardown.current;
+    void previousTeardown
       .then(async () => {
-        if (session === 'guest') await ensureGuestCatalog(transport);
+        if (!disposed) await transport.init();
+      })
+      .then(async () => {
+        if (!disposed && session === 'guest') await ensureGuestCatalog(transport);
       })
       .then(() => {
         if (!disposed) setRuntime({ error: null, session, status: 'ready', transport });
@@ -53,7 +88,11 @@ export function CoreProvider({ children }: { children: ReactNode }) {
 
     return () => {
       disposed = true;
-      transport.destroy();
+      teardown.current = previousTeardown
+        .then(() => transport.destroy())
+        .catch(() => {
+          console.error('[kino:core] session ended before all data could be saved');
+        });
     };
   }, [session]);
 

--- a/apps/desktop/src/core/core.worker.ts
+++ b/apps/desktop/src/core/core.worker.ts
@@ -2,6 +2,7 @@
 
 import Bridge from '@stremio/stremio-core-web/bridge.js';
 import wasmUrl from '@stremio/stremio-core-web/stremio_core_web_bg.wasm?url';
+import { PendingCoreWork, trackCoreSync } from './pendingWork';
 
 interface CoreWorkerScope extends DedicatedWorkerGlobalScope {
   app_version: string;
@@ -11,6 +12,7 @@ interface CoreWorkerScope extends DedicatedWorkerGlobalScope {
   encodeStream(stream: unknown): string | null;
   get_location_hash(): Promise<unknown>;
   getState(field: unknown): unknown;
+  flush(): Promise<void>;
   init(args: { appVersion: string; shellVersion: string | null }): Promise<void>;
   local_storage_get_item(key: string): Promise<unknown>;
   local_storage_remove_item(key: string): Promise<unknown>;
@@ -20,6 +22,9 @@ interface CoreWorkerScope extends DedicatedWorkerGlobalScope {
 
 const scope = self as unknown as CoreWorkerScope;
 const bridge = new Bridge(scope, scope);
+const work = new PendingCoreWork();
+scope.flush = () => work.flush();
+scope.fetch = trackCoreSync(scope.fetch.bind(scope), work);
 
 scope.init = async ({ appVersion, shellVersion }) => {
   scope.document = { baseURI: scope.location.href };
@@ -27,9 +32,10 @@ scope.init = async ({ appVersion, shellVersion }) => {
   scope.shell_version = shellVersion;
   scope.get_location_hash = () => bridge.call(['location', 'hash'], []);
   scope.local_storage_get_item = (key) => bridge.call(['localStorage', 'getItem'], [key]);
-  scope.local_storage_remove_item = (key) => bridge.call(['localStorage', 'removeItem'], [key]);
+  scope.local_storage_remove_item = (key) =>
+    work.track(bridge.call(['localStorage', 'removeItem'], [key]));
   scope.local_storage_set_item = (key, value) =>
-    bridge.call(['localStorage', 'setItem'], [key, value]);
+    work.track(bridge.call(['localStorage', 'setItem'], [key, value]));
 
   const loadedCore = await import('@stremio/stremio-core-web/stremio_core_web.js');
   const core =

--- a/apps/desktop/src/core/pendingWork.test.ts
+++ b/apps/desktop/src/core/pendingWork.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { PendingCoreWork, trackCoreSync } from './pendingWork';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((finish) => {
+    resolve = finish;
+  });
+  return { promise, resolve };
+}
+
+describe('Core persistence barrier', () => {
+  it('waits for work spawned after dispatch and after a previous write', async () => {
+    const work = new PendingCoreWork();
+    const first = deferred();
+    const second = deferred();
+    let done = false;
+    void Promise.resolve().then(() =>
+      work.track(first.promise).then(() => work.track(second.promise)),
+    );
+    const flushing = work.flush().then(() => {
+      done = true;
+    });
+    first.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(done).toBe(false);
+    second.resolve();
+    await flushing;
+    expect(done).toBe(true);
+  });
+
+  it('reports storage failure and permits a later successful retry', async () => {
+    const work = new PendingCoreWork();
+    void work.track(Promise.reject(new Error('quota'))).catch(() => undefined);
+    await expect(work.flush()).rejects.toThrow('could not save');
+    await work.track(Promise.resolve());
+    await expect(work.flush()).resolves.toBeUndefined();
+  });
+
+  it('bounds a stalled write without pretending it completed', async () => {
+    const work = new PendingCoreWork();
+    const stalled = deferred();
+    void work.track(stalled.promise);
+    await expect(work.flush(10)).rejects.toThrow('did not finish');
+    stalled.resolve();
+    await expect(work.flush()).resolves.toBeUndefined();
+  });
+
+  it('allows shutdown after failed account sync once local persistence finishes', async () => {
+    const work = new PendingCoreWork();
+    const fetchRequest: typeof fetch = async () => {
+      throw new TypeError('offline');
+    };
+    await expect(
+      trackCoreSync(fetchRequest, work)('https://api.strem.io/api/datastorePut'),
+    ).rejects.toThrow('offline');
+    await expect(work.flush()).resolves.toBeUndefined();
+  });
+});

--- a/apps/desktop/src/core/pendingWork.ts
+++ b/apps/desktop/src/core/pendingWork.ts
@@ -1,0 +1,63 @@
+// Core dispatch returns before its WASM futures finish. Track the work that
+// must outlive navigation or shutdown, including the storage bridge reply.
+export class PendingCoreWork {
+  readonly #pending = new Set<Promise<void>>();
+  #storageFailed = false;
+
+  track<Value>(operation: Promise<Value>, required = true): Promise<Value> {
+    const settled = operation.then(
+      () => undefined,
+      () => {
+        if (required) this.#storageFailed = true;
+      },
+    );
+    this.#pending.add(settled);
+    void settled.then(() => this.#pending.delete(settled));
+    return operation;
+  }
+
+  async flush(timeoutMs = 10000): Promise<void> {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const expired = new Promise<never>((_resolve, reject) => {
+      timeout = setTimeout(
+        () => reject(new Error('Core storage did not finish in time.')),
+        timeoutMs,
+      );
+    });
+    try {
+      for (;;) {
+        // spawn_local schedules WASM futures in microtasks. Give all resulting
+        // storage calls a chance to enter the set before declaring it drained.
+        await Promise.race([new Promise((resolve) => setTimeout(resolve, 0)), expired]);
+        if (this.#pending.size === 0) break;
+        await Promise.race([Promise.all(this.#pending), expired]);
+      }
+      if (this.#storageFailed) {
+        this.#storageFailed = false;
+        throw new Error('Core could not save data on this device.');
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export function trackCoreSync(fetchRequest: typeof fetch, work: PendingCoreWork): typeof fetch {
+  return (input, init) => {
+    const response = fetchRequest(input, init);
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    if (url.pathname.endsWith('/datastorePut')) {
+      // Core consumes response.text() before processing the sync result. Wait
+      // for the body too; receiving HTTP headers does not complete the write.
+      void work
+        .track(
+          response.then(async (value) => {
+            await value.clone().arrayBuffer();
+          }),
+          false,
+        )
+        .catch(() => undefined);
+    }
+    return response;
+  };
+}

--- a/apps/desktop/src/core/transport.shutdown.test.ts
+++ b/apps/desktop/src/core/transport.shutdown.test.ts
@@ -1,0 +1,52 @@
+import { expect, it, vi } from 'vitest';
+
+import { createCoreTransport } from './transport';
+
+const worker = vi.hoisted(() => ({ terminate: vi.fn(), call: vi.fn() }));
+vi.mock('./core.worker?worker', () => ({
+  default: class {
+    terminate = worker.terminate;
+  },
+}));
+vi.mock('@stremio/stremio-core-web/bridge.js', () => ({
+  default: class {
+    call = worker.call;
+  },
+}));
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((finish) => {
+    resolve = finish;
+  });
+  return { promise, resolve };
+}
+
+it('retains the worker through startup, final player save, and the storage acknowledgement', async () => {
+  const initialized = deferred();
+  const saved = deferred();
+  const drained = deferred();
+  worker.terminate.mockClear();
+  worker.call.mockImplementation(async ([method]: string[]) => {
+    if (method === 'init') await initialized.promise;
+    if (method === 'flush') await drained.promise;
+  });
+  const transport = createCoreTransport();
+  const init = transport.init();
+  const save = vi.fn(() => saved.promise);
+  transport.onBeforeDestroy(save);
+  const destroying = transport.destroy();
+  expect(transport.destroy()).toBe(destroying);
+  expect(save).not.toHaveBeenCalled();
+  initialized.resolve();
+  await init;
+  await Promise.resolve();
+  expect(save).toHaveBeenCalledOnce();
+  expect(worker.terminate).not.toHaveBeenCalled();
+  saved.resolve();
+  await Promise.resolve();
+  expect(worker.terminate).not.toHaveBeenCalled();
+  drained.resolve();
+  await destroying;
+  expect(worker.terminate).toHaveBeenCalledOnce();
+});

--- a/apps/desktop/src/core/transport.ts
+++ b/apps/desktop/src/core/transport.ts
@@ -13,10 +13,13 @@ import type { CoreAction, CoreModelName, CoreRuntimeEvent } from './types';
 type CoreEventListener = (event: CoreRuntimeEvent) => void;
 
 export interface CoreTransport {
-  destroy(): void;
+  destroy(): Promise<void>;
   dispatch(action: CoreAction, model?: CoreModelName): Promise<void>;
+  flush(): Promise<void>;
   getState<State>(model: CoreModelName): Promise<State>;
   init(): Promise<void>;
+  onBeforeDestroy(callback: () => Promise<void>): () => void;
+  prepareClose(): Promise<void>;
   subscribe(listener: CoreEventListener): () => void;
 }
 
@@ -91,21 +94,42 @@ export function createCoreTransport(session: CoreSession = 'guest'): CoreTranspo
     },
   };
   const bridge = new Bridge(scope, worker);
+  const beforeDestroy = new Set<() => Promise<void>>();
+  let initializing: Promise<void> | null = null;
+  const flush = () => bridge.call<void>(['flush'], []);
+  const prepareClose = async () => {
+    // Closing while Keychain/WASM startup is still running must also wait for
+    // initialization's storage work before terminating the worker.
+    await initializing?.catch(() => undefined);
+    await Promise.all([...beforeDestroy].map((callback) => callback()));
+    await flush();
+  };
+  let destroying: Promise<void> | null = null;
 
   return {
     destroy() {
-      listeners.clear();
-      worker.terminate();
+      destroying ??= prepareClose().finally(() => {
+        listeners.clear();
+        worker.terminate();
+      });
+      return destroying;
     },
     async dispatch(action, model) {
       await bridge.call(['dispatch'], [action, model, currentHash()]);
     },
+    flush,
     getState<State>(model: CoreModelName) {
       return bridge.call<State>(['getState'], [model]);
     },
-    async init() {
-      await bridge.call(['init'], [{ appVersion: '0.0.0', shellVersion: null }]);
+    init() {
+      initializing ??= bridge.call<void>(['init'], [{ appVersion: '0.0.0', shellVersion: null }]);
+      return initializing;
     },
+    onBeforeDestroy(callback) {
+      beforeDestroy.add(callback);
+      return () => beforeDestroy.delete(callback);
+    },
+    prepareClose,
     subscribe(listener) {
       listeners.add(listener);
       return () => listeners.delete(listener);

--- a/apps/desktop/src/core/useCoreModel.ts
+++ b/apps/desktop/src/core/useCoreModel.ts
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useState } from 'react';
+import { useCallback, useEffect, useEffectEvent, useRef, useState } from 'react';
 
 import { useCore } from './context';
 import type { CoreTransport } from './transport';
@@ -8,9 +8,10 @@ interface CoreModelResult<State> {
   error: string | null;
   loading: boolean;
   state: State | null;
+  unload(): Promise<void>;
 }
 
-interface CoreModelSnapshot<State> extends CoreModelResult<State> {
+interface CoreModelSnapshot<State> extends Omit<CoreModelResult<State>, 'unload'> {
   actionKey: string | null;
   transport: CoreTransport | null;
 }
@@ -32,11 +33,19 @@ export function useCoreModel<State>(
   model: CoreModelName,
   action: CoreAction | null,
   actionKey: string,
+  options?: { beforeUnload: (transport: CoreTransport, loaded: Promise<void>) => Promise<void> },
 ): CoreModelResult<State> {
   const { status, transport } = useCore();
   const dispatchLoad = useEffectEvent(async (target: CoreTransport, targetModel: CoreModelName) => {
     if (action) await target.dispatch(action, targetModel);
   });
+  const beforeUnload = useEffectEvent(async (target: CoreTransport, loaded: Promise<void>) => {
+    await options?.beforeUnload(target, loaded);
+  });
+  const managedUnload = Boolean(options?.beforeUnload);
+  const pendingUnload = useRef(Promise.resolve());
+  const release = useRef<() => Promise<void>>(() => Promise.resolve());
+  const unload = useCallback(() => release.current(), []);
   const [result, setResult] = useState<CoreModelSnapshot<State>>({
     actionKey: null,
     error: null,
@@ -69,10 +78,34 @@ export function useCoreModel<State>(
       if (event.name === 'NewState' && event.args.includes(model)) void read();
     };
     const unsubscribe = transport.subscribe(onEvent);
+    const loaded = managedUnload
+      ? pendingUnload.current.catch(() => undefined).then(() => dispatchLoad(transport, model))
+      : dispatchLoad(transport, model);
+    let closed: Promise<void> | null = null;
+    let unregister = () => {};
+    const close = () => {
+      if (closed) return closed;
+      closed = (async () => {
+        if (managedUnload) await beforeUnload(transport, loaded);
+        else await loaded.catch(() => undefined);
+        disposed = true;
+        unsubscribe();
+        await transport.dispatch({ action: 'Unload' }, model);
+        if (managedUnload) await transport.flush();
+        unregister();
+      })().catch((error: unknown) => {
+        closed = null;
+        throw error;
+      });
+      pendingUnload.current = closed;
+      return closed;
+    };
+    release.current = close;
+    if (managedUnload) unregister = transport.onBeforeDestroy(close);
 
     void (async () => {
       try {
-        await dispatchLoad(transport, model);
+        await loaded;
         await read();
       } catch (error) {
         console.error(`[kino:core] ${model} action failed`, errorMessage(error));
@@ -90,14 +123,21 @@ export function useCoreModel<State>(
     return () => {
       disposed = true;
       unsubscribe();
-      void transport.dispatch({ action: 'Unload' }, model).catch(() => undefined);
+      if (managedUnload) {
+        void close()
+          .catch(() => console.error('[kino:core] player shutdown could not save progress'))
+          .finally(unregister);
+      } else {
+        void transport.dispatch({ action: 'Unload' }, model).catch(() => undefined);
+      }
     };
-  }, [actionKey, model, status, transport]);
+  }, [actionKey, managedUnload, model, status, transport]);
 
   if (status !== 'ready' || !transport) {
-    return { error: null, loading: status === 'loading', state: null };
+    return { error: null, loading: status === 'loading', state: null, unload };
   }
-  if (result.actionKey === actionKey && result.transport === transport) return result;
+  if (result.actionKey === actionKey && result.transport === transport)
+    return { ...result, unload };
   // A new selection reloads the model. Keeping the previous state while that
   // happens stops the screen collapsing and losing its scroll position; a
   // different transport is a different session, so that state is dropped.
@@ -105,5 +145,6 @@ export function useCoreModel<State>(
     error: null,
     loading: true,
     state: result.transport === transport ? result.state : null,
+    unload,
   };
 }

--- a/apps/desktop/src/locales/en-US.ts
+++ b/apps/desktop/src/locales/en-US.ts
@@ -116,6 +116,7 @@ export const enUS = {
     inLibrary: 'In Library',
   },
   player: {
+    saveFailed: 'Progress could not be saved. Try closing playback again.',
     upNext: 'Up Next',
     chooseSource: 'Choose source',
     preparingTorrent: 'Finding peers for this torrent…',

--- a/apps/desktop/src/native/player.ts
+++ b/apps/desktop/src/native/player.ts
@@ -11,6 +11,7 @@ export interface NativeEngineEvent {
 export interface NativePlayer {
   addSubtitles(url: string, title: string, lang: string): void;
   load(url: string, forceStereo: boolean, headers: Record<string, string>): void;
+  pauseAndSnapshot(): Promise<{ duration: number; time: number }>;
   platform: string;
   playerEvent: NativePlayerEvent;
   seek(seconds: number): void;
@@ -34,6 +35,15 @@ export interface NativeDiagnostics {
   revealLogs(): Promise<boolean>;
 }
 
+export interface NativeLifecycle {
+  setReady(ready: boolean): void;
+  acknowledgeClose(requestId: number, saved: boolean): void;
+  closeRequested: {
+    connect(listener: (requestId: number) => void): void;
+    disconnect(listener: (requestId: number) => void): void;
+  };
+}
+
 export interface NativeSecureStore {
   clearStremioAuth(): Promise<boolean>;
   readStremioAuth(): Promise<{ ok: boolean; value: string }>;
@@ -41,6 +51,7 @@ export interface NativeSecureStore {
 }
 
 interface NativeShellConnection {
+  lifecycle: NativeLifecycle | null;
   diagnostics: NativeDiagnostics;
   player: NativePlayer;
   secureStore: NativeSecureStore;
@@ -49,6 +60,7 @@ interface NativeShellConnection {
 interface WebChannelResult {
   objects: {
     kinoDiagnostics?: NativeDiagnostics;
+    kinoLifecycle?: NativeLifecycle;
     kinoNative?: NativePlayer;
     kinoSecureStore?: NativeSecureStore;
   };
@@ -119,7 +131,12 @@ function connectNativeShell(): Promise<NativeShellConnection | null> {
             reject(new Error('Native shell services are unavailable.'));
             return;
           }
-          resolve({ diagnostics, player, secureStore });
+          resolve({
+            diagnostics,
+            player,
+            secureStore,
+            lifecycle: channel.objects.kinoLifecycle ?? null,
+          });
         });
       }),
   );
@@ -132,6 +149,10 @@ function connectNativeShell(): Promise<NativeShellConnection | null> {
 
 export async function connectNativePlayer() {
   return (await connectNativeShell())?.player ?? null;
+}
+
+export async function connectNativeLifecycle() {
+  return (await connectNativeShell())?.lifecycle ?? null;
 }
 
 export async function connectNativeDiagnostics() {

--- a/apps/desktop/src/screens/MetaDetailsScreen.test.tsx
+++ b/apps/desktop/src/screens/MetaDetailsScreen.test.tsx
@@ -62,6 +62,9 @@ function mountDetails(
   const dispatch = vi.fn<CoreTransport['dispatch']>().mockResolvedValue(undefined);
   const transport: CoreTransport = {
     destroy: vi.fn(),
+    flush: vi.fn().mockResolvedValue(undefined),
+    prepareClose: vi.fn().mockResolvedValue(undefined),
+    onBeforeDestroy: () => () => {},
     dispatch,
     init: vi.fn().mockResolvedValue(undefined),
     getState: async <State,>() => state as State,

--- a/apps/desktop/src/screens/PlayerScreen.shutdown.test.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.shutdown.test.tsx
@@ -1,0 +1,206 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CoreContext } from '../core/context';
+import { defaultSettings } from '../settings';
+import { PlayerScreen } from './PlayerScreen';
+
+const native = vi.hoisted(() => {
+  const listeners = new Set<(name: string, payload: Record<string, unknown>) => void>();
+  return {
+    listeners,
+    load: vi.fn(),
+    stop: vi.fn(),
+    pauseAndSnapshot: vi.fn(),
+    setSubtitleScale: vi.fn(),
+    setSubtitlePosition: vi.fn(),
+    setNowPlayingMetadata: vi.fn(),
+    playerEvent: {
+      connect: (listener: (name: string, payload: Record<string, unknown>) => void) =>
+        listeners.add(listener),
+      disconnect: (listener: (name: string, payload: Record<string, unknown>) => void) =>
+        listeners.delete(listener),
+    },
+  };
+});
+vi.mock('../native/player', () => ({
+  nativeShellPresent: () => true,
+  connectNativePlayer: async () => native,
+}));
+
+beforeEach(() => {
+  native.listeners.clear();
+  native.load.mockClear();
+  native.stop.mockClear();
+  native.pauseAndSnapshot.mockResolvedValue({ time: 0, duration: 0 });
+});
+
+async function mountPlayer() {
+  const calls: string[] = [];
+  const closing = new Set<() => Promise<void>>();
+  let holdFlush = false;
+  let finishFlush!: () => void;
+  const pending = new Promise<void>((resolve) => {
+    finishFlush = resolve;
+  });
+  const transport = {
+    init: vi.fn(),
+    destroy: vi.fn(),
+    dispatch: vi.fn(async (action: { action: string; args?: unknown }) => {
+      const args = action.args as { action?: string; args?: { time?: number } } | undefined;
+      calls.push(
+        action.action === 'Player' ? `${args?.action}:${args?.args?.time ?? ''}` : action.action,
+      );
+    }),
+    getState: async <State,>() =>
+      ({ selected: { stream }, stream: { type: 'Ready', content: stream } }) as State,
+    subscribe: () => () => {},
+    onBeforeDestroy: (callback: () => Promise<void>) => {
+      closing.add(callback);
+      return () => closing.delete(callback);
+    },
+    prepareClose: async () => {
+      await Promise.all([...closing].map((callback) => callback()));
+    },
+    flush: vi.fn(async () => {
+      calls.push('flush');
+      if (holdFlush) await pending;
+      calls.push('saved');
+    }),
+  };
+  const stream = { url: 'https://media.invalid/fixture.mp4', deepLinks: { player: '' } };
+  const onBack = vi.fn();
+  const onSourceFailure = vi.fn();
+  const onUpNext = vi.fn();
+  const nextVideo = { id: 'ep2', title: 'Episode two', season: 1, episode: 2 };
+  const view = render(
+    <StrictMode>
+      <CoreContext.Provider
+        value={{
+          error: null,
+          status: 'ready',
+          session: 'guest',
+          transport,
+          selectSession: vi.fn(),
+        }}
+      >
+        <PlayerScreen
+          selection={{
+            meta: {
+              id: 'show',
+              name: 'Test series',
+              type: 'series',
+              inLibrary: false,
+              watched: false,
+            },
+            stream,
+            streamTransportUrl: 'https://addon.invalid/manifest.json',
+            metaTransportUrl: 'https://addon.invalid/manifest.json',
+            video: { id: 'ep1', title: 'Episode one', season: 1, episode: 1 },
+            nextVideo,
+          }}
+          settings={defaultSettings}
+          preferredSubtitleLanguage={null}
+          onBack={onBack}
+          onSourceFailure={onSourceFailure}
+          onUpNext={onUpNext}
+          onSettingsChange={vi.fn()}
+        />
+      </CoreContext.Provider>
+    </StrictMode>,
+  );
+  await waitFor(() => expect(native.load).toHaveBeenCalled());
+  const emit = async (name: string, payload: Record<string, unknown> = {}) => {
+    await act(async () => {
+      native.listeners.forEach((listener) => listener(name, payload));
+    });
+  };
+  await emit('duration', { milliseconds: 120000 });
+  await emit('time', { milliseconds: 30000 });
+  await emit('time', { milliseconds: 34567 });
+  native.pauseAndSnapshot.mockResolvedValue({ time: 34567, duration: 120000 });
+  calls.length = 0;
+  holdFlush = true;
+  return {
+    calls,
+    closing,
+    emit,
+    finishFlush,
+    nextVideo,
+    onBack,
+    onSourceFailure,
+    onUpNext,
+    transport,
+    view,
+  };
+}
+
+describe('ordered playback shutdown', () => {
+  it('keeps playback open on a failed save and retries without losing the captured position', async () => {
+    const player = await mountPlayer();
+    native.stop.mockClear();
+    player.transport.flush.mockRejectedValueOnce(new Error('Storage is full.'));
+    fireEvent.click(screen.getByRole('button', { name: /Back/ }));
+    await screen.findByRole('alert');
+    expect(player.onBack).not.toHaveBeenCalled();
+    expect(player.calls).not.toContain('Unload');
+    expect(native.stop).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: /Back/ }));
+    await act(async () => player.finishFlush());
+    await waitFor(() => expect(player.onBack).toHaveBeenCalledOnce());
+    expect(player.calls.filter((call) => call === 'TimeChanged:34567')).toHaveLength(2);
+    expect(native.stop).toHaveBeenCalledOnce();
+  });
+
+  it('shares one save when Back and native close happen together', async () => {
+    const player = await mountPlayer();
+    fireEvent.click(screen.getByRole('button', { name: /Back/ }));
+    const closing = player.transport.prepareClose();
+    fireEvent.click(screen.getByRole('button', { name: /Back/ }));
+    await waitFor(() => expect(player.calls).toContain('TimeChanged:34567'));
+    await act(async () => {
+      player.finishFlush();
+      await closing;
+    });
+    expect(player.calls.filter((call) => call === 'TimeChanged:34567')).toHaveLength(1);
+    expect(player.calls.filter((call) => call === 'Unload')).toHaveLength(1);
+    expect(player.onBack).toHaveBeenCalledOnce();
+  });
+
+  it.each(['Back', 'failure', 'Up Next', 'native close', 'unmount'] as const)(
+    'saves the latest position before unload on %s',
+    async (exit) => {
+      const player = await mountPlayer();
+      let closing: Promise<void> | undefined;
+      if (exit === 'Back') fireEvent.click(screen.getByRole('button', { name: /Back/ }));
+      if (exit === 'failure') await player.emit('error', { code: 'decoder-or-stream-failed' });
+      if (exit === 'Up Next') {
+        await player.emit('ended');
+        fireEvent.click(screen.getByRole('button', { name: /Choose source/i }));
+      }
+      if (exit === 'native close') {
+        expect(player.closing.size).toBe(1);
+        closing = player.transport.prepareClose();
+      }
+      if (exit === 'unmount') player.view.unmount();
+      await waitFor(() => expect(player.calls).toContain('TimeChanged:34567'));
+      expect(player.calls).not.toContain('Unload');
+      expect(player.onBack).not.toHaveBeenCalled();
+      expect(player.onSourceFailure).not.toHaveBeenCalled();
+      expect(player.onUpNext).not.toHaveBeenCalled();
+      await act(async () => {
+        player.finishFlush();
+        await closing;
+      });
+      await waitFor(() => expect(player.calls).toContain('Unload'));
+      expect(player.calls.indexOf('TimeChanged:34567')).toBeLessThan(player.calls.indexOf('saved'));
+      expect(player.calls.indexOf('saved')).toBeLessThan(player.calls.indexOf('Unload'));
+      expect(player.calls.filter((call) => call === 'Unload')).toHaveLength(1);
+      if (exit === 'Back') expect(player.onBack).toHaveBeenCalledOnce();
+      if (exit === 'failure') expect(player.onSourceFailure).toHaveBeenCalledOnce();
+      if (exit === 'Up Next')
+        expect(player.onUpNext).toHaveBeenCalledExactlyOnceWith(player.nextVideo);
+    },
+  );
+});

--- a/apps/desktop/src/screens/PlayerScreen.test.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.test.tsx
@@ -8,6 +8,7 @@ import { PlayerScreen } from './PlayerScreen';
 
 const native = vi.hoisted(() => ({
   load: vi.fn(),
+  pauseAndSnapshot: vi.fn().mockResolvedValue({ time: 0, duration: 0 }),
   stop: vi.fn(),
   playerEvent: { connect: vi.fn(), disconnect: vi.fn() },
   setSubtitleScale: vi.fn(),
@@ -44,6 +45,9 @@ describe('native direct sources', () => {
       };
       const transport: CoreTransport = {
         destroy: vi.fn(),
+        flush: vi.fn().mockResolvedValue(undefined),
+        prepareClose: vi.fn().mockResolvedValue(undefined),
+        onBeforeDestroy: () => () => {},
         dispatch: vi.fn().mockResolvedValue(undefined),
         getState: async <State,>() => state as State,
         init: vi.fn().mockResolvedValue(undefined),

--- a/apps/desktop/src/screens/PlayerScreen.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.tsx
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styles from '../App.module.css';
 import { loadPlayerAction, playerAction, type PlaybackSelection } from '../core/actions';
 import { useCore } from '../core/context';
+import type { CoreTransport } from '../core/transport';
 import { classifySource } from '../core/sources';
 import type { CoreVideo, PlayerState } from '../core/types';
 import { useCoreModel } from '../core/useCoreModel';
@@ -130,14 +131,12 @@ export function PlayerScreen({
   settings: KinoSettings;
 }) {
   const { transport } = useCore();
-  const result = useCoreModel<PlayerState>(
-    'player',
-    loadPlayerAction(selection),
-    `${selection.meta.id}:${selection.video?.id ?? 'movie'}:${selection.streamTransportUrl}`,
-  );
   const containerRef = useRef<HTMLDivElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
   const playbackRef = useRef({ duration: 0, time: 0 });
+  const closingRef = useRef(false);
+  const navigationPendingRef = useRef(false);
+  const [shutdownError, setShutdownError] = useState<string | null>(null);
   const lastProgressRef = useRef(0);
   const resumeAppliedRef = useRef(false);
   const autoSkipSuppressedRef = useRef(false);
@@ -161,6 +160,12 @@ export function PlayerScreen({
   const [ended, setEnded] = useState(false);
   const [torrentUrl, setTorrentUrl] = useState<string | null>(null);
   const [engineUrl, setEngineUrl] = useState<string | null>(null);
+  const result = useCoreModel<PlayerState>(
+    'player',
+    loadPlayerAction(selection),
+    `${selection.meta.id}:${selection.video?.id ?? 'movie'}:${selection.streamTransportUrl}`,
+    { beforeUnload: (target, loaded) => saveBeforeUnload(target, loaded) },
+  );
   const stream = result.state?.stream?.type === 'Ready' ? result.state.stream.content : null;
   const isTorrent = stream ? classifySource(stream) === 'torrent' : false;
   // Core wraps direct streams with proxy headers in a URL for the account's
@@ -212,6 +217,7 @@ export function PlayerScreen({
 
   const reportProgress = useCallback(
     (isSeek = false) => {
+      if (closingRef.current) return;
       const video = videoRef.current;
       const progressDuration =
         video && Number.isFinite(video.duration)
@@ -229,20 +235,84 @@ export function PlayerScreen({
     [dispatchPlayer, nativeShell],
   );
 
+  async function saveBeforeUnload(target: CoreTransport, loaded: Promise<void>) {
+    closingRef.current = true;
+    setPaused(true);
+    setShutdownError(null);
+    try {
+      if (nativePlayer) {
+        const snapshot = await nativePlayer.pauseAndSnapshot();
+        if (
+          Number.isFinite(snapshot.duration) &&
+          snapshot.duration > 0 &&
+          Number.isFinite(snapshot.time)
+        ) {
+          playbackRef.current = snapshot;
+        }
+      } else if (videoRef.current) {
+        const video = videoRef.current;
+        playbackRef.current = {
+          duration: Math.round(video.duration * 1000),
+          time: Math.round(video.currentTime * 1000),
+        };
+        video.pause();
+      }
+      await loaded.catch(() => undefined);
+      const progress = playbackRef.current;
+      if (
+        Number.isFinite(progress.duration) &&
+        progress.duration > 0 &&
+        Number.isFinite(progress.time)
+      ) {
+        await target.dispatch(
+          playerAction('TimeChanged', {
+            ...progress,
+            device: nativeShell ? 'kino-macos' : 'kino-web',
+          }),
+          'player',
+        );
+      }
+      // TimeChanged is throttled by Core. PausedChanged forces the current
+      // library item into storage and account sync before Unload clears it.
+      await target.dispatch(playerAction('PausedChanged', { paused: true }), 'player');
+      await target.flush();
+      nativePlayer?.stop();
+    } catch (error) {
+      closingRef.current = false;
+      setShutdownError(enUS.player.saveFailed);
+      throw error;
+    }
+  }
+
+  const unloadPlayer = result.unload;
+  const finishPlayback = useCallback(
+    (navigate: () => void) => {
+      if (navigationPendingRef.current) return;
+      navigationPendingRef.current = true;
+      void unloadPlayer()
+        .then(navigate)
+        .catch(() => {
+          navigationPendingRef.current = false;
+          setShutdownError(enUS.player.saveFailed);
+        });
+    },
+    [unloadPlayer],
+  );
+
   // The contract on failure: save progress, record a sanitized diagnostic, mark
   // the source failed for this selection session, and return to the source list.
   const reportFailure = useCallback(
     (message: string, diagnostic: Record<string, unknown> = {}) => {
       if (failureReportedRef.current) return;
       failureReportedRef.current = true;
-      reportProgress();
       console.error('[kino:player] source failed', { message, ...diagnostic });
-      onSourceFailure(message);
+      finishPlayback(() => onSourceFailure(message));
     },
-    [onSourceFailure, reportProgress],
+    [finishPlayback, onSourceFailure],
   );
 
   const togglePlayback = useCallback(() => {
+    if (closingRef.current) return;
     if (nativePlayer) {
       const nextPaused = !paused;
       setPaused(nextPaused);
@@ -266,6 +336,7 @@ export function PlayerScreen({
 
   const seekTo = useCallback(
     (milliseconds: number) => {
+      if (closingRef.current) return;
       const safeTime = Math.max(0, milliseconds);
       updateTime(safeTime);
       if (nativePlayer) {
@@ -425,7 +496,9 @@ export function PlayerScreen({
 
   useEffect(() => {
     if (!nativePlayer || !streamUrl) return;
+    closingRef.current = false;
     const onEvent = (name: string, payload: Record<string, unknown>) => {
+      if (closingRef.current) return;
       if (name === 'time' && typeof payload.milliseconds === 'number') {
         const nextTime = payload.milliseconds;
         updateTime(nextTime);
@@ -466,7 +539,7 @@ export function PlayerScreen({
 
     return () => {
       nativePlayer.playerEvent.disconnect(onEvent);
-      nativePlayer.stop();
+      if (!closingRef.current) nativePlayer.stop();
     };
   }, [
     dispatchPlayer,
@@ -590,8 +663,6 @@ export function PlayerScreen({
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [enterFullscreen, nativePlayer, reportProgress, seekTo, toggleMuted, togglePlayback]);
 
-  useEffect(() => () => reportProgress(), [reportProgress]);
-
   const insideIntro = Boolean(marker && time >= marker.startMs && time < marker.endMs);
   const markerStyle = useMemo(() => {
     if (!marker || duration <= 0) return undefined;
@@ -660,7 +731,7 @@ export function PlayerScreen({
       ) : null}
 
       <div className={styles.playerTopbar}>
-        <button onClick={onBack} type="button">
+        <button onClick={() => finishPlayback(onBack)} type="button">
           <ArrowLeft aria-hidden size={18} />
           Back to sources
         </button>
@@ -671,6 +742,11 @@ export function PlayerScreen({
       </div>
 
       <div aria-live="polite">
+        {shutdownError ? (
+          <div className={styles.playerStatus} role="alert">
+            {shutdownError}
+          </div>
+        ) : null}
         {result.loading ? <div className={styles.playerStatus}>Preparing source…</div> : null}
         {nativeShell && !nativePlayer ? (
           <div className={styles.playerStatus}>Preparing native player…</div>
@@ -706,7 +782,8 @@ export function PlayerScreen({
           </strong>
           <button
             onClick={() => {
-              if (selection.nextVideo) onUpNext(selection.nextVideo);
+              const next = selection.nextVideo;
+              if (next) finishPlayback(() => onUpNext(next));
             }}
             type="button"
           >

--- a/apps/macos-shell/CMakeLists.txt
+++ b/apps/macos-shell/CMakeLists.txt
@@ -35,6 +35,7 @@ qt_add_executable(
   Kino
   MACOSX_BUNDLE
   ${KINO_ICON}
+  src/closecoordinator.cpp
   src/diagnostics.cpp
   src/logging.cpp
   src/main.cpp
@@ -52,6 +53,7 @@ qt_add_qml_module(
   VERSION 1.0
   QML_FILES qml/Main.qml qml/Probe.qml
   SOURCES
+    src/closecoordinator.h
     src/diagnostics.h
     src/mpvitem.h
     src/nowplaying.h
@@ -149,4 +151,13 @@ if(BUILD_TESTING)
   target_link_libraries(kino_logging_test PRIVATE Qt6::Core Qt6::Qml)
   add_test(NAME diagnostic_logging COMMAND kino_logging_test)
   set_tests_properties(diagnostic_logging PROPERTIES TIMEOUT 30)
+
+  qt_add_executable(
+    kino_closecoordinator_test
+    tests/closecoordinator_test.cpp
+    src/closecoordinator.cpp
+  )
+  target_include_directories(kino_closecoordinator_test PRIVATE src)
+  target_link_libraries(kino_closecoordinator_test PRIVATE Qt6::Qml Qt6::Test)
+  add_test(NAME ordered_shutdown COMMAND kino_closecoordinator_test)
 endif()

--- a/apps/macos-shell/qml/Main.qml
+++ b/apps/macos-shell/qml/Main.qml
@@ -17,6 +17,14 @@ ApplicationWindow {
     visible: true
     color: "#09090a"
     title: "Kino"
+    onClosing: function(close) {
+        close.accepted = lifecycle.requestClose()
+    }
+
+    CloseCoordinator {
+        id: lifecycle
+        onCloseApproved: root.close()
+    }
 
     function setFullscreen(enabled) {
         root.visibility = enabled ? Window.FullScreen : Window.Windowed
@@ -71,6 +79,10 @@ ApplicationWindow {
 
         function load(url, forceStereo, headers) {
             player.load(url, forceStereo, headers || {})
+        }
+
+        function pauseAndSnapshot() {
+            return player.pauseAndSnapshot()
         }
 
         function seek(seconds) {
@@ -156,6 +168,7 @@ ApplicationWindow {
             registerObject("kinoNative", nativeBridge)
             registerObject("kinoSecureStore", secureStore)
             registerObject("kinoDiagnostics", diagnostics)
+            registerObject("kinoLifecycle", lifecycle)
         }
     }
 

--- a/apps/macos-shell/src/closecoordinator.cpp
+++ b/apps/macos-shell/src/closecoordinator.cpp
@@ -1,0 +1,49 @@
+#include "closecoordinator.h"
+
+#include <QCoreApplication>
+#include <QEvent>
+
+CloseCoordinator::CloseCoordinator(QObject *parent) : QObject(parent) {
+    QCoreApplication::instance()->installEventFilter(this);
+    timeout_.setSingleShot(true);
+    timeout_.setInterval(15000);
+    connect(&timeout_, &QTimer::timeout, this, [this]() {
+        pending_ = false;
+        qWarning("[kino:shutdown] save acknowledgement timed out; window kept open");
+    });
+}
+
+void CloseCoordinator::setReady(bool ready) {
+    if (ready_ == ready) return;
+    ready_ = ready;
+    emit readyChanged();
+}
+
+bool CloseCoordinator::requestClose() {
+    if (approved_ || !ready_) return true;
+    if (!pending_) {
+        pending_ = true;
+        timeout_.start();
+        emit closeRequested(++requestId_);
+    }
+    return false;
+}
+
+void CloseCoordinator::acknowledgeClose(int requestId, bool saved) {
+    if (!pending_ || requestId != requestId_) return;
+    pending_ = false;
+    timeout_.stop();
+    if (!saved) {
+        qWarning("[kino:shutdown] progress save failed; window kept open");
+        return;
+    }
+    approved_ = true;
+    emit closeApproved();
+}
+
+bool CloseCoordinator::eventFilter(QObject *watched, QEvent *event) {
+    if (watched == QCoreApplication::instance() && event->type() == QEvent::Quit) {
+        return !requestClose();
+    }
+    return QObject::eventFilter(watched, event);
+}

--- a/apps/macos-shell/src/closecoordinator.h
+++ b/apps/macos-shell/src/closecoordinator.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <QObject>
+#include <QTimer>
+#include <QtQml/qqmlregistration.h>
+
+class CloseCoordinator : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+    Q_PROPERTY(bool ready READ ready WRITE setReady NOTIFY readyChanged)
+public:
+    explicit CloseCoordinator(QObject *parent = nullptr);
+    bool ready() const { return ready_; }
+    Q_INVOKABLE void setReady(bool ready);
+    Q_INVOKABLE bool requestClose();
+    Q_INVOKABLE void acknowledgeClose(int requestId, bool saved);
+
+signals:
+    void readyChanged();
+    void closeRequested(int requestId);
+    void closeApproved();
+
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
+private:
+    bool ready_ = false;
+    bool pending_ = false;
+    bool approved_ = false;
+    int requestId_ = 0;
+    QTimer timeout_;
+};

--- a/apps/macos-shell/src/main.cpp
+++ b/apps/macos-shell/src/main.cpp
@@ -1,4 +1,5 @@
 #include "logging.h"
+#include "closecoordinator.h"
 #include "mpvitem.h"
 #include "playbackprobe.h"
 #include "streamengine.h"
@@ -105,6 +106,21 @@ int main(int argc, char *argv[]) {
     QObject::connect(&engine, &QQmlApplicationEngine::objectCreationFailed, &app,
                      []() { QCoreApplication::exit(1); }, Qt::QueuedConnection);
     engine.loadFromModule("KinoShell", "Main");
+
+    const QString closeProbe = qEnvironmentVariable("KINO_CLOSE_PROBE");
+    if (!closeProbe.isEmpty() && !engine.rootObjects().isEmpty()) {
+        auto *window = qobject_cast<QQuickWindow *>(engine.rootObjects().first());
+        auto *lifecycle = window ? window->findChild<CloseCoordinator *>() : nullptr;
+        if (!lifecycle || (closeProbe != "window" && closeProbe != "quit")) return 1;
+        QObject::connect(lifecycle, &CloseCoordinator::readyChanged, &app,
+                         [window, lifecycle, closeProbe]() {
+            if (!lifecycle->ready()) return;
+            QTimer::singleShot(0, window, [window, closeProbe]() {
+                if (closeProbe == "quit") QCoreApplication::quit();
+                else window->close();
+            });
+        });
+    }
 
     qInfo("[kino:shell] native shell started architecture=arm64");
     return app.exec();

--- a/apps/macos-shell/src/mpvitem.cpp
+++ b/apps/macos-shell/src/mpvitem.cpp
@@ -365,6 +365,19 @@ void MpvItem::addSubtitles(const QString &url, const QString &title, const QStri
     }
 }
 
+QVariantMap MpvItem::pauseAndSnapshot() {
+    int paused = 1;
+    mpv_set_property(handle_, "pause", MPV_FORMAT_FLAG, &paused);
+    double time = 0;
+    double duration = 0;
+    mpv_get_property(handle_, "time-pos", MPV_FORMAT_DOUBLE, &time);
+    mpv_get_property(handle_, "duration", MPV_FORMAT_DOUBLE, &duration);
+    return {
+        {QStringLiteral("time"), std::isfinite(time) ? std::llround(std::max(0.0, time) * 1000) : 0},
+        {QStringLiteral("duration"), std::isfinite(duration) ? std::llround(std::max(0.0, duration) * 1000) : 0},
+    };
+}
+
 void MpvItem::seek(double seconds) {
     double safeSeconds = std::max(0.0, seconds);
     mpv_set_property_async(handle_, 0, "time-pos", MPV_FORMAT_DOUBLE, &safeSeconds);

--- a/apps/macos-shell/src/mpvitem.h
+++ b/apps/macos-shell/src/mpvitem.h
@@ -25,6 +25,7 @@ public:
 
     Q_INVOKABLE void addSubtitles(const QString &url, const QString &title, const QString &lang);
     Q_INVOKABLE void load(const QString &url, bool forceStereo, const QVariantMap &headers = {});
+    Q_INVOKABLE QVariantMap pauseAndSnapshot();
     Q_INVOKABLE void seek(double seconds);
     Q_INVOKABLE void setMuted(bool muted);
     Q_INVOKABLE void setPaused(bool paused);

--- a/apps/macos-shell/tests/closecoordinator_test.cpp
+++ b/apps/macos-shell/tests/closecoordinator_test.cpp
@@ -1,0 +1,63 @@
+#include "closecoordinator.h"
+
+#include <QCoreApplication>
+#include <QEvent>
+#include <QSignalSpy>
+#include <QtTest>
+
+class CloseCoordinatorTest : public QObject {
+    Q_OBJECT
+private slots:
+    void closeBeforeUiStarts() {
+        CloseCoordinator lifecycle;
+        QVERIFY(lifecycle.requestClose());
+    }
+
+    void waitsForMatchingSaveAcknowledgement() {
+        CloseCoordinator lifecycle;
+        QSignalSpy requested(&lifecycle, &CloseCoordinator::closeRequested);
+        QSignalSpy approved(&lifecycle, &CloseCoordinator::closeApproved);
+        lifecycle.setReady(true);
+        QVERIFY(!lifecycle.requestClose());
+        QVERIFY(!lifecycle.requestClose());
+        QCOMPARE(requested.size(), 1);
+        const int id = requested.first().first().toInt();
+        lifecycle.acknowledgeClose(id + 1, true);
+        QCOMPARE(approved.size(), 0);
+        lifecycle.acknowledgeClose(id, true);
+        QCOMPARE(approved.size(), 1);
+        QVERIFY(lifecycle.requestClose());
+    }
+
+    void failedSaveKeepsWindowOpenAndAllowsRetry() {
+        CloseCoordinator lifecycle;
+        QSignalSpy requested(&lifecycle, &CloseCoordinator::closeRequested);
+        QSignalSpy approved(&lifecycle, &CloseCoordinator::closeApproved);
+        lifecycle.setReady(true);
+        QVERIFY(!lifecycle.requestClose());
+        const int firstId = requested.first().first().toInt();
+        QTest::ignoreMessage(QtWarningMsg, "[kino:shutdown] progress save failed; window kept open");
+        lifecycle.acknowledgeClose(firstId, false);
+        QCOMPARE(approved.size(), 0);
+        QVERIFY(!lifecycle.requestClose());
+        QCOMPARE(requested.size(), 2);
+        lifecycle.acknowledgeClose(firstId, true);
+        QCOMPARE(approved.size(), 0);
+        lifecycle.acknowledgeClose(requested.last().first().toInt(), true);
+        QCOMPARE(approved.size(), 1);
+    }
+
+    void applicationQuitUsesTheSameSaveRequest() {
+        CloseCoordinator lifecycle;
+        QSignalSpy requested(&lifecycle, &CloseCoordinator::closeRequested);
+        lifecycle.setReady(true);
+        QEvent quit(QEvent::Quit);
+        QVERIFY(QCoreApplication::sendEvent(QCoreApplication::instance(), &quit));
+        QCOMPARE(requested.size(), 1);
+        QVERIFY(!lifecycle.requestClose());
+        QCOMPARE(requested.size(), 1);
+    }
+};
+
+QTEST_GUILESS_MAIN(CloseCoordinatorTest)
+#include "closecoordinator_test.moc"

--- a/docs/PLAYBACK.md
+++ b/docs/PLAYBACK.md
@@ -55,6 +55,10 @@ TV playback is always fullscreen. Back first closes the active menu or hides con
 
 Continue Watching resumes at saved progress. Media details also offers Start Over. Playback updates progress through Stremio Core when signed in and locally for guests.
 
+Back, source failure, Up Next, window close, and application Quit share the same shutdown sequence. Kino pauses playback, captures the current position, sends the final progress and pause actions to Core, and waits for storage writes and pending library sync requests before unloading the player. The macOS shell keeps WebEngine alive until this sequence acknowledges completion. Failed local saves keep playback open for retry; failed account requests leave the locally saved progress available.
+
+`pnpm core:check-shutdown` runs the pinned Core WASM with guest and synthetic account profiles, delayed storage acknowledgements, and delayed sync response bodies. `pnpm macos:check-shutdown` checks window close and application Quit against a running shell and libmpv using the legal H.264 fixture. Set `KINO_FIXTURES_DIR` when the fixtures are outside `build/fixtures`.
+
 ## Intro behavior
 
 Marker resolution uses this order:

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   },
   "scripts": {
     "build": "pnpm --filter @kino/desktop build",
-    "check": "pnpm format:check && pnpm lint && pnpm typecheck && pnpm test && pnpm core:check-streams && pnpm engine:check-vendor && pnpm build",
+    "check": "pnpm format:check && pnpm lint && pnpm typecheck && pnpm test && pnpm core:check-streams && pnpm core:check-shutdown && pnpm engine:check-vendor && pnpm build",
     "core:check-streams": "node scripts/check-core-streams.mjs",
+    "core:check-shutdown": "node scripts/check-core-shutdown.mjs",
     "dev": "pnpm --filter @kino/desktop dev",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
@@ -27,6 +28,7 @@
     "macos:check-launch": "./scripts/check-macos-launch.sh",
     "macos:check-playback": "node scripts/check-macos-playback.mjs",
     "macos:check-request-headers": "node scripts/check-macos-request-headers.mjs",
+    "macos:check-shutdown": "node scripts/check-macos-shutdown.mjs",
     "macos:package": "node scripts/package-macos.mjs",
     "test": "pnpm --filter @kino/desktop test",
     "typecheck": "pnpm --filter @kino/desktop typecheck"

--- a/scripts/check-core-shutdown.mjs
+++ b/scripts/check-core-shutdown.mjs
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+
+import { playerAction } from '../apps/desktop/src/core/actions.ts';
+import { PendingCoreWork, trackCoreSync } from '../apps/desktop/src/core/pendingWork.ts';
+import { initializeCore, resolveCoreStream } from './test-support/core-stream.mjs';
+
+const mode = process.argv[2];
+if (!mode) {
+  const initializedStorage = new Map();
+  const defaults = (await initializeCore({ storage: initializedStorage })).get_state('ctx').profile
+    .settings;
+  for (const session of ['guest', 'account']) {
+    const result = spawnSync(
+      process.execPath,
+      [
+        process.argv[1],
+        session,
+        JSON.stringify(defaults),
+        initializedStorage.get('schema_version'),
+      ],
+      {
+        stdio: 'inherit',
+        timeout: 15000,
+      },
+    );
+    assert.equal(result.status, 0, `${session} Core shutdown check failed.`);
+  }
+  process.exit(0);
+} else {
+  const storage = new Map([['schema_version', process.argv[4]]]);
+  if (mode === 'account') {
+    storage.set(
+      'profile',
+      JSON.stringify({
+        auth: {
+          key: 'synthetic-account-never-sent-to-a-network',
+          user: {
+            _id: 'synthetic-account',
+            email: 'fixture@kino.invalid',
+            lastModified: '2026-01-01T00:00:00Z',
+            dateRegistered: '2026-01-01T00:00:00Z',
+            premium_expire: null,
+            gdpr_consent: { tos: true, privacy: true, marketing: false, from: null },
+          },
+        },
+        addons: [],
+        settings: JSON.parse(process.argv[3]),
+      }),
+    );
+  }
+  const core = await initializeCore({ storage });
+  assert.equal(Boolean(core.get_state('ctx').profile.auth), mode === 'account');
+  const work = new PendingCoreWork();
+  let held = false;
+  const storageGate = Promise.withResolvers();
+  const syncGate = Promise.withResolvers();
+  const finalSyncStarted = Promise.withResolvers();
+  const synced = [];
+  globalThis.local_storage_set_item = (key, value) =>
+    work.track(
+      (async () => {
+        if (held) await storageGate.promise;
+        storage.set(key, value);
+      })(),
+    );
+  const metadataFetch = globalThis.fetch;
+  globalThis.fetch = trackCoreSync(async (request) => {
+    if (!request.url.endsWith('/datastorePut')) return metadataFetch(request);
+    const { changes } = await request.clone().json();
+    if (held) finalSyncStarted.resolve();
+    // Deliver HTTP headers immediately, but withhold the response body until
+    // the fixture has accepted the write. Shutdown must await both.
+    return new Response(
+      new ReadableStream({
+        async start(controller) {
+          if (held) await syncGate.promise;
+          synced.push(...changes);
+          controller.enqueue(new TextEncoder().encode('{"result":{"success":true}}'));
+          controller.close();
+        },
+      }),
+    );
+  }, work);
+  await resolveCoreStream(core, { url: 'https://media.invalid/fixture.mp4' });
+  const progress = (time) =>
+    core.dispatch(
+      playerAction('TimeChanged', { time, duration: 120000, device: 'kino-macos' }),
+      'player',
+      '',
+    );
+  progress(30000);
+  await work.flush();
+  core.dispatch({ action: 'Unload' }, 'player', '');
+  progress(34567);
+  await work.flush();
+  const savedTime = () =>
+    JSON.parse(storage.get('library_recent')).items['kino-fixture'].state.timeOffset;
+  assert.equal(
+    savedTime(),
+    30000,
+    'The old Unload-before-TimeChanged order must reproduce the lost position.',
+  );
+
+  await resolveCoreStream(core, { url: 'https://media.invalid/fixture.mp4' });
+  held = true;
+  progress(34567);
+  core.dispatch(playerAction('PausedChanged', { paused: true }), 'player', '');
+  let flushed = false;
+  const flushing = work.flush().then(() => {
+    flushed = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(flushed, false, 'Flush must wait for the storage bridge acknowledgement.');
+  assert.equal(savedTime(), 30000);
+  storageGate.resolve();
+  if (mode === 'account') {
+    await finalSyncStarted.promise;
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.equal(flushed, false, 'Flush must wait for the account write response body.');
+  }
+  syncGate.resolve();
+  await flushing;
+  assert.equal(savedTime(), 34567);
+  if (mode === 'account') assert.equal(synced.at(-1).state.timeOffset, 34567);
+  core.dispatch({ action: 'Unload' }, 'player', '');
+  await work.flush();
+  assert.equal(savedTime(), 34567);
+  console.log(
+    `Pinned Core ${mode} shutdown saved 34,567 ms before unload and awaited storage${mode === 'account' ? ' and account sync' : ''}.`,
+  );
+  // Core owns repeating runtime timers, as it does in its browser worker.
+  process.exit(0);
+}

--- a/scripts/check-macos-shutdown.mjs
+++ b/scripts/check-macos-shutdown.mjs
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const binary = resolve('build/macos/Kino.app/Contents/MacOS/Kino');
+const fixtures = process.env.KINO_FIXTURES_DIR ?? resolve('build/fixtures');
+const media = join(fixtures, 'h264-sdr-aac.mp4');
+assert.ok(existsSync(binary), 'Build the macOS shell first.');
+assert.ok(existsSync(media), 'Generate the legal playback fixtures first.');
+const root = mkdtempSync(join(tmpdir(), 'kino-shutdown-'));
+try {
+  for (const mode of ['window', 'quit']) {
+    let child;
+    let timeout;
+    let requests = 0;
+    let snapshot;
+    let stillOpenDuringSave = false;
+    const server = createServer((request, response) => {
+      if (request.url !== '/save') {
+        response.writeHead(404).end();
+        return;
+      }
+      requests += 1;
+      let body = '';
+      request.on('data', (chunk) => {
+        body += chunk;
+      });
+      request.on('end', () => {
+        snapshot = JSON.parse(body);
+        setTimeout(() => {
+          stillOpenDuringSave = child.exitCode === null && child.signalCode === null;
+          response.setHeader('Access-Control-Allow-Origin', '*');
+          response.end('saved');
+        }, 500);
+      });
+    });
+    try {
+      server.listen(0, '127.0.0.1');
+      await once(server, 'listening');
+      const origin = `http://127.0.0.1:${server.address().port}`;
+      const document = join(root, `${mode}.html`);
+      writeFileSync(
+        document,
+        `<!doctype html><meta charset="utf-8"><title>Kino shutdown check</title>
+<script src="qrc:///qtwebchannel/qwebchannel.js"></script><script>
+new QWebChannel(qt.webChannelTransport, function(channel) {
+  const native = channel.objects.kinoNative, lifecycle = channel.objects.kinoLifecycle;
+  let ready = false;
+  native.playerEvent.connect(function(name, payload) {
+    if (!ready && name === 'time' && payload.milliseconds >= 500) {
+      ready = true;
+      lifecycle.setReady(true);
+    }
+  });
+  lifecycle.closeRequested.connect(async function(id) {
+    const snapshot = await native.pauseAndSnapshot();
+    await fetch(${JSON.stringify(origin + '/save')}, {method:'POST',body:JSON.stringify(snapshot)});
+    native.stop();
+    lifecycle.acknowledgeClose(id, true);
+  });
+  native.load(${JSON.stringify(pathToFileURL(media).href)}, false, {});
+});
+</script>`,
+      );
+      child = spawn(binary, [], {
+        env: { ...process.env, KINO_UI_URL: document, KINO_CLOSE_PROBE: mode },
+        stdio: ['ignore', 'ignore', 'pipe'],
+      });
+      let diagnostics = '';
+      child.stderr.on('data', (data) => {
+        diagnostics += data;
+      });
+      const result = await Promise.race([
+        once(child, 'exit'),
+        new Promise((_resolve, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error(`${mode} shutdown timed out: ${diagnostics}`)),
+            15000,
+          );
+        }),
+      ]);
+      assert.deepEqual(result, [0, null], `${mode} must exit normally: ${diagnostics}`);
+      assert.equal(requests, 1, `${mode} must save exactly once.`);
+      assert.equal(stillOpenDuringSave, true, `${mode} must keep WebEngine alive until saved.`);
+      assert.ok(
+        snapshot.time >= 500 && snapshot.duration > snapshot.time,
+        'Capture the actual libmpv position before stopping.',
+      );
+      console.log(
+        `Native ${mode} awaited the save acknowledgement with playback paused at ${snapshot.time} ms.`,
+      );
+    } finally {
+      clearTimeout(timeout);
+      if (child && child.exitCode === null && child.signalCode === null) {
+        const exited = once(child, 'exit');
+        child.kill('SIGKILL');
+        await exited;
+      }
+      server.closeAllConnections();
+      server.close();
+    }
+  }
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/scripts/test-support/core-stream.mjs
+++ b/scripts/test-support/core-stream.mjs
@@ -7,7 +7,7 @@ const require = createRequire(new URL('../../apps/desktop/package.json', import.
 
 // Run the pinned WASM serializer with synthetic metadata and in-memory storage.
 // Every Core fetch stays in this fixture; it never contacts an add-on or account.
-export async function initializeCore() {
+export async function initializeCore({ storage = new Map() } = {}) {
   Object.assign(globalThis, {
     WorkerGlobalScope: { [Symbol.hasInstance]: () => true },
     self: globalThis,
@@ -17,7 +17,6 @@ export async function initializeCore() {
     shell_version: null,
     get_location_hash: async () => '',
   });
-  const storage = new Map();
   globalThis.local_storage_get_item = async (key) => storage.get(key) ?? null;
   globalThis.local_storage_set_item = async (key, value) => storage.set(key, value);
   globalThis.local_storage_remove_item = async (key) => storage.delete(key);


### PR DESCRIPTION
Closing playback could unload Core before its final progress update, so a session at 34,567 ms resumed at the previous 30,000 ms report. Window close and application Quit could also destroy WebEngine without running the React cleanup.

Playback now pauses and captures the latest position, sends final progress and pause actions, awaits storage acknowledgements and library sync response bodies, then unloads Core. Back, source failure, Up Next, unmount, and native shutdown share this operation. The macOS shell intercepts window close and Quit until the UI acknowledges completion. Failed local saves keep playback open for retry; failed account requests retain local progress. Worker teardown also waits for initialization and pending saves.

Validation:

- `pnpm check`: 64 tests, format, lint, typecheck, pinned Core stream and shutdown checks, engine vendor checks, and production build passed.
- The real Core WASM reproduces the old lost position and verifies 34,567 ms in both guest storage and a synthetic account sync. Delayed storage replies and HTTP response bodies hold shutdown open.
- `pnpm macos:build`, all three CTest suites, and `pnpm macos:check-shutdown` passed. A running Qt window and libmpv paused at 583 ms and waited for the save acknowledgement on both window close and application Quit.
- The existing protected-stream playback check passed, including exact request headers, subtitle isolation, subsequent-source reset, TLS verification, and injection rejection.

Closes #36.
