### PR TITLE
Let focused player controls handle their own keyboard input

### DIFF
--- a/apps/desktop/src/screens/PlayerScreen.keyboard.test.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.keyboard.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, expect, it, vi } from 'vitest';
+
+import { defaultSettings } from '../settings';
+import { PlayerScreen } from './PlayerScreen';
+
+const fixture = vi.hoisted(() => ({
+  stream: { url: 'https://media.invalid/fixture.mp4', deepLinks: { player: '' } },
+  native: {
+    load: vi.fn(),
+    stop: vi.fn(),
+    pauseAndSnapshot: vi.fn().mockResolvedValue({ time: 0, duration: 0 }),
+    playerEvent: { connect: vi.fn(), disconnect: vi.fn() },
+    setPaused: vi.fn(),
+    seek: vi.fn(),
+    setMuted: vi.fn(),
+    setFullscreen: vi.fn(),
+    setSubtitleTrack: vi.fn(),
+    setSubtitleScale: vi.fn(),
+    setSubtitlePosition: vi.fn(),
+    setNowPlayingMetadata: vi.fn(),
+  },
+}));
+vi.mock('../native/player', () => ({
+  nativeShellPresent: () => true,
+  connectNativePlayer: async () => fixture.native,
+}));
+vi.mock('../core/context', () => ({
+  useCore: () => ({ transport: { dispatch: async () => {} } }),
+}));
+vi.mock('../core/useCoreModel', () => ({
+  useCoreModel: () => ({
+    state: { stream: { type: 'Ready', content: fixture.stream } },
+    loading: false,
+    error: null,
+    unload: async () => {},
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+async function mountPlayer() {
+  render(
+    <PlayerScreen
+      selection={{
+        meta: { id: 'fixture', type: 'movie', name: 'Fixture', inLibrary: false, watched: false },
+        stream: fixture.stream,
+        metaTransportUrl: 'https://addon.invalid/manifest.json',
+        streamTransportUrl: 'https://addon.invalid/manifest.json',
+        video: null,
+        nextVideo: null,
+      }}
+      settings={defaultSettings}
+      preferredSubtitleLanguage={null}
+      onBack={vi.fn()}
+      onSourceFailure={vi.fn()}
+      onUpNext={vi.fn()}
+      onSettingsChange={vi.fn()}
+    />,
+  );
+  await screen.findByRole('button', { name: 'Subtitles' });
+}
+
+it('lets Space activate the focused subtitle option without toggling playback', async () => {
+  await mountPlayer();
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('button', { name: 'Subtitles' }));
+  screen.getByRole('button', { name: 'Off' }).focus();
+  await user.keyboard(' ');
+  expect(fixture.native.setSubtitleTrack).toHaveBeenCalledExactlyOnceWith(0);
+  expect(fixture.native.setPaused).not.toHaveBeenCalled();
+});
+
+it('leaves arrows on the focused timeline to the range control', async () => {
+  await mountPlayer();
+  const range = screen.getByRole('slider', { name: 'Playback position' });
+  const allowed = fireEvent.keyDown(range, { key: 'ArrowRight', code: 'ArrowRight' });
+  expect(allowed).toBe(true);
+  expect(fixture.native.seek).not.toHaveBeenCalled();
+});
+
+it.each([
+  { ctrlKey: true },
+  { metaKey: true },
+  { altKey: true },
+  { shiftKey: true },
+  { repeat: true },
+  { isComposing: true },
+])('ignores global shortcuts with %j', async (extra) => {
+  await mountPlayer();
+  expect(fireEvent.keyDown(window, { key: 'k', code: 'KeyK', ...extra })).toBe(true);
+  expect(fixture.native.setPaused).not.toHaveBeenCalled();
+});
+
+it('ignores handled events and typing in an editable element', async () => {
+  await mountPlayer();
+  const handled = new KeyboardEvent('keydown', { key: 'k', code: 'KeyK', cancelable: true });
+  handled.preventDefault();
+  window.dispatchEvent(handled);
+  const editable = document.createElement('div');
+  editable.contentEditable = 'true';
+  editable.setAttribute('contenteditable', 'true');
+  document.body.append(editable);
+  expect(fireEvent.keyDown(editable, { key: 'k', code: 'KeyK' })).toBe(true);
+  editable.remove();
+  expect(fixture.native.setPaused).not.toHaveBeenCalled();
+});
+
+it('keeps unmodified playback shortcuts available on the player background', async () => {
+  await mountPlayer();
+  expect(fireEvent.keyDown(window, { key: 'k', code: 'KeyK' })).toBe(false);
+  expect(fixture.native.setPaused).toHaveBeenCalledExactlyOnceWith(false);
+  expect(fireEvent.keyDown(window, { key: 'ArrowRight', code: 'ArrowRight' })).toBe(false);
+  expect(fixture.native.seek).toHaveBeenCalledExactlyOnceWith(10);
+});

--- a/apps/desktop/src/screens/PlayerScreen.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.tsx
@@ -641,6 +641,27 @@ export function PlayerScreen({
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.defaultPrevented ||
+        event.repeat ||
+        event.isComposing ||
+        event.altKey ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.shiftKey
+      )
+        return;
+      // Focused controls own Space, arrows, and text entry. In particular the
+      // timeline's native arrow step must not become a global ten-second seek.
+      if (
+        event.target instanceof Element &&
+        event.target.closest(
+          'button, input, textarea, select, summary, a[href], [contenteditable], ' +
+            '[role="menu"], [role="menubar"], [role="menuitem"], [role="listbox"], ' +
+            '[role="option"], [role="combobox"], [role="textbox"], [role="slider"], [role="button"]',
+        )
+      )
+        return;
       const video = videoRef.current;
       if (!nativePlayer && !video) return;
       if (event.code === 'Space' || event.key.toLowerCase() === 'k') {
@@ -654,8 +675,10 @@ export function PlayerScreen({
         seekTo(Math.max(0, currentTime + (event.key === 'ArrowRight' ? 10_000 : -10_000)));
         reportProgress(true);
       } else if (event.key.toLowerCase() === 'm') {
+        event.preventDefault();
         toggleMuted();
       } else if (event.key.toLowerCase() === 'f') {
+        event.preventDefault();
         enterFullscreen();
       }
     };


### PR DESCRIPTION
The window-level player handler intercepted Space on focused subtitle buttons and replaced the timeline's one-second arrow step with a ten-second seek. Modified, repeated, composing, and already handled key events could also trigger playback actions.

Global shortcuts now defer to buttons, ranges, menus, links, and editable controls, and ignore those event states. Unmodified shortcuts still work on the player background.

Validation:

- `pnpm check` passed 99 tests and all format, lint, typecheck, pinned Core, vendor, and production build checks. The macOS app rebuilt successfully.
- Nine focused regression cases failed before the fix; all ten keyboard cases now pass, including the ordinary-shortcut control case.
- An isolated real Chrome instance reproduced Space calling pause instead of selecting the subtitle option. After the fix, Space selected the option and ArrowRight moved the actual timeline value from 30,000 to 31,000 ms, matching its declared step. The temporary fixture was removed from the repository after validation.

Closes #45.
