### PR TITLE
Validate the native shell and locked streaming engine in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
-    name: Validate
+  changes:
+    name: Detect native changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      native: ${{ steps.paths.outputs.native }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - id: paths
+        name: Check native build inputs
+        env:
+          KINO_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+          KINO_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          node <<'JS'
+          const { execFileSync } = require('node:child_process');
+          const { appendFileSync } = require('node:fs');
+          const { KINO_BASE: base, KINO_HEAD: head } = process.env;
+          const files = !base || /^0+$/.test(base)
+            ? ['.github/workflows/ci.yml']
+            : execFileSync('git', ['diff', '--name-only', '-z', base, head], { encoding: 'utf8' }).split('\0');
+          const native = files.some((file) => /^(\.github\/|apps\/(macos-shell|stream-engine)\/|apps\/desktop\/src\/native\/|scripts\/|package\.json$|pnpm-lock\.yaml$|\.node-version$)/.test(file));
+          appendFileSync(process.env.GITHUB_OUTPUT, `native=${native}\n`);
+          JS
+
+  web:
+    name: Web validation
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -37,3 +64,105 @@ jobs:
 
       - name: Validate
         run: pnpm check
+
+  native:
+    name: Native and engine validation
+    needs: changes
+    if: needs.changes.outputs.native == 'true'
+    runs-on: macos-26
+    timeout-minutes: 45
+    env:
+      CARGO_BUILD_JOBS: '2'
+      CARGO_TARGET_DIR: ${{ github.workspace }}/build/engine-target
+      CMAKE_BUILD_PARALLEL_LEVEL: '2'
+      HOMEBREW_NO_AUTO_UPDATE: '1'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Restore Homebrew downloads
+        id: brew-cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: ~/Library/Caches/Homebrew/downloads
+          key: brew-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/ci.yml') }}
+          restore-keys: brew-${{ runner.os }}-${{ runner.arch }}-
+      - name: Install native dependencies
+        run: |
+          brew install cmake qt mpv pkgconf rust libtorrent-rasterbar boost
+          echo "$(brew --prefix rust)/bin" >> "$GITHUB_PATH"
+      - name: Save Homebrew downloads
+        if: steps.brew-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: ~/Library/Caches/Homebrew/downloads
+          key: ${{ steps.brew-cache.outputs.cache-primary-key }}
+
+      - name: Identify the engine toolchain
+        id: toolchain
+        run: |
+          kino_toolchain="$(rustc --version)-$(pkg-config --modversion libtorrent-rasterbar)-$(brew list --versions boost)"
+          echo "key=$(printf '%s' "$kino_toolchain" | shasum -a 256 | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+      - name: Restore Cargo dependencies and build outputs
+        id: engine-cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            build/engine-target
+          key: cargo-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.key }}-${{ hashFiles('apps/stream-engine/Cargo.lock', 'apps/stream-engine/engine.lock', 'apps/stream-engine/patches/**') }}
+          restore-keys: cargo-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.key }}-
+      - name: Reconstruct vendor patches and build the locked engine
+        run: pnpm engine:build
+      - name: Test the locked engine and embedded profile
+        timeout-minutes: 5
+        run: |
+          CXXFLAGS="-I$(brew --prefix)/include" cargo test --locked --release --manifest-path apps/stream-engine/Cargo.toml
+          pnpm engine:check-profile
+          pnpm engine:check-trackers
+      - name: Save Cargo dependencies and build outputs
+        if: steps.engine-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            build/engine-target
+          key: ${{ steps.engine-cache.outputs.cache-primary-key }}
+
+      - name: Compile and bundle the native shell
+        run: pnpm macos:build
+      - name: Run native unit tests and startup probes
+        timeout-minutes: 5
+        run: |
+          ctest --test-dir build/macos --output-on-failure --timeout 30
+          pnpm macos:check-launch
+          pnpm macos:check-engine
+
+  validate:
+    name: Validate
+    needs: [changes, web, native]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every applicable validation job
+        env:
+          KINO_CHANGES_RESULT: ${{ needs.changes.result }}
+          KINO_WEB_RESULT: ${{ needs.web.result }}
+          KINO_NATIVE_RESULT: ${{ needs.native.result }}
+          KINO_NATIVE_REQUIRED: ${{ needs.changes.outputs.native }}
+        run: |
+          test "$KINO_CHANGES_RESULT" = success
+          test "$KINO_WEB_RESULT" = success
+          if test "$KINO_NATIVE_REQUIRED" = true; then
+            test "$KINO_NATIVE_RESULT" = success
+          else
+            test "$KINO_NATIVE_RESULT" = skipped
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,9 @@ jobs:
           restore-keys: brew-${{ runner.os }}-${{ runner.arch }}-
       - name: Install native dependencies
         run: |
+          brew update
           brew install cmake qt mpv pkgconf rust libtorrent-rasterbar boost
+          pkg-config --print-errors --atleast-version=2.1.1 libtorrent-rasterbar
           echo "$(brew --prefix rust)/bin" >> "$GITHUB_PATH"
       - name: Save Homebrew downloads
         if: steps.brew-cache.outputs.cache-hit != 'true'

--- a/README.md
+++ b/README.md
@@ -75,11 +75,15 @@ The engine profile check streams a private torrent from a local web seed and com
 
 `pnpm core:check-streams` runs the pinned Core WASM serializer and verifies that add-on torrent trackers survive resolution into the engine request. It runs in CI as part of `pnpm check`. `pnpm engine:check-trackers` also runs a local tracker and a libtorrent seeder with DHT, local discovery, and peer exchange disabled. A random unpublished torrent must transfer through the actual engine using only the tracker supplied through Core. This native check requires the engine build, a C++ compiler, and `pkg-config` for libtorrent.
 
-Run the complete local validation suite with:
+Run the web checks, pinned Core integration checks, and vendor reconstruction regression with:
 
 ```sh
 pnpm check
 ```
+
+CI runs those checks on every PR. Changes to the native shell, native bridge, engine, build scripts, workflow, or dependency locks also run on a macOS 26 ARM runner. That job reconstructs the pinned vendor checkout, applies patches, builds and tests the Rust helper with `--locked`, checks the engine profile and tracker transfer, compiles the shell and packaged UI, and runs CTest plus launch and engine-supervision probes. Homebrew downloads and Cargo outputs are cached. The `Validate` result includes every applicable job.
+
+The hardware playback fixture matrix, HDR tone mapping, and audio output checks remain manual release gates. Hosted runner probes do not establish playback quality or hardware decoder support.
 
 ### Packaging
 

--- a/apps/macos-shell/src/closecoordinator.cpp
+++ b/apps/macos-shell/src/closecoordinator.cpp
@@ -1,3 +1,5 @@
+#error KINO_CI_EXPECTED_COMPILE_FAILURE
+
 #include "closecoordinator.h"
 
 #include <QCoreApplication>

--- a/apps/macos-shell/src/closecoordinator.cpp
+++ b/apps/macos-shell/src/closecoordinator.cpp
@@ -1,5 +1,3 @@
-#error KINO_CI_EXPECTED_COMPILE_FAILURE
-
 #include "closecoordinator.h"
 
 #include <QCoreApplication>

--- a/apps/macos-shell/tests/mpvitem_test.cpp
+++ b/apps/macos-shell/tests/mpvitem_test.cpp
@@ -3,6 +3,7 @@
 #include <QSignalSpy>
 #include <QtTest>
 
+#include <clocale>
 #include <cstring>
 
 class MpvItemTest : public QObject {
@@ -29,6 +30,11 @@ class MpvItemTest : public QObject {
     }
 
 private slots:
+    void initTestCase() {
+        // Match the application after Qt initializes the system locale.
+        std::setlocale(LC_NUMERIC, "C");
+    }
+
     void subtitleVariantMetadata_data() {
         QTest::addColumn<bool>("flag");
         QTest::newRow("variant") << true;


### PR DESCRIPTION
Native and engine changes previously passed CI without compiling the shell or reconstructing and testing its Rust helper. Add a macOS 26 ARM job for changes to the shell, bridge, engine, build scripts, workflow, and dependency locks. It builds the locked engine, checks its embedded profile and local tracker transfer, compiles and bundles the shell, and runs native tests plus launch and engine-supervision probes. The existing Validate check includes every applicable job.

Cache Homebrew downloads and Cargo outputs. Refresh Homebrew metadata and check libtorrent's minimum version before compiling. Match the native test executable's numeric locale setup to the application so libmpv initializes on runners with a non-C locale. The README documents CI coverage and the manual hardware playback release checks.

Validation:

- Clean hosted run [33960392890](https://github.com/chriscorbell/kino/actions/runs/33960392890) passes all web, engine, native, and aggregate checks on this head.
- A deliberate C++ compile error in [33958222138](https://github.com/chriscorbell/kino/actions/runs/33958222138) failed both the native job and Validate while web validation passed. The error is removed.
- `actionlint`, `pnpm check` with 114 tests, and native property tests under `LC_ALL=de_DE.UTF-8` pass. The locale test aborted before the setup correction.

Closes #66.
