### PR TITLE
Make the genre selector accessible with a native select

### DIFF
--- a/apps/desktop/src/App.module.css
+++ b/apps/desktop/src/App.module.css
@@ -1370,12 +1370,10 @@
   flex: 0 0 auto;
 }
 
-.genreButton {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+.genreSelect {
+  appearance: none;
   min-height: 32px;
-  padding: 0 14px;
+  padding: 0 34px 0 14px;
   border: 1px solid var(--kino-border);
   border-radius: var(--kino-pill-radius);
   color: var(--kino-text-muted);
@@ -1386,47 +1384,17 @@
   transition: border-color var(--kino-duration-fast) ease;
 }
 
-.genreButton:hover {
+.genreSelect:hover {
   border-color: var(--kino-text-faint);
 }
 
-.genreList {
+.genreMenu > svg {
   position: absolute;
-  z-index: var(--kino-layer-navigation);
-  top: calc(100% + 8px);
-  right: 0;
-  display: grid;
-  overflow-y: auto;
-  min-width: 180px;
-  max-height: 320px;
-  padding: 6px;
-  border: 1px solid var(--kino-border);
-  border-radius: var(--kino-panel-radius);
-  background: var(--kino-surface);
-  box-shadow: 0 12px 32px rgb(0 0 0 / 50%);
-  animation: enter var(--kino-duration-fast) var(--kino-ease-out);
-}
-
-.genreList button {
-  min-height: 32px;
-  padding: 0 12px;
-  border: 0;
-  border-radius: var(--kino-control-radius);
+  top: 50%;
+  right: 14px;
   color: var(--kino-text-muted);
-  background: transparent;
-  font: inherit;
-  font-size: 13px;
-  text-align: left;
-  cursor: pointer;
-}
-
-.genreList button:hover {
-  color: var(--kino-text);
-  background: var(--kino-border);
-}
-
-.genreList button[aria-pressed='true'] {
-  color: var(--kino-accent);
+  pointer-events: none;
+  transform: translateY(-50%);
 }
 
 .settingsGroup {
@@ -1612,7 +1580,6 @@
 @media (prefers-reduced-motion: reduce) {
   .accountDialog,
   .content,
-  .genreList,
   .skipIntro,
   .subtitlePanel,
   .upNext {
@@ -1622,7 +1589,7 @@
   .catalogTab,
   .catalogTabActive,
   .continueDismiss,
-  .genreButton,
+  .genreSelect,
   .libraryButton,
   .logoButton,
   .navButton,

--- a/apps/desktop/src/locales/en-US.ts
+++ b/apps/desktop/src/locales/en-US.ts
@@ -38,6 +38,7 @@ export const enUS = {
     typeLabel: 'Media type',
     catalogLabel: 'Catalog',
     allGenres: 'All Genres',
+    genreLabel: 'Genre',
   },
   library: {
     title: 'Library',

--- a/apps/desktop/src/screens/DiscoverScreen.tsx
+++ b/apps/desktop/src/screens/DiscoverScreen.tsx
@@ -1,5 +1,5 @@
 import { CaretDown } from '@phosphor-icons/react';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 
 import styles from '../App.module.css';
 import { MediaCard } from '../components/MediaCard';
@@ -15,8 +15,6 @@ function typeLabel(type: string) {
 
 export function DiscoverScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => void }) {
   const [request, setRequest] = useState<CatalogRequest | null>(null);
-  const [genresOpen, setGenresOpen] = useState(false);
-  const genreRef = useRef<HTMLDivElement>(null);
   const result = useCoreModel<CatalogWithFiltersState>(
     'discover',
     loadCatalogAction(request),
@@ -30,30 +28,11 @@ export function DiscoverScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => 
   const genreFilter = selectable?.extra.find(
     (extra) => !extra.isRequired && extra.options.length > 0,
   );
-  const selectedGenre = genreFilter?.options.find((option) => option.selected)?.value ?? null;
 
   const select = (link: string | undefined) => {
     const next = catalogRequestFromDeepLink(link);
     if (next) setRequest(next);
   };
-
-  useEffect(() => {
-    if (!genresOpen) return;
-    const onPointerDown = (event: PointerEvent) => {
-      if (!genreRef.current?.contains(event.target as Node)) setGenresOpen(false);
-    };
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') return;
-      setGenresOpen(false);
-      genreRef.current?.querySelector('button')?.focus();
-    };
-    window.addEventListener('pointerdown', onPointerDown);
-    window.addEventListener('keydown', onKeyDown);
-    return () => {
-      window.removeEventListener('pointerdown', onPointerDown);
-      window.removeEventListener('keydown', onKeyDown);
-    };
-  }, [genresOpen]);
 
   return (
     <div className={styles.page}>
@@ -92,33 +71,26 @@ export function DiscoverScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => 
           </div>
 
           {genreFilter ? (
-            <div className={styles.genreMenu} ref={genreRef}>
-              <button
-                aria-expanded={genresOpen}
-                className={styles.genreButton}
-                onClick={() => setGenresOpen((open) => !open)}
-                type="button"
+            <div className={styles.genreMenu}>
+              <select
+                aria-label={enUS.discover.genreLabel}
+                className={styles.genreSelect}
+                onChange={(event) => {
+                  const option = genreFilter.options[Number(event.target.value)];
+                  select(option?.deepLinks?.discover);
+                }}
+                value={Math.max(
+                  0,
+                  genreFilter.options.findIndex((option) => option.selected),
+                )}
               >
-                {selectedGenre ?? enUS.discover.allGenres}
-                <CaretDown aria-hidden size={13} />
-              </button>
-              {genresOpen ? (
-                <div className={styles.genreList} role="listbox">
-                  {genreFilter.options.map((option) => (
-                    <button
-                      aria-pressed={option.selected}
-                      key={option.value ?? 'all'}
-                      onClick={() => {
-                        select(option.deepLinks?.discover);
-                        setGenresOpen(false);
-                      }}
-                      type="button"
-                    >
-                      {option.value ?? enUS.discover.allGenres}
-                    </button>
-                  ))}
-                </div>
-              ) : null}
+                {genreFilter.options.map((option, index) => (
+                  <option key={option.value ?? 'all'} value={index}>
+                    {option.value ?? enUS.discover.allGenres}
+                  </option>
+                ))}
+              </select>
+              <CaretDown aria-hidden size={13} />
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
Replace the unnamed custom genre popup with a named native select. The selected option and keyboard behavior now come from the browser, while changing an option still follows the Core catalog deep link. Preserve Kino's dark styling, border, caret, focus outline, and reduced-motion behavior.

Validation: the browser check fails against the old unnamed control. With the native select, keyboard type-ahead chooses Action, selecting and dismissing retain focus, and All Genres clears the filter. Checked the control at 1280, 1000, and 320 px widths and inspected the rendered result. `pnpm check` passes with 114 tests.

Closes #47.
