### PR TITLE
Remove the inactive display frame-rate preference

### DIFF
--- a/apps/desktop/src/locales/en-US.ts
+++ b/apps/desktop/src/locales/en-US.ts
@@ -90,8 +90,6 @@ export const enUS = {
     clearing: 'Clearing…',
     revealLogs: 'Reveal logs',
     desktopOnly: 'Desktop only',
-    matchFrameRate: 'Match display frame rate',
-    matchFrameRateDescription: 'Switch the display to match the selected source',
     audioOutput: 'Audio output',
     audioOutputDescription: 'Use connected equipment or force a stereo downmix',
     audioAuto: 'Auto',

--- a/apps/desktop/src/screens/SettingsScreen.tsx
+++ b/apps/desktop/src/screens/SettingsScreen.tsx
@@ -178,12 +178,6 @@ export function SettingsScreen({
           label={enUS.settings.upNext}
           onChange={(checked) => update('upNext', checked)}
         />
-        <SettingSwitch
-          checked={settings.matchFrameRate}
-          description={enUS.settings.matchFrameRateDescription}
-          label={enUS.settings.matchFrameRate}
-          onChange={(checked) => update('matchFrameRate', checked)}
-        />
         <SettingSelect
           description={enUS.settings.audioOutputDescription}
           id="audio-output"

--- a/apps/desktop/src/settings.test.ts
+++ b/apps/desktop/src/settings.test.ts
@@ -31,7 +31,7 @@ describe('settings storage', () => {
     ).toEqual(defaultSettings);
   });
 
-  it('keeps valid values and repairs invalid values', () => {
+  it('keeps valid values, repairs invalid values, and ignores retired settings', () => {
     const storage = createStorage(
       JSON.stringify({
         automaticIntroSkipping: true,
@@ -47,7 +47,6 @@ describe('settings storage', () => {
     expect(loadSettings(storage)).toEqual({
       automaticIntroSkipping: true,
       audioOutput: 'auto',
-      matchFrameRate: true,
       skipIntroButton: false,
       subtitlePosition: 94,
       subtitleSize: 100,

--- a/apps/desktop/src/settings.ts
+++ b/apps/desktop/src/settings.ts
@@ -5,7 +5,6 @@ export type AudioOutput = 'auto' | 'stereo';
 export interface KinoSettings {
   automaticIntroSkipping: boolean;
   audioOutput: AudioOutput;
-  matchFrameRate: boolean;
   skipIntroButton: boolean;
   subtitlePosition: number;
   subtitleSize: number;
@@ -19,7 +18,6 @@ export const subtitleSizeRange = { max: 200, min: 50 } as const;
 export const defaultSettings: KinoSettings = {
   automaticIntroSkipping: false,
   audioOutput: 'auto',
-  matchFrameRate: false,
   skipIntroButton: true,
   subtitlePosition: 94,
   subtitleSize: 100,
@@ -70,10 +68,6 @@ export function loadSettings(storage: Pick<Storage, 'getItem'>): KinoSettings {
       audioOutput: isAudioOutput(values.audioOutput)
         ? values.audioOutput
         : defaultSettings.audioOutput,
-      matchFrameRate:
-        typeof values.matchFrameRate === 'boolean'
-          ? values.matchFrameRate
-          : defaultSettings.matchFrameRate,
       skipIntroButton:
         typeof values.skipIntroButton === 'boolean'
           ? values.skipIntroButton


### PR DESCRIPTION
Remove the Match display frame rate switch because neither playback nor the native shell implements it. Also remove its locale copy and device setting. Existing settings records still load their supported preferences and ignore the retired field.

Validation: updated the existing settings migration case, observed it fail before removing the field, and ran `pnpm check` successfully (104 tests, Core integration checks, vendor check, production build). Repository search confirms no production references remain.

Closes #53.
