### PR TITLE
Reset media library state when the Core profile changes

### DIFF
--- a/apps/desktop/src/locales/en-US.ts
+++ b/apps/desktop/src/locales/en-US.ts
@@ -117,6 +117,7 @@ export const enUS = {
     unavailable: 'Not available',
     failed: 'Failed',
     addToLibrary: 'Add to Library',
+    loadingLibrary: 'Loading library…',
     inLibrary: 'In Library',
   },
   player: {

--- a/apps/desktop/src/screens/MetaDetailsScreen.profile.test.tsx
+++ b/apps/desktop/src/screens/MetaDetailsScreen.profile.test.tsx
@@ -1,0 +1,116 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { expect, it, vi } from 'vitest';
+
+import { CoreContext } from '../core/context';
+import type { CoreTransport } from '../core/transport';
+import { MetaDetailsScreen } from './MetaDetailsScreen';
+
+const item = {
+  id: 'movie',
+  name: 'Profile fixture',
+  type: 'movie',
+  inLibrary: false,
+  watched: false,
+};
+
+function transport(inLibrary: boolean) {
+  return {
+    destroy: vi.fn(),
+    flush: vi.fn(),
+    prepareClose: vi.fn(),
+    init: vi.fn(),
+    onBeforeDestroy: () => () => {},
+    subscribe: () => () => {},
+    dispatch: vi.fn<CoreTransport['dispatch']>().mockResolvedValue(undefined),
+    getState: async <State,>() =>
+      ({
+        libraryItem: null,
+        streams: [],
+        selected: null,
+        metaItem: {
+          addon: { manifest: { id: 'test', name: 'Test' } },
+          content: {
+            type: 'Ready',
+            content: { ...item, inLibrary, videos: [] },
+          },
+        },
+      }) as State,
+  } satisfies CoreTransport;
+}
+
+function view(target: CoreTransport, session: 'guest' | 'account') {
+  return (
+    <CoreContext.Provider
+      value={{ transport: target, session, status: 'ready', error: null, selectSession: vi.fn() }}
+    >
+      <MetaDetailsScreen item={item} failedSources={new Map()} onBack={vi.fn()} onPlay={vi.fn()} />
+    </CoreContext.Provider>
+  );
+}
+
+it.each([false, true])(
+  'drops the guest override when the account membership is %s',
+  async (membership) => {
+    const guest = transport(membership);
+    const account = transport(membership);
+    const currentLabel = membership ? 'In Library' : 'Add to Library';
+    const optimisticLabel = membership ? 'Add to Library' : 'In Library';
+    const rendered = render(view(guest, 'guest'));
+    await waitFor(() => expect(screen.getByRole('button', { name: currentLabel })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: currentLabel }));
+    expect(screen.getByRole('button', { name: optimisticLabel })).toBeInTheDocument();
+    rendered.rerender(view(account, 'account'));
+    await waitFor(() => expect(screen.getByRole('button', { name: currentLabel })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: currentLabel }));
+    expect(account.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'Ctx',
+        args: expect.objectContaining({
+          action: membership ? 'RemoveFromLibrary' : 'AddToLibrary',
+        }),
+      }),
+    );
+  },
+);
+
+it('does not let a late guest failure overwrite the account mutation', async () => {
+  const guest = transport(false),
+    account = transport(false);
+  let rejectGuest!: (error: Error) => void;
+  const pending = new Promise<void>((_resolve, reject) => {
+    rejectGuest = reject;
+  });
+  const rendered = render(view(guest, 'guest'));
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Add to Library' })).toBeEnabled());
+  guest.dispatch.mockImplementation((action) =>
+    action.action === 'Ctx' ? pending : Promise.resolve(),
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'Add to Library' }));
+  rendered.rerender(view(account, 'account'));
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Add to Library' })).toBeEnabled());
+  fireEvent.click(screen.getByRole('button', { name: 'Add to Library' }));
+  await act(async () => rejectGuest(new Error('Old guest request failed.')));
+  expect(screen.getByRole('button', { name: 'In Library' })).toBeInTheDocument();
+});
+
+it('waits for current-profile metadata before showing or changing membership', async () => {
+  const guest = transport(true),
+    account = transport(false);
+  const rendered = render(view(guest, 'guest'));
+  await screen.findByRole('button', { name: 'In Library' });
+  let finishLoad!: () => void;
+  const loading = new Promise<void>((resolve) => {
+    finishLoad = resolve;
+  });
+  account.dispatch.mockImplementation((action) =>
+    action.action === 'Load' ? loading : Promise.resolve(),
+  );
+  rendered.rerender(view(account, 'account'));
+  const pending = screen.getByRole('button', { name: 'Loading library…' });
+  expect(pending).toBeDisabled();
+  expect(screen.queryByRole('button', { name: 'In Library' })).not.toBeInTheDocument();
+  fireEvent.click(pending);
+  expect(account.dispatch.mock.calls.some(([action]) => action.action === 'Ctx')).toBe(false);
+  await act(async () => finishLoad());
+  expect(screen.getByRole('button', { name: 'Add to Library' })).toBeEnabled();
+});

--- a/apps/desktop/src/screens/MetaDetailsScreen.tsx
+++ b/apps/desktop/src/screens/MetaDetailsScreen.tsx
@@ -54,7 +54,8 @@ export function MetaDetailsScreen({
   const [videoId, setVideoId] = useState<string | null>(
     () => initialVideoId ?? defaultVideoId(item),
   );
-  const [libraryOverride, setLibraryOverride] = useState<boolean | null>(null);
+  const [profileTransport, setProfileTransport] = useState(transport);
+  const [libraryOverride, setLibraryOverride] = useState<{ value: boolean } | null>(null);
   const result = useCoreModel<MetaDetailsState>(
     'meta_details',
     loadMetaDetailsAction(item, videoId),
@@ -71,10 +72,15 @@ export function MetaDetailsScreen({
   // its metadata still loading. Without the previous copy the episode list
   // unmounts, the page collapses to the hero, and the browser discards the
   // scroll position. The screen is keyed by title, so this cannot leak between
-  // titles, and a title's metadata does not change when only the episode does.
+  // titles. Profile changes clear it because metadata also includes library
+  // membership and progress that belong to that Core transport.
   const [lastMeta, setLastMeta] = useState<CoreMetaItem | null>(null);
-  if (loadedMeta && loadedMeta !== lastMeta) setLastMeta(loadedMeta);
-  const meta = loadedMeta ?? lastMeta;
+  if (profileTransport !== transport) {
+    setProfileTransport(transport);
+    setLibraryOverride(null);
+    setLastMeta(loadedMeta);
+  } else if (loadedMeta && loadedMeta !== lastMeta) setLastMeta(loadedMeta);
+  const meta = loadedMeta ?? (profileTransport === transport ? lastMeta : null);
   const videos = useMemo(() => meta?.videos ?? [], [meta]);
   const sourcesRef = useRef<HTMLElement>(null);
   const episodeChosenRef = useRef(false);
@@ -143,16 +149,20 @@ export function MetaDetailsScreen({
     : null;
   const activeIndex = activeVideo ? videos.findIndex((video) => video.id === activeVideo.id) : -1;
   const nextEpisode = activeIndex >= 0 ? (videos[activeIndex + 1] ?? null) : null;
-  const inLibrary = libraryOverride ?? display.inLibrary;
+  const inLibrary = libraryOverride?.value ?? display.inLibrary;
+  const libraryReady = Boolean(transport && meta);
 
   const toggleLibrary = () => {
-    if (!transport) return;
+    if (!transport || !libraryReady) return;
     const next = !inLibrary;
-    setLibraryOverride(next);
+    const change = { value: next };
+    setLibraryOverride(change);
     void transport
       .dispatch(next ? addToLibraryAction(display) : removeFromLibraryAction(display.id))
       .catch((error: unknown) => {
-        setLibraryOverride(!next);
+        // A failure from an earlier profile or mutation must not overwrite the
+        // currently displayed profile's newer optimistic action.
+        setLibraryOverride((current) => (current === change ? null : current));
         console.error(
           '[kino:library] update failed',
           error instanceof Error ? error.message : error,
@@ -177,9 +187,24 @@ export function MetaDetailsScreen({
           {display.description ? (
             <p className={styles.detailDescription}>{display.description}</p>
           ) : null}
-          <button className={styles.libraryButton} onClick={toggleLibrary} type="button">
-            {inLibrary ? <Check aria-hidden size={16} /> : <Plus aria-hidden size={16} />}
-            {inLibrary ? enUS.details.inLibrary : enUS.details.addToLibrary}
+          <button
+            className={styles.libraryButton}
+            disabled={!libraryReady}
+            onClick={toggleLibrary}
+            type="button"
+          >
+            {libraryReady ? (
+              inLibrary ? (
+                <Check aria-hidden size={16} />
+              ) : (
+                <Plus aria-hidden size={16} />
+              )
+            ) : null}
+            {!libraryReady
+              ? enUS.details.loadingLibrary
+              : inLibrary
+                ? enUS.details.inLibrary
+                : enUS.details.addToLibrary}
           </button>
         </div>
       </header>


### PR DESCRIPTION
Switching profiles while media details remained open retained the previous profile's optimistic library membership. The button could then send RemoveFromLibrary to an account where the item was absent, or AddToLibrary where it was already present.

Details now clears cached metadata and optimistic membership when the Core transport changes. It waits for current-profile metadata before showing or changing library membership. A failed earlier mutation can only roll back its own optimistic state, so a late guest failure cannot overwrite a newer account action.

Validation: `pnpm check` passed 86 tests and all format, lint, typecheck, pinned Core, vendor, and production build checks. Four focused component regressions cover guest-add/account-absent, guest-remove/account-present, delayed metadata, and a late guest failure after an account mutation. Existing episode/source identity tests still pass.

Closes #78.
