### PR TITLE
Enforce secure add-on requests before network transmission

### DIFF
--- a/apps/desktop/src/core/addonNetwork.test.ts
+++ b/apps/desktop/src/core/addonNetwork.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { addonTransportIssue, createAddonNetwork } from './addonNetwork';
+
+describe('add-on transport policy', () => {
+  it('gives Core a network failure without triggering its credential-bearing rejection logs', async () => {
+    const fetchRequest = vi.fn<typeof fetch>().mockRejectedValue(new TypeError('offline'));
+    const network = createAddonNetwork(fetchRequest, false);
+    const result = await network.coreFetch('https://addon.invalid/synthetic-token/manifest.json');
+    expect(result.status).toBe(502);
+    const blocked = await network.coreFetch('http://addon.invalid/synthetic-token/manifest.json');
+    expect(blocked.status).toBe(403);
+    expect(fetchRequest).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    'http://remote.invalid/manifest.json',
+    'http://localhost.remote.invalid/manifest.json',
+    'http://127.0.0.1.remote.invalid/manifest.json',
+    'http://192.168.1.1/manifest.json',
+    'file:///manifest.json',
+    'ftp://remote.invalid/manifest.json',
+    'https://account:secret@remote.invalid/manifest.json',
+    'not a URL',
+  ])('blocks %s before transmission, including in development', async (url) => {
+    const fetchRequest = vi.fn<typeof fetch>();
+    await expect(createAddonNetwork(fetchRequest, true).fetch(url)).rejects.toThrow();
+    expect(fetchRequest).not.toHaveBeenCalled();
+  });
+
+  it.each(['localhost', '127.0.0.1', '127.20.30.40', '[::1]'])(
+    'permits HTTP to %s only in development',
+    async (host) => {
+      const url = `http://${host}:7000/manifest.json`;
+      const fetchRequest = vi.fn<typeof fetch>().mockResolvedValue(Response.json({}));
+      await expect(createAddonNetwork(fetchRequest, false).fetch(url)).rejects.toThrow();
+      expect(fetchRequest).not.toHaveBeenCalled();
+      await createAddonNetwork(fetchRequest, true).fetch(url);
+      expect(fetchRequest).toHaveBeenCalledOnce();
+      expect(addonTransportIssue(url, true)).toBeNull();
+    },
+  );
+
+  it('overrides redirect following in Request and init before the network call', async () => {
+    const url = 'https://addon.invalid/configuration-token/manifest.json';
+    const fetchRequest = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { Location: 'http://insecure.invalid/manifest.json' },
+      }),
+    );
+    const network = createAddonNetwork(fetchRequest, false);
+    await expect(
+      network.fetch(new Request(url, { redirect: 'follow' }), { redirect: 'follow' }),
+    ).rejects.toThrow('redirects are blocked');
+    expect(fetchRequest).toHaveBeenCalledOnce();
+    expect(fetchRequest.mock.calls[0]?.[1]?.redirect).toBe('manual');
+    expect(network.describeAddon({ transportUrl: url }).transportIssue).toBe('redirect');
+    expect(
+      network.describeAddon({ transportUrl: 'https://addon.invalid/another-token/manifest.json' })
+        .transportIssue,
+    ).toBeNull();
+  });
+
+  it('reports opaque redirects and clears the block when the request succeeds', async () => {
+    const url = 'https://addon.invalid/token/catalog/movie/top.json';
+    const onChange = vi.fn();
+    const fetchRequest = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce({ type: 'opaqueredirect', status: 0 } as Response)
+      .mockResolvedValueOnce(Response.json({ metas: [] }));
+    const network = createAddonNetwork(fetchRequest, false, onChange);
+    const addon = { transportUrl: 'https://addon.invalid/token/manifest.json' };
+    await expect(network.fetch(url)).rejects.toThrow('redirects are blocked');
+    expect(network.describeAddon(addon).transportIssue).toBe('redirect');
+    await network.fetch(url);
+    expect(network.describeAddon(addon).transportIssue).toBeNull();
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/core/addonNetwork.ts
+++ b/apps/desktop/src/core/addonNetwork.ts
@@ -1,0 +1,88 @@
+export type AddonTransportIssue = 'invalid' | 'insecure' | 'redirect';
+
+export function addonTransportIssue(
+  value: string,
+  development: boolean,
+): AddonTransportIssue | null {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return 'invalid';
+  }
+  if (url.username || url.password) return 'invalid';
+  if (url.protocol === 'https:') return null;
+  const loopback =
+    url.hostname === 'localhost' ||
+    url.hostname === '[::1]' ||
+    /^127\.\d+\.\d+\.\d+$/.test(url.hostname);
+  if (development && url.protocol === 'http:' && loopback) return null;
+  return 'insecure';
+}
+
+export class AddonTransportError extends Error {
+  readonly issue: AddonTransportIssue;
+
+  constructor(issue: AddonTransportIssue) {
+    // These messages can pass through Core diagnostics. Never include a URL,
+    // since configured add-ons commonly carry account tokens in the path.
+    super(
+      issue === 'redirect'
+        ? 'Add-on redirects are blocked. Use the final HTTPS manifest URL.'
+        : 'Add-on requests require HTTPS.',
+    );
+    this.issue = issue;
+  }
+}
+
+export function createAddonNetwork(
+  fetchRequest: typeof fetch,
+  development: boolean,
+  onChange = () => {},
+) {
+  const blocked = new Map<string, AddonTransportIssue>();
+  const reject = (url: string, issue: AddonTransportIssue): never => {
+    if (blocked.get(url) !== issue) {
+      blocked.set(url, issue);
+      if (blocked.size > 128) blocked.delete(blocked.keys().next().value!);
+      onChange();
+    }
+    throw new AddonTransportError(issue);
+  };
+
+  const request: typeof fetch = async (input, init) => {
+    const url = input instanceof Request ? input.url : String(input);
+    const issue = addonTransportIssue(url, development);
+    if (issue) return reject(url, issue);
+    // Browsers conceal Location on manual cross-origin redirects. Reject the
+    // response without following it, even when the caller asks for follow.
+    const response = await fetchRequest(input, { ...init, redirect: 'manual' });
+    if (response.type === 'opaqueredirect' || (response.status >= 300 && response.status < 400)) {
+      return reject(url, 'redirect');
+    }
+    if (blocked.delete(url)) onChange();
+    return response;
+  };
+
+  return {
+    fetch: request,
+    // Core logs the full request URL and body when fetch rejects. Local HTTP
+    // errors preserve failure handling without logging configured add-on
+    // tokens or account request bodies (403 for policy, 502 for network).
+    coreFetch: (async (input, init) => {
+      try {
+        return await request(input, init);
+      } catch (error) {
+        return new Response(null, { status: error instanceof AddonTransportError ? 403 : 502 });
+      }
+    }) as typeof fetch,
+    describeAddon<Addon extends { transportUrl: string }>(addon: Addon) {
+      let issue = addonTransportIssue(addon.transportUrl, development);
+      if (!issue) {
+        const base = new URL('.', addon.transportUrl).href;
+        issue = [...blocked].find(([url]) => url.startsWith(base))?.[1] ?? null;
+      }
+      return { ...addon, transportIssue: issue };
+    },
+  };
+}

--- a/apps/desktop/src/core/bootstrap.ts
+++ b/apps/desktop/src/core/bootstrap.ts
@@ -1,4 +1,5 @@
 import type { CoreTransport } from './transport';
+import { createAddonNetwork } from './addonNetwork';
 import type { ProfileState } from './types';
 
 const CINEMETA_MANIFEST_URL = 'https://v3-cinemeta.strem.io/manifest.json';
@@ -16,9 +17,12 @@ export async function ensureGuestCatalog(transport: CoreTransport) {
   const context = await transport.getState<ProfileState>('ctx');
   if (context.profile.addons.length > 0) return;
 
-  const response = await fetch(CINEMETA_MANIFEST_URL, {
-    headers: { Accept: 'application/json' },
-  });
+  const response = await createAddonNetwork(fetch, import.meta.env.DEV).fetch(
+    CINEMETA_MANIFEST_URL,
+    {
+      headers: { Accept: 'application/json' },
+    },
+  );
   if (!response.ok) throw new Error(`Cinemeta manifest returned ${response.status}.`);
   const manifest: unknown = await response.json();
   if (!isManifest(manifest)) throw new Error('Cinemeta returned an invalid manifest.');

--- a/apps/desktop/src/core/core.worker.ts
+++ b/apps/desktop/src/core/core.worker.ts
@@ -2,7 +2,9 @@
 
 import Bridge from '@stremio/stremio-core-web/bridge.js';
 import wasmUrl from '@stremio/stremio-core-web/stremio_core_web_bg.wasm?url';
+import { createAddonNetwork } from './addonNetwork';
 import { PendingCoreWork, trackCoreSync } from './pendingWork';
+import type { ProfileState } from './types';
 
 interface CoreWorkerScope extends DedicatedWorkerGlobalScope {
   app_version: string;
@@ -42,11 +44,24 @@ scope.init = async ({ appVersion, shellVersion }) => {
     typeof loadedCore.default === 'function'
       ? loadedCore
       : (loadedCore.default as unknown as typeof loadedCore);
-  scope.getState = core.get_state;
   scope.dispatch = core.dispatch;
   scope.decodeStream = core.decode_stream;
   scope.encodeStream = core.encode_stream;
 
   await core.default({ module_or_path: wasmUrl });
+  // The packaged WASM file loads first. Every subsequent Core request, including
+  // requests from stored and synced descriptors, goes through this policy.
+  const network = createAddonNetwork(scope.fetch.bind(scope), import.meta.env.DEV, () => {
+    void bridge.call(['onCoreEvent'], [{ name: 'NewState', args: ['ctx'] }]);
+  });
+  scope.fetch = network.coreFetch;
+  scope.getState = (field) => {
+    const state = core.get_state(field);
+    if (field === 'ctx') {
+      const context = state as ProfileState;
+      context.profile.addons = context.profile.addons.map(network.describeAddon);
+    }
+    return state;
+  };
   await core.initialize_runtime((event) => bridge.call(['onCoreEvent'], [event]));
 };

--- a/apps/desktop/src/core/types.ts
+++ b/apps/desktop/src/core/types.ts
@@ -1,3 +1,5 @@
+import type { AddonTransportIssue } from './addonNetwork';
+
 export type CoreModelName =
   | 'board'
   | 'continue_watching_preview'
@@ -224,6 +226,7 @@ export interface LibraryState {
 }
 
 export interface CoreAddon {
+  transportIssue?: AddonTransportIssue | null;
   flags?: { official?: boolean; protected?: boolean };
   manifest: {
     description?: string | null;

--- a/apps/desktop/src/locales/en-US.ts
+++ b/apps/desktop/src/locales/en-US.ts
@@ -57,7 +57,11 @@ export const enUS = {
     install: 'Install',
     installing: 'Installing…',
     installFailed: 'That add-on could not be installed.',
-    insecure: 'Add-on manifests must be served over HTTPS.',
+    transportIssues: {
+      invalid: 'Blocked. Use a valid HTTPS manifest URL without a username or password.',
+      insecure: 'Blocked. This add-on requires an HTTPS manifest URL.',
+      redirect: 'Blocked. This add-on redirects requests. Install its final HTTPS manifest URL.',
+    },
     remove: 'Remove',
     removeFailed: 'That add-on could not be removed.',
     protectedAddon: 'Required',

--- a/apps/desktop/src/screens/AddonsScreen.test.tsx
+++ b/apps/desktop/src/screens/AddonsScreen.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, expect, it, vi } from 'vitest';
+
+import { AddonsScreen } from './AddonsScreen';
+
+const fixture = vi.hoisted(() => ({ dispatch: vi.fn(), addons: [] as unknown[] }));
+vi.mock('../core/context', () => ({
+  useCore: () => ({ transport: { dispatch: fixture.dispatch } }),
+}));
+vi.mock('../core/useCoreModel', () => ({
+  useCoreModel: () => ({
+    loading: false,
+    state: { profile: { addons: fixture.addons } },
+  }),
+}));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  fixture.dispatch.mockReset();
+  fixture.addons = [];
+});
+
+it('explains a blocked synced add-on without requesting its logo', () => {
+  fixture.addons = [
+    {
+      transportUrl: 'http://insecure.invalid/token/manifest.json',
+      manifest: {
+        id: 'insecure',
+        name: 'Synced add-on',
+        logo: 'http://insecure.invalid/token/logo.png',
+      },
+    },
+  ];
+  render(<AddonsScreen />);
+  expect(screen.getByRole('status')).toHaveTextContent('requires an HTTPS manifest URL');
+  expect(screen.queryByRole('img', { hidden: true })).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Remove Synced add-on' })).toBeEnabled();
+});
+
+it('uses the development loopback exception for manual installation', async () => {
+  vi.stubEnv('DEV', true);
+  const fetchRequest = vi
+    .fn()
+    .mockResolvedValue(Response.json({ id: 'local', name: 'Local add-on' }));
+  vi.stubGlobal('fetch', fetchRequest);
+  render(<AddonsScreen />);
+  fireEvent.change(screen.getByLabelText('Add-on manifest URL'), {
+    target: { value: 'http://127.0.0.1:7000/manifest.json' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Install' }));
+  await waitFor(() => expect(fixture.dispatch).toHaveBeenCalledOnce());
+  expect(fetchRequest.mock.calls[0]?.[1].redirect).toBe('manual');
+});
+
+it('explains a redirect and never installs the redirected manifest', async () => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ type: 'opaqueredirect', status: 0 }));
+  render(<AddonsScreen />);
+  fireEvent.change(screen.getByLabelText('Add-on manifest URL'), {
+    target: { value: 'https://addon.invalid/manifest.json' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Install' }));
+  await screen.findByText(
+    'Blocked. This add-on redirects requests. Install its final HTTPS manifest URL.',
+  );
+  expect(fixture.dispatch).not.toHaveBeenCalled();
+});

--- a/apps/desktop/src/screens/AddonsScreen.tsx
+++ b/apps/desktop/src/screens/AddonsScreen.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import styles from '../App.module.css';
 import { installAddonAction, uninstallAddonAction } from '../core/actions';
+import { AddonTransportError, addonTransportIssue, createAddonNetwork } from '../core/addonNetwork';
 import { useCore } from '../core/context';
 import type { CoreAddon, ProfileState } from '../core/types';
 import { useCoreModel } from '../core/useCoreModel';
@@ -29,24 +30,30 @@ export function AddonsScreen() {
     event.preventDefault();
     const url = manifestUrl.trim();
     if (!transport || !url || busy) return;
-    // ADR 0012 keeps remote add-on transports on HTTPS.
-    if (!url.startsWith('https://')) {
-      setError(enUS.addons.insecure);
+    const issue = addonTransportIssue(url, import.meta.env.DEV);
+    if (issue) {
+      setError(enUS.addons.transportIssues[issue]);
       return;
     }
 
     setBusy(true);
     setError(null);
     try {
-      const response = await fetch(url, { headers: { Accept: 'application/json' } });
+      const response = await createAddonNetwork(fetch, import.meta.env.DEV).fetch(url, {
+        headers: { Accept: 'application/json' },
+      });
       if (!response.ok) throw new Error(`Manifest returned ${response.status}.`);
       const manifest: unknown = await response.json();
       if (!isManifest(manifest)) throw new Error('That URL did not return an add-on manifest.');
       await transport.dispatch(installAddonAction({ flags: {}, manifest, transportUrl: url }));
       setManifestUrl('');
     } catch (cause: unknown) {
-      setError(cause instanceof Error ? cause.message : enUS.addons.installFailed);
-      console.error('[kino:addons] install failed', cause);
+      setError(
+        cause instanceof AddonTransportError
+          ? enUS.addons.transportIssues[cause.issue]
+          : enUS.addons.installFailed,
+      );
+      console.error('[kino:addons] install failed');
     } finally {
       setBusy(false);
     }
@@ -90,37 +97,42 @@ export function AddonsScreen() {
       </div>
 
       <div className={styles.addonList}>
-        {addons.map((addon) => (
-          <div className={styles.addonRow} key={addon.transportUrl}>
-            {addon.manifest.logo ? (
-              <img alt="" className={styles.addonLogo} src={addon.manifest.logo} />
-            ) : (
-              <span className={styles.addonLogo} />
-            )}
-            <div className={styles.addonCopy}>
-              <strong>
-                {addon.manifest.name}
-                {addon.manifest.version ? <small> {addon.manifest.version}</small> : null}
-              </strong>
-              {addon.manifest.description ? <p>{addon.manifest.description}</p> : null}
-              <span className={styles.addonTypes}>
-                {(addon.manifest.types ?? []).join(' · ') || addon.manifest.id}
-              </span>
+        {addons.map((addon) => {
+          const issue =
+            addon.transportIssue ?? addonTransportIssue(addon.transportUrl, import.meta.env.DEV);
+          return (
+            <div className={styles.addonRow} key={addon.transportUrl}>
+              {!issue && addon.manifest.logo ? (
+                <img alt="" className={styles.addonLogo} src={addon.manifest.logo} />
+              ) : (
+                <span className={styles.addonLogo} />
+              )}
+              <div className={styles.addonCopy}>
+                <strong>
+                  {addon.manifest.name}
+                  {addon.manifest.version ? <small> {addon.manifest.version}</small> : null}
+                </strong>
+                {addon.manifest.description ? <p>{addon.manifest.description}</p> : null}
+                {issue ? <p role="status">{enUS.addons.transportIssues[issue]}</p> : null}
+                <span className={styles.addonTypes}>
+                  {(addon.manifest.types ?? []).join(' · ') || addon.manifest.id}
+                </span>
+              </div>
+              {addon.flags?.protected ? (
+                <span className={styles.addonBadge}>{enUS.addons.protectedAddon}</span>
+              ) : (
+                <button
+                  aria-label={`${enUS.addons.remove} ${addon.manifest.name}`}
+                  className={styles.addonRemove}
+                  onClick={() => uninstall(addon)}
+                  type="button"
+                >
+                  <Trash aria-hidden size={16} />
+                </button>
+              )}
             </div>
-            {addon.flags?.protected ? (
-              <span className={styles.addonBadge}>{enUS.addons.protectedAddon}</span>
-            ) : (
-              <button
-                aria-label={`${enUS.addons.remove} ${addon.manifest.name}`}
-                className={styles.addonRemove}
-                onClick={() => uninstall(addon)}
-                type="button"
-              >
-                <Trash aria-hidden size={16} />
-              </button>
-            )}
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/docs/PLAYBACK.md
+++ b/docs/PLAYBACK.md
@@ -4,6 +4,10 @@
 
 Kino shows every source returned by an installed add-on and asks the user to choose. The source list exposes the add-on name and any available resolution, codec, range, audio, size, and peer information. It preflights clear incompatibilities when the metadata is sufficient but may attempt unknown sources.
 
+Core requests, manual manifest installation, and guest catalog setup require HTTPS. Development builds also allow HTTP to loopback addresses. Stored and synced add-ons follow the same policy. Requests that redirect are blocked because browser fetch conceals the destination before following it; install the final HTTPS manifest URL instead. The Add-ons screen explains blocked transports and leaves them available for removal.
+
+`pnpm core:check-addon-transports` verifies the policy with the pinned Core WASM. `pnpm macos:check-addon-transports` checks actual Qt WebEngine requests against local HTTP and HTTPS fixtures, including a redirect to HTTP whose destination must receive no request.
+
 | Source                               | Version-one behavior                                        |
 | ------------------------------------ | ----------------------------------------------------------- |
 | HTTPS direct media                   | Play internally                                             |

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
   },
   "scripts": {
     "build": "pnpm --filter @kino/desktop build",
-    "check": "pnpm format:check && pnpm lint && pnpm typecheck && pnpm test && pnpm core:check-streams && pnpm core:check-shutdown && pnpm engine:check-vendor && pnpm build",
+    "check": "pnpm format:check && pnpm lint && pnpm typecheck && pnpm test && pnpm core:check-streams && pnpm core:check-shutdown && pnpm core:check-addon-transports && pnpm engine:check-vendor && pnpm build",
     "core:check-streams": "node scripts/check-core-streams.mjs",
     "core:check-shutdown": "node scripts/check-core-shutdown.mjs",
+    "core:check-addon-transports": "node scripts/check-core-addon-transports.mjs",
     "dev": "pnpm --filter @kino/desktop dev",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
@@ -29,6 +30,7 @@
     "macos:check-playback": "node scripts/check-macos-playback.mjs",
     "macos:check-request-headers": "node scripts/check-macos-request-headers.mjs",
     "macos:check-shutdown": "node scripts/check-macos-shutdown.mjs",
+    "macos:check-addon-transports": "node scripts/check-macos-addon-transports.mjs",
     "macos:package": "node scripts/package-macos.mjs",
     "test": "pnpm --filter @kino/desktop test",
     "typecheck": "pnpm --filter @kino/desktop typecheck"

--- a/scripts/check-core-addon-transports.mjs
+++ b/scripts/check-core-addon-transports.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+
+import { installAddonAction, loadPlayerAction } from '../apps/desktop/src/core/actions.ts';
+import { createAddonNetwork } from '../apps/desktop/src/core/addonNetwork.ts';
+import { initializeCore } from './test-support/core-stream.mjs';
+
+const stored = process.argv[2] === 'stored';
+const storage = new Map(
+  stored
+    ? [
+        ['profile', process.argv[3]],
+        ['schema_version', process.argv[4]],
+      ]
+    : [],
+);
+const core = await initializeCore({ storage });
+const requests = [];
+const meta = { id: 'kino-fixture', type: 'movie', name: 'Transport fixture', videos: [] };
+const network = createAddonNetwork(async (request) => {
+  requests.push(request.url);
+  return Response.json({ meta });
+}, false);
+globalThis.fetch = network.coreFetch;
+const addon = {
+  transportUrl: 'http://insecure.invalid/synthetic-secret/manifest.json',
+  flags: {},
+  manifest: {
+    id: 'synthetic.insecure',
+    name: 'Synthetic insecure add-on',
+    version: '1.0.0',
+    types: ['movie'],
+    resources: ['meta', 'stream'],
+    catalogs: [],
+  },
+};
+if (!stored) core.dispatch(installAddonAction(addon), undefined, '');
+core.dispatch(
+  loadPlayerAction({
+    meta,
+    metaTransportUrl: addon.transportUrl,
+    streamTransportUrl: addon.transportUrl,
+    stream: { url: 'https://media.invalid/fixture.mp4', deepLinks: { player: '' } },
+    video: null,
+    nextVideo: null,
+  }),
+  'player',
+  '',
+);
+await new Promise((resolve) => setTimeout(resolve, 20));
+assert.equal(
+  requests.filter((url) => url.startsWith('http://insecure.invalid/')).length,
+  0,
+  'A descriptor supplied directly to Core must not transmit an insecure add-on request.',
+);
+assert.equal(
+  network.describeAddon(
+    core.get_state('ctx').profile.addons.find((item) => item.manifest.id === addon.manifest.id),
+  ).transportIssue,
+  'insecure',
+);
+assert.equal(core.get_state('player').metaItem.type, 'Err');
+console.log(
+  `Core blocked ${stored ? 'stored' : 'directly installed'} insecure descriptors before network transmission.`,
+);
+if (!stored) {
+  const profile = core.get_state('ctx').profile;
+  const result = spawnSync(
+    process.execPath,
+    [process.argv[1], 'stored', JSON.stringify(profile), storage.get('schema_version')],
+    { encoding: 'utf8', timeout: 15000 },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(
+    (result.stdout + result.stderr).includes('synthetic-secret'),
+    false,
+    'Blocked configured URLs must not enter Core diagnostics.',
+  );
+  process.stdout.write(result.stdout);
+}
+process.exit(0);

--- a/scripts/check-macos-addon-transports.mjs
+++ b/scripts/check-macos-addon-transports.mjs
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { createServer as createHttpsServer } from 'node:https';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import ts from 'typescript';
+
+const root = mkdtempSync(join(tmpdir(), 'kino-addon-transports-'));
+let child;
+let timeout;
+let plain;
+let secure;
+try {
+  const key = join(root, 'key.pem'),
+    cert = join(root, 'cert.pem');
+  execFileSync(
+    'openssl',
+    [
+      'req',
+      '-x509',
+      '-newkey',
+      'rsa:2048',
+      '-nodes',
+      '-subj',
+      '/CN=localhost',
+      '-days',
+      '1',
+      '-keyout',
+      key,
+      '-out',
+      cert,
+    ],
+    { stdio: 'ignore' },
+  );
+  const requests = [];
+  let report;
+  plain = createServer((request, response) => {
+    response.setHeader('Access-Control-Allow-Origin', '*');
+    if (request.url === '/result') {
+      let body = '';
+      request.on('data', (data) => {
+        body += data;
+      });
+      request.on('end', () => {
+        response.end();
+        report(JSON.parse(body));
+      });
+      return;
+    }
+    requests.push(request.url);
+    response.end('{}');
+  });
+  plain.listen(0, '127.0.0.1');
+  await once(plain, 'listening');
+  const plainOrigin = `http://127.0.0.1:${plain.address().port}`;
+  const secureRequests = [];
+  secure = createHttpsServer(
+    { key: readFileSync(key), cert: readFileSync(cert) },
+    (request, response) => {
+      secureRequests.push(request.url);
+      response.setHeader('Access-Control-Allow-Origin', '*');
+      if (request.url === '/redirect') {
+        response.writeHead(302, { Location: plainOrigin + '/downgrade' }).end();
+      } else response.end('{}');
+    },
+  );
+  secure.listen(0, '127.0.0.1');
+  await once(secure, 'listening');
+  const secureOrigin = `https://127.0.0.1:${secure.address().port}`;
+  const network = ts.transpileModule(
+    readFileSync('apps/desktop/src/core/addonNetwork.ts', 'utf8'),
+    {
+      compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ES2022 },
+    },
+  ).outputText;
+  writeFileSync(join(root, 'network.js'), network);
+  const document = join(root, 'check.html');
+  writeFileSync(
+    document,
+    `<!doctype html><meta charset="utf-8"><title>Kino add-on transport check</title>
+<script type="module">
+import { createAddonNetwork } from './network.js';
+const plain = ${JSON.stringify(plainOrigin)}, secure = ${JSON.stringify(secureOrigin)};
+const production = createAddonNetwork(fetch, false), development = createAddonNetwork(fetch, true);
+try {
+  const results = [];
+  for (const url of [plain + '/blocked', secure + '/redirect']) {
+    try { await production.fetch(url, {redirect:'follow'}); results.push('allowed'); }
+    catch (error) { results.push(error.issue); }
+  }
+  await production.fetch(secure + '/allowed');
+  await development.fetch(plain + '/development');
+  await fetch(plain + '/result', {method:'POST',body:JSON.stringify({results})});
+} catch (error) {
+  await fetch(plain + '/result', {method:'POST',body:JSON.stringify({error:String(error)})});
+}
+</script>`,
+  );
+  const verdict = new Promise((resolveReport, reject) => {
+    report = resolveReport;
+    timeout = setTimeout(
+      () => reject(new Error('Native add-on transport check timed out.')),
+      15000,
+    );
+  });
+  child = spawn(resolve('build/macos/Kino.app/Contents/MacOS/Kino'), [], {
+    env: {
+      ...process.env,
+      KINO_UI_URL: document,
+      // Permit the synthetic TLS certificate in this disposable probe process.
+      // The production shell receives no certificate override.
+      QTWEBENGINE_CHROMIUM_FLAGS: `${process.env.QTWEBENGINE_CHROMIUM_FLAGS ?? ''} --ignore-certificate-errors`,
+    },
+    stdio: ['ignore', 'ignore', 'pipe'],
+  });
+  let diagnostics = '';
+  child.stderr.on('data', (data) => {
+    diagnostics += data;
+  });
+  const result = await verdict;
+  assert.equal(result.error, undefined, result.error);
+  assert.deepEqual(result.results, ['insecure', 'redirect']);
+  assert.deepEqual(
+    requests,
+    ['/development'],
+    'Blocked URLs and redirect destinations must receive no request.',
+  );
+  assert.deepEqual(secureRequests, ['/redirect', '/allowed']);
+  assert.equal(diagnostics.includes('ReferenceError'), false);
+  console.log(
+    'Qt WebEngine blocked HTTP and HTTPS-to-HTTP redirects before transmission, and allowed loopback HTTP only in development.',
+  );
+} finally {
+  clearTimeout(timeout);
+  if (child && child.exitCode === null && child.signalCode === null) {
+    const exited = once(child, 'exit');
+    child.kill('SIGTERM');
+    const force = setTimeout(() => child.kill('SIGKILL'), 3000);
+    await exited;
+    clearTimeout(force);
+  }
+  plain?.closeAllConnections();
+  plain?.close();
+  secure?.closeAllConnections();
+  secure?.close();
+  rmSync(root, { recursive: true, force: true });
+}


### PR DESCRIPTION
Stored and synced add-ons bypassed the installation form's HTTPS check, so Core could contact an HTTP provider. Manifest and resource redirects could also send requests to HTTP before Kino inspected the response.

Core networking, manual installation, and guest catalog setup now share one transport policy. Production permits HTTPS; development also permits HTTP to literal loopback addresses and localhost. Requests use manual redirect handling and reject redirects before following them. Because browser fetch conceals cross-origin redirect destinations, this also blocks HTTPS redirects; the UI directs users to the final HTTPS manifest URL.

The installed list explains insecure and redirected add-ons, retains their removal action, and skips blocked add-on logos. Core receives local HTTP failures for blocked transports and network errors, avoiding its upstream fetch-rejection logger that includes configured URLs and account request bodies.

Validation:

- `pnpm check` passed 82 tests, format, lint, typecheck, production build, vendor reconstruction, and the pinned Core checks.
- The original real-WASM regression sent one HTTP request. It now sends none, including when the descriptor is restored from storage, and configured tokens stay out of diagnostics.
- `pnpm macos:build` and `pnpm macos:check-addon-transports` passed. Qt WebEngine received an HTTPS redirect to HTTP; the destination received no request. HTTPS succeeded and HTTP loopback succeeded only with the development policy.
- Native launch and the window-close/application-Quit regression passed with the updated bundle.

Closes #37.
