### PR TITLE
Discover add-on subtitles for sources without file hints

### DIFF
--- a/apps/desktop/src/player/videoParams.ts
+++ b/apps/desktop/src/player/videoParams.ts
@@ -1,0 +1,20 @@
+import type { CoreStream } from '../core/types';
+
+// Unknown parameters still let Core discover subtitles by media ID. Only
+// forward supplied file metadata; a URL or torrent hash is not a video hash.
+export function videoParams(stream: CoreStream) {
+  const hints = stream.behaviorHints;
+  return {
+    hash:
+      typeof hints?.videoHash === 'string' && /^[a-f0-9]{16}$/i.test(hints.videoHash)
+        ? hints.videoHash
+        : null,
+    size:
+      typeof hints?.videoSize === 'number' &&
+      Number.isSafeInteger(hints.videoSize) &&
+      hints.videoSize > 0
+        ? hints.videoSize
+        : null,
+    filename: typeof hints?.filename === 'string' && hints.filename.trim() ? hints.filename : null,
+  };
+}

--- a/apps/desktop/src/screens/PlayerScreen.discovery.test.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.discovery.test.tsx
@@ -1,0 +1,103 @@
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { beforeEach, expect, it, vi } from 'vitest';
+
+import type { CoreStream } from '../core/types';
+import { defaultSettings } from '../settings';
+import { PlayerScreen } from './PlayerScreen';
+
+const fixture = vi.hoisted(() => ({
+  nativeShell: true,
+  stream: { url: 'https://media.invalid/fixture.mp4', deepLinks: { player: '' } },
+  transport: { dispatch: vi.fn().mockResolvedValue(undefined) },
+  native: {
+    load: vi.fn(),
+    stop: vi.fn(),
+    playerEvent: { connect: vi.fn(), disconnect: vi.fn() },
+    setSubtitleScale: vi.fn(),
+    setSubtitlePosition: vi.fn(),
+    setNowPlayingMetadata: vi.fn(),
+  },
+}));
+vi.mock('../native/player', () => ({
+  nativeShellPresent: () => fixture.nativeShell,
+  connectNativePlayer: async () => fixture.native,
+}));
+vi.mock('../core/context', () => ({ useCore: () => ({ transport: fixture.transport }) }));
+vi.mock('../core/useCoreModel', () => ({
+  useCoreModel: () => ({
+    state: { stream: { type: 'Ready', content: fixture.stream } },
+    loading: false,
+    error: null,
+    unload: async () => {},
+  }),
+}));
+beforeEach(() => vi.clearAllMocks());
+
+it.each([true, false])(
+  'discovers subtitles once media is ready (native=%s)',
+  async (nativeShell) => {
+    fixture.nativeShell = nativeShell;
+    const { container } = renderPlayer(fixture.stream);
+    if (nativeShell) await waitFor(() => expect(fixture.native.load).toHaveBeenCalled());
+    expect(fixture.transport.dispatch).not.toHaveBeenCalled();
+    await act(async () => {
+      for (let count = 0; count < 2; count++) {
+        if (nativeShell) fixture.native.playerEvent.connect.mock.calls.at(-1)?.[0]('ready', {});
+        else fireEvent.loadedMetadata(container.querySelector('video')!);
+      }
+    });
+    expect(fixture.transport.dispatch).toHaveBeenCalledExactlyOnceWith(
+      {
+        action: 'Player',
+        args: {
+          action: 'VideoParamsChanged',
+          args: { videoParams: { hash: null, size: null, filename: null } },
+        },
+      },
+      'player',
+    );
+  },
+);
+
+it('includes supplied file hints when reporting native readiness', async () => {
+  fixture.nativeShell = true;
+  renderPlayer({
+    ...fixture.stream,
+    behaviorHints: { videoHash: '0123456789abcdef', videoSize: 123456, filename: 'fixture.mkv' },
+  });
+  await waitFor(() => expect(fixture.native.load).toHaveBeenCalled());
+  await act(async () => fixture.native.playerEvent.connect.mock.calls.at(-1)?.[0]('ready', {}));
+  expect(fixture.transport.dispatch).toHaveBeenCalledWith(
+    {
+      action: 'Player',
+      args: {
+        action: 'VideoParamsChanged',
+        args: {
+          videoParams: { hash: '0123456789abcdef', size: 123456, filename: 'fixture.mkv' },
+        },
+      },
+    },
+    'player',
+  );
+});
+
+function renderPlayer(stream: CoreStream) {
+  return render(
+    <PlayerScreen
+      selection={{
+        meta: { id: 'fixture', type: 'movie', name: 'Fixture', inLibrary: false, watched: false },
+        stream,
+        metaTransportUrl: 'https://addon.invalid/manifest.json',
+        streamTransportUrl: 'https://addon.invalid/manifest.json',
+        video: null,
+        nextVideo: null,
+      }}
+      settings={defaultSettings}
+      preferredSubtitleLanguage={null}
+      onBack={vi.fn()}
+      onSourceFailure={vi.fn()}
+      onUpNext={vi.fn()}
+      onSettingsChange={vi.fn()}
+    />,
+  );
+}

--- a/apps/desktop/src/screens/PlayerScreen.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.tsx
@@ -43,6 +43,7 @@ import {
   type TorrentStats,
 } from '../player/torrent';
 import { subtitlePositionRange, subtitleSizeRange, type KinoSettings } from '../settings';
+import { videoParams } from '../player/videoParams';
 
 function formatTime(milliseconds: number) {
   const seconds = Math.max(0, Math.floor(milliseconds / 1000));
@@ -157,6 +158,7 @@ export function PlayerScreen({
   const [addedSubtitleUrls, setAddedSubtitleUrls] = useState<ReadonlySet<string>>(new Set());
   const failureReportedRef = useRef(false);
   const subtitleAutoDoneRef = useRef(false);
+  const videoParamsReportedRef = useRef(false);
   const [ended, setEnded] = useState(false);
   const [torrentUrl, setTorrentUrl] = useState<string | null>(null);
   const [engineUrl, setEngineUrl] = useState<string | null>(null);
@@ -234,6 +236,12 @@ export function PlayerScreen({
     },
     [dispatchPlayer, nativeShell],
   );
+
+  const reportMediaReady = useCallback(() => {
+    if (!transport || closingRef.current || videoParamsReportedRef.current) return;
+    videoParamsReportedRef.current = true;
+    dispatchPlayer('VideoParamsChanged', { videoParams: videoParams(selection.stream) });
+  }, [dispatchPlayer, selection.stream, transport]);
 
   async function saveBeforeUnload(target: CoreTransport, loaded: Promise<void>) {
     closingRef.current = true;
@@ -497,6 +505,7 @@ export function PlayerScreen({
   useEffect(() => {
     if (!nativePlayer || !streamUrl) return;
     closingRef.current = false;
+    videoParamsReportedRef.current = false;
     const onEvent = (name: string, payload: Record<string, unknown>) => {
       if (closingRef.current) return;
       if (name === 'time' && typeof payload.milliseconds === 'number') {
@@ -517,6 +526,7 @@ export function PlayerScreen({
         setBuffering(payload.active);
       } else if (name === 'ready') {
         setBuffering(false);
+        reportMediaReady();
       } else if (name === 'chapters') {
         setChapterCues(nativeChapterCues(payload.items));
       } else if (name === 'subtitleTracks') {
@@ -545,6 +555,7 @@ export function PlayerScreen({
     dispatchPlayer,
     nativePlayer,
     reportFailure,
+    reportMediaReady,
     reportProgress,
     requestHeaders,
     settings.audioOutput,
@@ -724,8 +735,12 @@ export function PlayerScreen({
             const video = event.currentTarget;
             updateDuration(video.duration * 1000);
             setPaused(video.paused);
+            reportMediaReady();
           }}
-          onLoadStart={() => setBuffering(true)}
+          onLoadStart={() => {
+            videoParamsReportedRef.current = false;
+            setBuffering(true);
+          }}
           onPause={() => {
             setPaused(true);
             dispatchPlayer('PausedChanged', { paused: true });

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   },
   "scripts": {
     "build": "pnpm --filter @kino/desktop build",
-    "check": "pnpm format:check && pnpm lint && pnpm typecheck && pnpm test && pnpm core:check-streams && pnpm core:check-shutdown && pnpm core:check-addon-transports && pnpm engine:check-vendor && pnpm build",
+    "check": "pnpm format:check && pnpm lint && pnpm typecheck && pnpm test && pnpm core:check-streams && pnpm core:check-subtitles && pnpm core:check-shutdown && pnpm core:check-addon-transports && pnpm engine:check-vendor && pnpm build",
     "core:check-streams": "node scripts/check-core-streams.mjs",
+    "core:check-subtitles": "node scripts/check-core-subtitles.mjs",
     "core:check-shutdown": "node scripts/check-core-shutdown.mjs",
     "core:check-addon-transports": "node scripts/check-core-addon-transports.mjs",
     "dev": "pnpm --filter @kino/desktop dev",

--- a/scripts/check-core-subtitles.mjs
+++ b/scripts/check-core-subtitles.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+
+import { installAddonAction, playerAction } from '../apps/desktop/src/core/actions.ts';
+import { videoParams } from '../apps/desktop/src/player/videoParams.ts';
+import { initializeCore, resolveCoreStream } from './test-support/core-stream.mjs';
+
+const core = await initializeCore();
+const addon = {
+  transportUrl: 'https://subtitles.invalid/manifest.json',
+  flags: {},
+  manifest: {
+    id: 'synthetic.subtitles',
+    name: 'Subtitle fixture',
+    version: '1.0.0',
+    types: ['movie'],
+    resources: ['subtitles'],
+    catalogs: [],
+  },
+};
+core.dispatch(installAddonAction(addon), undefined, '');
+const requests = [];
+const metadataFetch = globalThis.fetch;
+globalThis.fetch = async (request) => {
+  const url = new URL(request.url);
+  if (!url.pathname.includes('/subtitles/')) return metadataFetch(request);
+  requests.push(url);
+  return Response.json({
+    subtitles: [{ id: 'fixture-en', lang: 'eng', url: 'https://subtitles.invalid/english.srt' }],
+  });
+};
+
+for (const behaviorHints of [
+  undefined,
+  {
+    videoHash: '0123456789abcdef',
+    videoSize: 123456,
+    filename: 'fixture.mkv',
+  },
+]) {
+  core.dispatch({ action: 'Unload' }, 'player', '');
+  requests.length = 0;
+  const stream = {
+    url: 'https://media.invalid/fixture.mp4',
+    ...(behaviorHints ? { behaviorHints } : {}),
+  };
+  await resolveCoreStream(core, stream);
+  await new Promise((resolve) => setImmediate(resolve));
+  if (!behaviorHints) {
+    assert.equal(
+      requests.length,
+      0,
+      'Core defers hint-free subtitle discovery until media is ready.',
+    );
+    assert.deepEqual(core.get_state('player').subtitles, []);
+  }
+  core.dispatch(
+    playerAction('VideoParamsChanged', { videoParams: videoParams(stream) }),
+    'player',
+    '',
+  );
+  await new Promise((resolve) => setImmediate(resolve));
+  const addonRequests = requests.filter((url) => url.hostname === 'subtitles.invalid');
+  assert.equal(
+    addonRequests.length,
+    1,
+    'Readiness must discover subtitles without duplicating a hinted request.',
+  );
+  assert.ok(
+    core
+      .get_state('player')
+      .subtitles.some((subtitle) => subtitle.url === 'https://subtitles.invalid/english.srt'),
+  );
+  if (behaviorHints) {
+    const path = decodeURIComponent(addonRequests[0].pathname);
+    for (const [key, value] of Object.entries(behaviorHints))
+      assert.ok(path.includes(`${key}=${value}`), path);
+  }
+  console.log(
+    `Pinned Core exposes add-on subtitles for a direct URL ${behaviorHints ? 'with file hints' : 'without file hints'} after media readiness.`,
+  );
+}
+assert.deepEqual(
+  videoParams({ behaviorHints: { videoHash: 'not-a-video-hash', videoSize: -1, filename: ' ' } }),
+  { hash: null, size: null, filename: null },
+);
+process.exit(0);


### PR DESCRIPTION
Core waits for video parameters before discovering subtitles for a source without file hints. Notify it once when native playback is ready or browser metadata loads. Send unknown fields as null and retain valid supplied video hash, size, and filename hints.

Validation: native and browser readiness regressions fail before the change and pass afterward. Added a pinned Core integration check to `pnpm check`: hint-free URLs discover external subtitles after readiness, hinted URLs preserve request parameters without a duplicate request, and invalid hints stay unknown. All 114 tests and the production build pass. A Chrome check using the real Core worker and a native bridge fixture verifies the discovered subtitle appears in the menu, selecting it forwards the subtitle URL, and playback loads once.

Closes #73.
