### PR TITLE
Make Library type filters use Core's serialized selections

### DIFF
--- a/apps/desktop/src/core/types.ts
+++ b/apps/desktop/src/core/types.ts
@@ -218,9 +218,9 @@ export interface LibraryItem {
 export interface LibraryState {
   catalog: LibraryItem[];
   selectable: {
-    nextPage: { request: LibraryRequest } | null;
-    sorts: Array<{ request: LibraryRequest; selected: boolean; sort: string }>;
-    types: Array<{ request: LibraryRequest; selected: boolean; type: string | null }>;
+    nextPage: boolean;
+    sorts: Array<{ deepLinks: { library: string }; selected: boolean; sort: string }>;
+    types: Array<{ deepLinks: { library: string }; selected: boolean; type: string | null }>;
   } | null;
   selected: { request: LibraryRequest } | null;
 }

--- a/apps/desktop/src/screens/LibraryScreen.test.tsx
+++ b/apps/desktop/src/screens/LibraryScreen.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { expect, it, vi } from 'vitest';
+
+import { CoreContext } from '../core/context';
+import type { CoreTransport } from '../core/transport';
+import type { LibraryRequest } from '../core/types';
+import { LibraryScreen } from './LibraryScreen';
+
+it('uses serialized type options to filter Movies, Series, and All', async () => {
+  let request: LibraryRequest = { page: 1, sort: 'lastwatched', type: null };
+  const catalog = ['movie', 'series'].map((type) => ({
+    _id: `kino-${type}`,
+    name: `Synthetic ${type}`,
+    type,
+    poster: null,
+    posterShape: 'poster',
+  }));
+  const target: CoreTransport = {
+    destroy: async () => {},
+    flush: async () => {},
+    prepareClose: async () => {},
+    init: async () => {},
+    onBeforeDestroy: () => () => {},
+    subscribe: () => () => {},
+    dispatch: vi.fn(async (action) => {
+      if (action.action !== 'Load') return;
+      request = (action.args as { args: { request: LibraryRequest } }).args.request;
+    }),
+    getState: async <State,>() =>
+      ({
+        selected: { request },
+        selectable: {
+          nextPage: false,
+          sorts: [
+            {
+              sort: 'lastwatched',
+              selected: true,
+              deepLinks: { library: '#/library?sort=lastwatched' },
+            },
+          ],
+          types: [null, 'movie', 'series'].map((type) => ({
+            type,
+            selected: type === request.type,
+            deepLinks: { library: `#/library${type ? `/${type}` : ''}?sort=lastwatched` },
+          })),
+        },
+        catalog: catalog.filter((item) => !request.type || item.type === request.type),
+      }) as State,
+  };
+  render(
+    <CoreContext.Provider
+      value={{
+        transport: target,
+        session: 'guest',
+        status: 'ready',
+        error: null,
+        selectSession: vi.fn(),
+      }}
+    >
+      <LibraryScreen onOpen={vi.fn()} />
+    </CoreContext.Provider>,
+  );
+  await screen.findByText('Synthetic movie');
+  for (const [label, type] of [
+    ['Movie', 'movie'],
+    ['Series', 'series'],
+    ['All', null],
+  ] as const) {
+    fireEvent.click(screen.getByRole('button', { name: label }));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: label })).toHaveAttribute('aria-pressed', 'true'),
+    );
+    expect(request).toEqual({ page: 1, sort: 'lastwatched', type });
+    for (const item of catalog) {
+      expect(Boolean(screen.queryByText(item.name))).toBe(!type || type === item.type);
+    }
+  }
+});

--- a/apps/desktop/src/screens/LibraryScreen.tsx
+++ b/apps/desktop/src/screens/LibraryScreen.tsx
@@ -32,7 +32,14 @@ export function LibraryScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => v
               aria-pressed={option.selected}
               className={option.selected ? styles.pillActive : styles.pill}
               key={option.type ?? 'all'}
-              onClick={() => setRequest(option.request)}
+              onClick={() => {
+                if (option.selected) return;
+                setRequest({
+                  page: 1,
+                  sort: result.state?.selected?.request.sort ?? 'lastwatched',
+                  type: option.type,
+                });
+              }}
               type="button"
             >
               {typeLabel(option.type)}


### PR DESCRIPTION
Library type buttons read a request field that Core never serializes, so clicking Movie or Series kept All selected. Construct the request from the offered type, keep the current sort, and return to page one. Correct the selectable types to describe Core deep links and the boolean next-page flag.

Validation: the component regression fails before the fix and passes after. In Chrome with the real pinned Core worker and synthetic library entries, Movie and Series each select one item and All selects both. Starting from page three with name sorting verifies that type changes preserve the sort and reset to page one. `pnpm check` passes with 111 tests.

Closes #70.
