### PR TITLE
Fix Core startup with a relative WASM URL

### DIFF
--- a/apps/desktop/src/core/pendingWork.test.ts
+++ b/apps/desktop/src/core/pendingWork.test.ts
@@ -11,6 +11,17 @@ function deferred() {
 }
 
 describe('Core persistence barrier', () => {
+  it.each(['/assets/core.wasm', './core.wasm'])(
+    'preserves relative fetch URLs: %s',
+    async (url) => {
+      const response = new Response('wasm fixture');
+      const fetchRequest: typeof fetch = async () => response;
+      const work = new PendingCoreWork();
+      expect(await trackCoreSync(fetchRequest, work)(url)).toBe(response);
+      await expect(work.flush()).resolves.toBeUndefined();
+    },
+  );
+
   it('waits for work spawned after dispatch and after a previous write', async () => {
     const work = new PendingCoreWork();
     const first = deferred();

--- a/apps/desktop/src/core/pendingWork.ts
+++ b/apps/desktop/src/core/pendingWork.ts
@@ -45,7 +45,10 @@ export class PendingCoreWork {
 export function trackCoreSync(fetchRequest: typeof fetch, work: PendingCoreWork): typeof fetch {
   return (input, init) => {
     const response = fetchRequest(input, init);
-    const url = new URL(input instanceof Request ? input.url : String(input));
+    const url = new URL(
+      input instanceof Request ? input.url : String(input),
+      globalThis.location?.href,
+    );
     if (url.pathname.endsWith('/datastorePut')) {
       // Core consumes response.text() before processing the sync result. Wait
       // for the body too; receiving HTTP headers does not complete the write.


### PR DESCRIPTION
The persistence tracker parsed every fetch URL without a base. Vite supplies a relative URL for Core WASM, so the tracker threw during initialization and left the development UI waiting for Core. Resolve inspected URLs against the worker location, matching browser fetch behavior.

Validation: both root-relative and directory-relative regression cases fail before the fix. `pnpm check` passes with 106 tests. The real Core worker now initializes in Chrome and dispatches catalog requests; the existing shutdown checks still pass.
