### PR TITLE
Honor reduced motion for the subtitle panel

### DIFF
--- a/apps/desktop/src/App.module.css
+++ b/apps/desktop/src/App.module.css
@@ -1614,6 +1614,7 @@
   .content,
   .genreList,
   .skipIntro,
+  .subtitlePanel,
   .upNext {
     animation: none;
   }


### PR DESCRIPTION
The subtitle panel still slid upward when the system requested reduced motion. Add it to the existing reduced-motion rule so it appears immediately at full opacity. Normal-motion entry animation remains enabled.

Audited the other player overlays: Skip Intro and Up Next already use this rule; status and control feedback have no entry animations.

Validation: reproduced the failure in Chrome, then verified panel visibility and subtitle selection with both motion preferences. `pnpm check` passes, including 104 tests and the production build.

Closes #48.
