### PR TITLE
Restore the playing episode when returning to sources

### DIFF
--- a/apps/desktop/src/App.sourceFailure.test.tsx
+++ b/apps/desktop/src/App.sourceFailure.test.tsx
@@ -4,7 +4,8 @@ import { beforeEach, expect, it, vi } from 'vitest';
 import { App } from './App';
 import { CoreContext } from './core/context';
 import type { CoreTransport } from './core/transport';
-import type { CoreMetaItem, CoreRuntimeEvent } from './core/types';
+import type { PlaybackSelection } from './core/actions';
+import type { CoreMetaItem, CoreRuntimeEvent, CoreVideo } from './core/types';
 
 const meta: CoreMetaItem = {
   id: 'show',
@@ -15,6 +16,9 @@ const meta: CoreMetaItem = {
   videos: [
     { id: 'ep1', title: 'Episode one', season: 1, episode: 1 },
     { id: 'ep2', title: 'Episode two', season: 1, episode: 2 },
+    { id: 's2e5', title: 'Season two episode five', season: 2, episode: 5 },
+    { id: 's2e6', title: 'Season two episode six', season: 2, episode: 6 },
+    { id: 's2e7', title: 'Season two episode seven', season: 2, episode: 7 },
   ],
 };
 const addon = {
@@ -28,8 +32,23 @@ vi.mock('./screens/HomeScreen', () => ({
   ),
 }));
 vi.mock('./screens/PlayerScreen', () => ({
-  PlayerScreen: ({ onSourceFailure }: { onSourceFailure: (message: string) => void }) => (
-    <button onClick={() => onSourceFailure('Synthetic source failure')}>Fail playback</button>
+  PlayerScreen: ({
+    onSourceFailure,
+    onBack,
+    onUpNext,
+    selection,
+  }: {
+    onSourceFailure: (message: string) => void;
+    onBack: () => void;
+    onUpNext: (video: CoreVideo) => void;
+    selection: PlaybackSelection;
+  }) => (
+    <>
+      <p>Playing {selection.video?.title}</p>
+      <button onClick={() => onSourceFailure('Synthetic source failure')}>Fail playback</button>
+      <button onClick={onBack}>Back from playback</button>
+      <button onClick={() => selection.nextVideo && onUpNext(selection.nextVideo)}>Up Next</button>
+    </>
   ),
 }));
 
@@ -38,7 +57,7 @@ beforeEach(() => {
   Element.prototype.scrollIntoView = vi.fn();
 });
 
-it('marks only the failed torrent file and keeps another episode independent', async () => {
+function mountApp() {
   let videoId = 'ep1';
   const listeners = new Set<(event: CoreRuntimeEvent) => void>();
   const transport: CoreTransport = {
@@ -90,6 +109,10 @@ it('marks only the failed torrent file and keeps another episode independent', a
       <App />
     </CoreContext.Provider>,
   );
+}
+
+it('marks only the failed torrent file and keeps another episode independent', async () => {
+  mountApp();
   fireEvent.click(screen.getByRole('button', { name: 'Open test series' }));
   const first = await screen.findByRole('button', { name: /Pack file 0/ });
   await waitFor(() => expect(first).toBeEnabled());
@@ -109,3 +132,45 @@ it('marks only the failed torrent file and keeps another episode independent', a
   expect(screen.queryByText('Failed')).not.toBeInTheDocument();
   expect(screen.queryByText('Synthetic source failure')).not.toBeInTheDocument();
 });
+
+it.each(['Back from playback', 'Fail playback', 'Up Next'])(
+  'restores the selected season and episode after %s',
+  async (exit) => {
+    mountApp();
+    fireEvent.click(screen.getByRole('button', { name: 'Open test series' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Season 2' }));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Season two episode five/ })).toHaveAttribute(
+        'aria-current',
+        'true',
+      ),
+    );
+    await waitFor(() => expect(screen.getByRole('button', { name: /Pack file 0/ })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: /Pack file 0/ }));
+    expect(screen.getByText('Playing Season two episode five')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: exit }));
+    const title = exit === 'Up Next' ? 'Season two episode six' : 'Season two episode five';
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: new RegExp(title) })).toHaveAttribute(
+        'aria-current',
+        'true',
+      ),
+    );
+    expect(screen.getByRole('button', { name: 'Season 2' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    const source = screen.getByRole('button', { name: /Pack file 0/ });
+    await waitFor(() => expect(source).toBeEnabled());
+    if (exit === 'Fail playback') expect(within(source).getByText('Failed')).toBeInTheDocument();
+    fireEvent.click(source);
+    expect(screen.getByText(`Playing ${title}`)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Back from playback' }));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: new RegExp(title) })).toHaveAttribute(
+        'aria-current',
+        'true',
+      ),
+    );
+  },
+);

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -160,7 +160,12 @@ export function App() {
             initialVideoId={detailVideoId}
             item={detail}
             onBack={() => setScreen(previousScreen)}
-            onPlay={setPlayback}
+            onPlay={(selection) => {
+              // Details unmounts during playback. Keep its chosen episode in
+              // navigation state so Back and failure return to the same source list.
+              setDetailVideoId(selection.video?.id ?? null);
+              setPlayback(selection);
+            }}
           />
         ) : (
           <HomeScreen onOpen={openDetail} />


### PR DESCRIPTION
Playing S2E5 unmounted details without saving its selection in App, so Back or a source failure reopened S1E1. App now retains the selected episode before starting playback. Both exits restore that episode's season and sources, while Up Next explicitly selects the following episode.

Validation: `pnpm check` passed 89 tests and all format, lint, typecheck, pinned Core, vendor, and build checks. The actual App/details regression failed for Back and failure before the fix; it now passes, preserves the failed-source badge, and verifies Up Next advances exactly once.

Closes #69.
