### PR TITLE
Debounce catalog searches and discard stale results

### DIFF
--- a/apps/desktop/src/screens/SearchScreen.test.tsx
+++ b/apps/desktop/src/screens/SearchScreen.test.tsx
@@ -1,0 +1,146 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+import { CoreContext } from '../core/context';
+import type { CoreTransport } from '../core/transport';
+import type { BoardState, CoreRuntimeEvent } from '../core/types';
+import { SearchScreen } from './SearchScreen';
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+function setup() {
+  let state: BoardState = { catalogs: [], selected: null };
+  const listeners = new Set<(event: CoreRuntimeEvent) => void>();
+  const requests: string[] = [];
+  const publish = () =>
+    listeners.forEach((listener) => listener({ name: 'NewState', args: ['search'] }));
+  const target: CoreTransport = {
+    destroy: async () => {},
+    flush: async () => {},
+    prepareClose: async () => {},
+    init: async () => {},
+    onBeforeDestroy: () => () => {},
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    getState: async <State,>() => state as State,
+    dispatch: vi.fn(async (action) => {
+      if (action.action === 'Load') {
+        const args = action.args as { args: { extra: Array<[string, string]> } };
+        state = {
+          selected: args.args,
+          catalogs: ['one', 'two', 'three'].map((id) => ({
+            addon: { manifest: { id, name: id } },
+            id,
+            name: id,
+            type: 'movie',
+            content: null,
+          })),
+        };
+      } else if (action.action === 'CatalogsWithExtra') {
+        const query = state.selected?.extra[0]?.[1];
+        state.catalogs.forEach((catalog) => requests.push(`${catalog.id}:${query}`));
+      } else if (action.action === 'Unload') {
+        state = { selected: null, catalogs: [] };
+      }
+    }),
+  };
+  const view = render(
+    <CoreContext.Provider
+      value={{
+        transport: target,
+        session: 'guest',
+        status: 'ready',
+        error: null,
+        selectSession: vi.fn(),
+      }}
+    >
+      <SearchScreen onOpen={vi.fn()} />
+    </CoreContext.Provider>,
+  );
+  return {
+    ...view,
+    requests,
+    target,
+    finish(query: string) {
+      state = {
+        selected: { extra: [['search', query]] },
+        catalogs: [
+          {
+            addon: { manifest: { id: 'one', name: 'one' } },
+            id: 'one',
+            name: 'one',
+            type: 'movie',
+            content: {
+              type: 'Ready',
+              content: [
+                {
+                  id: query,
+                  name: `${query} result`,
+                  type: 'movie',
+                  inLibrary: false,
+                  watched: false,
+                },
+              ],
+            },
+          },
+        ],
+      };
+      publish();
+    },
+  };
+}
+
+async function type(value: string, elapsed = 100) {
+  fireEvent.change(screen.getByRole('searchbox'), { target: { value } });
+  await act(async () => vi.advanceTimersByTimeAsync(elapsed));
+}
+
+it('waits for a pause in typing before loading three search providers', async () => {
+  const { requests } = setup();
+  for (const value of ['m', 'ma', 'mat', 'matr', 'matri', 'matrix']) await type(value);
+  expect(requests).toEqual([]);
+  await act(async () => vi.advanceTimersByTimeAsync(200));
+  expect(requests).toEqual(['one:matrix', 'two:matrix', 'three:matrix']);
+  await type(' matrix ', 500);
+  expect(requests).toHaveLength(3);
+});
+
+it('submits immediately and cancels the trailing timer and empty searches', async () => {
+  const { requests } = setup();
+  await type('matrix');
+  await act(async () => fireEvent.submit(screen.getByRole('search')));
+  expect(requests).toHaveLength(3);
+  await act(async () => vi.advanceTimersByTimeAsync(500));
+  await act(async () => fireEvent.submit(screen.getByRole('search')));
+  expect(requests).toHaveLength(3);
+  await type('unfinished');
+  await type('   ', 500);
+  expect(requests).toHaveLength(3);
+});
+
+it('hides superseded results and ignores late responses after the query changes', async () => {
+  const fixture = setup();
+  await type('old', 300);
+  await act(async () => fixture.finish('old'));
+  expect(screen.getByText('old result')).toBeInTheDocument();
+  await type('final');
+  expect(screen.queryByText('old result')).not.toBeInTheDocument();
+  await act(async () => vi.advanceTimersByTimeAsync(200));
+  await act(async () => fixture.finish('old'));
+  expect(screen.queryByText('old result')).not.toBeInTheDocument();
+  await act(async () => fixture.finish('final'));
+  expect(screen.getByText('final result')).toBeInTheDocument();
+  await type('');
+  expect(screen.queryByText('final result')).not.toBeInTheDocument();
+});
+
+it('cancels pending typing when leaving Search', async () => {
+  const fixture = setup();
+  await type('matrix');
+  fixture.unmount();
+  await act(async () => vi.advanceTimersByTimeAsync(500));
+  expect(fixture.requests).toEqual([]);
+});

--- a/apps/desktop/src/screens/SearchScreen.tsx
+++ b/apps/desktop/src/screens/SearchScreen.tsx
@@ -1,4 +1,4 @@
-import { useDeferredValue, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import styles from '../App.module.css';
 import { MediaCard } from '../components/MediaCard';
@@ -11,16 +11,27 @@ import { t as enUS } from '../locales';
 export function SearchScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => void }) {
   const { transport } = useCore();
   const [query, setQuery] = useState('');
-  const deferredQuery = useDeferredValue(query.trim());
-  const result = useCoreModel<BoardState>(
-    'search',
-    deferredQuery ? loadSearchAction(deferredQuery) : null,
-    deferredQuery,
-  );
-  const catalogCount = result.state?.catalogs.length ?? 0;
+  const [submittedQuery, setSubmittedQuery] = useState('');
+  const normalizedQuery = query.trim();
 
   useEffect(() => {
-    if (!transport || !deferredQuery || catalogCount === 0) return;
+    if (normalizedQuery === submittedQuery) return;
+    const timer = window.setTimeout(() => setSubmittedQuery(normalizedQuery), 300);
+    return () => window.clearTimeout(timer);
+  }, [normalizedQuery, submittedQuery]);
+
+  const result = useCoreModel<BoardState>(
+    'search',
+    submittedQuery ? loadSearchAction(submittedQuery) : null,
+    submittedQuery,
+  );
+  const stateQuery = result.state?.selected?.extra.find(([name]) => name === 'search')?.[1];
+  const currentState = submittedQuery && stateQuery === submittedQuery ? result.state : null;
+  const catalogCount = currentState?.catalogs.length ?? 0;
+  const pending = normalizedQuery !== submittedQuery;
+
+  useEffect(() => {
+    if (!transport || !submittedQuery || catalogCount === 0) return;
     void transport.dispatch(
       {
         action: 'CatalogsWithExtra',
@@ -28,40 +39,52 @@ export function SearchScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => vo
       },
       'search',
     );
-  }, [catalogCount, deferredQuery, transport]);
+  }, [catalogCount, submittedQuery, transport]);
   const items = useMemo(() => {
-    if (!deferredQuery) return [];
+    if (pending || !submittedQuery) return [];
     const unique = new Map<string, CoreMetaPreview>();
-    result.state?.catalogs.forEach((catalog) => {
+    currentState?.catalogs.forEach((catalog) => {
       if (catalog.content?.type !== 'Ready') return;
       catalog.content.content.forEach((item) => unique.set(`${item.type}:${item.id}`, item));
     });
     return [...unique.values()];
-  }, [deferredQuery, result.state]);
+  }, [currentState, pending, submittedQuery]);
 
   return (
     <div className={styles.page}>
       <h1 className={styles.visuallyHidden}>{enUS.search.title}</h1>
-      <label className={styles.visuallyHidden} htmlFor="catalog-search">
-        {enUS.search.placeholder}
-      </label>
-      <input
-        autoFocus
-        className={styles.searchInput}
-        id="catalog-search"
-        onChange={(event) => setQuery(event.target.value)}
-        placeholder={enUS.search.placeholder}
-        type="search"
-        value={query}
-      />
-      {deferredQuery ? (
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          setSubmittedQuery(normalizedQuery);
+        }}
+        role="search"
+      >
+        <label className={styles.visuallyHidden} htmlFor="catalog-search">
+          {enUS.search.placeholder}
+        </label>
+        <input
+          autoFocus
+          className={styles.searchInput}
+          id="catalog-search"
+          onChange={(event) => {
+            const value = event.target.value;
+            setQuery(value);
+            if (!value.trim()) setSubmittedQuery('');
+          }}
+          placeholder={enUS.search.placeholder}
+          type="search"
+          value={query}
+        />
+      </form>
+      {normalizedQuery ? (
         <p className={styles.searchHelp} role="status">
-          {result.loading ? enUS.search.loading : `${items.length} results`}
+          {pending || result.loading ? enUS.search.loading : `${items.length} results`}
         </p>
       ) : (
         <p className={styles.searchHelp}>{enUS.search.idle}</p>
       )}
-      {result.error ? <p className={styles.loadError}>{enUS.search.error}</p> : null}
+      {!pending && result.error ? <p className={styles.loadError}>{enUS.search.error}</p> : null}
       {items.length > 0 ? (
         <div className={styles.mediaGrid}>
           {items.map((item) => (


### PR DESCRIPTION
Typing in Search previously loaded every intermediate prefix across installed providers. Wait 300 ms after typing stops, submit immediately on Enter, and cancel pending typing when the field is cleared or Search unmounts. Trimmed, unchanged queries do not reload. Results must match the submitted Core query and the current input.

Validation: four regression tests fail before the fix and pass afterward. In Chrome with the real pinned Core worker and three synthetic search add-ons, typing six letters at 80 ms intervals produces 3 catalog requests, down from 18. Enter submits before the debounce deadline; repeated and cleared queries make no extra requests; deliberately delayed old responses leave the final results visible. `pnpm check` passes with 110 tests.

Closes #59.
