### PR TITLE
Free mpv rendering resources during Qt renderer cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,18 @@ Validate the playback contract against generated legal fixtures — codecs, HDR 
 pnpm macos:check-playback
 ```
 
-Run the native property-event regression tests after building with:
+Run the native regression tests after building with:
 
 ```sh
 ctest --test-dir build/macos --output-on-failure
 pnpm macos:check-request-headers
+```
+
+The render lifetime test checks the real libmpv calls for the original current OpenGL context, callback removal, and render cleanup before core destruction. It exercises item and window deletion plus repeated scene-graph invalidation on the GUI thread and a dedicated render thread. To include repeated hardware playback and verify rendered frames after reconstruction, generate the fixtures above and run:
+
+```sh
+KINO_LIFETIME_MEDIA="$PWD/build/fixtures/h264-sdr-aac.mp4" \
+  ctest --test-dir build/macos -R render_lifetime --output-on-failure
 ```
 
 Direct media uses the add-on's original HTTPS URL and required request headers in libmpv, independent of any Stremio Service URL saved in the account. TLS certificate verification is required. The native header check drives the production WebChannel and player through a protected media request, external subtitles, and a second source. It verifies literal header values, prevents headers from carrying into subtitles or later sources, rejects header injection and untrusted certificates, and checks diagnostic output for synthetic credentials. It uses `openssl` for the untrusted certificate and generates a short H.264 fixture with `ffmpeg`, or uses `KINO_PLAYBACK_FIXTURE` when provided.

--- a/apps/macos-shell/CMakeLists.txt
+++ b/apps/macos-shell/CMakeLists.txt
@@ -141,6 +141,28 @@ if(BUILD_TESTING)
   add_test(NAME mpvitem_properties COMMAND kino_mpvitem_test)
   set_tests_properties(mpvitem_properties PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
+  # Interpose the real libmpv calls so wrong-context cleanup fails before UB.
+  add_library(kino_render_lifetime_guard SHARED tests/render_lifetime_guard.cpp)
+  target_link_libraries(kino_render_lifetime_guard PRIVATE PkgConfig::MPV "-framework OpenGL")
+  target_compile_options(kino_render_lifetime_guard PRIVATE -Wno-deprecated-declarations)
+  qt_add_executable(
+    kino_render_lifetime_test
+    tests/render_lifetime_test.cpp
+    src/mpvitem.cpp
+    src/powerguard.cpp
+  )
+  target_include_directories(kino_render_lifetime_test PRIVATE src)
+  target_link_libraries(
+    kino_render_lifetime_test
+    PRIVATE kino_render_lifetime_guard PkgConfig::MPV ${IOKIT_FRAMEWORK} Qt6::Quick Qt6::Test
+  )
+  add_test(NAME render_lifetime COMMAND kino_render_lifetime_test)
+  set_tests_properties(
+    render_lifetime
+    PROPERTIES TIMEOUT 60
+    ENVIRONMENT "QSG_RENDER_LOOP=basic;QSG_INFO=1;QT_LOGGING_RULES=qt.scenegraph.general=true"
+  )
+
   qt_add_executable(
     kino_logging_test
     tests/logging_test.cpp

--- a/apps/macos-shell/src/mpvitem.cpp
+++ b/apps/macos-shell/src/mpvitem.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <mutex>
 #include <stdexcept>
 
 namespace {
@@ -122,37 +123,64 @@ QVariantList subtitleTrackPayload(const mpv_node &root) {
 
 } // namespace
 
+struct MpvContext {
+    explicit MpvContext(MpvItem *owner) : item(owner), handle(mpv_create()) {}
+
+    ~MpvContext() {
+        // The last renderer has already freed its render context, so the core
+        // cannot wait for more frames while it shuts down.
+        if (handle) mpv_terminate_destroy(handle);
+    }
+
+    std::mutex callbackMutex;
+    MpvItem *item;
+    mpv_handle *handle;
+};
+
 class MpvRenderer final : public QQuickFramebufferObject::Renderer {
 public:
-    explicit MpvRenderer(MpvItem *item) : item_(item) {}
+    explicit MpvRenderer(std::shared_ptr<MpvContext> context)
+        : context_(std::move(context)) {}
+
+    ~MpvRenderer() override {
+        // Qt deletes its FBO renderer on the render thread with its GL context
+        // current, including when the scene graph is invalidated.
+        if (renderContext_) {
+            mpv_render_context_set_update_callback(renderContext_, nullptr, nullptr);
+            mpv_render_context_free(renderContext_);
+        }
+    }
 
     QOpenGLFramebufferObject *createFramebufferObject(const QSize &size) override {
-        if (!item_->renderContext_) {
+        if (!renderContext_) {
             mpv_opengl_init_params openGlParameters{resolveOpenGlSymbol, nullptr};
             mpv_render_param parameters[] = {
                 {MPV_RENDER_PARAM_API_TYPE, const_cast<char *>(MPV_RENDER_API_TYPE_OPENGL)},
                 {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &openGlParameters},
                 {MPV_RENDER_PARAM_INVALID, nullptr},
             };
-            const int result = mpv_render_context_create(&item_->renderContext_, item_->handle_,
+            const int result = mpv_render_context_create(&renderContext_, context_->handle,
                                                          parameters);
             if (result < 0) {
-                QMetaObject::invokeMethod(item_, [item = item_]() {
-                    item->emitError(QStringLiteral("render-context-unavailable"));
-                });
+                std::lock_guard lock(context_->callbackMutex);
+                if (auto *item = context_->item) {
+                    QMetaObject::invokeMethod(item, [item]() {
+                        item->emitError(QStringLiteral("render-context-unavailable"));
+                    }, Qt::QueuedConnection);
+                }
             } else {
-                mpv_render_context_set_update_callback(item_->renderContext_,
-                                                       MpvItem::onRenderUpdate, item_);
+                mpv_render_context_set_update_callback(renderContext_,
+                                                       MpvItem::onRenderUpdate, context_.get());
             }
         }
         return Renderer::createFramebufferObject(size);
     }
 
     void render() override {
-        if (!item_->renderContext_) {
+        if (!renderContext_) {
             return;
         }
-        mpv_render_context_update(item_->renderContext_);
+        mpv_render_context_update(renderContext_);
         QQuickOpenGLUtils::resetOpenGLState();
         QOpenGLFramebufferObject *target = framebufferObject();
         mpv_opengl_fbo frameBuffer{static_cast<int>(target->handle()), target->width(),
@@ -163,16 +191,18 @@ public:
             {MPV_RENDER_PARAM_FLIP_Y, &flipY},
             {MPV_RENDER_PARAM_INVALID, nullptr},
         };
-        mpv_render_context_render(item_->renderContext_, parameters);
+        mpv_render_context_render(renderContext_, parameters);
         QQuickOpenGLUtils::resetOpenGLState();
     }
 
 private:
-    MpvItem *item_;
+    std::shared_ptr<MpvContext> context_;
+    mpv_render_context *renderContext_ = nullptr;
 };
 
 MpvItem::MpvItem(QQuickItem *parent)
-    : QQuickFramebufferObject(parent), handle_(mpv_create()) {
+    : QQuickFramebufferObject(parent), context_(std::make_shared<MpvContext>(this)),
+      handle_(context_->handle) {
     if (!handle_) {
         throw std::runtime_error("could not create the mpv context");
     }
@@ -192,12 +222,14 @@ MpvItem::MpvItem(QQuickItem *parent)
 }
 
 MpvItem::~MpvItem() {
-    if (renderContext_) {
-        mpv_render_context_free(renderContext_);
+    {
+        // A callback may already be running on an mpv thread. Finish posting
+        // its queued call before detaching the receiver; Qt removes pending
+        // calls when the item is destroyed.
+        std::lock_guard lock(context_->callbackMutex);
+        context_->item = nullptr;
     }
-    if (handle_) {
-        mpv_terminate_destroy(handle_);
-    }
+    mpv_set_wakeup_callback(handle_, nullptr, nullptr);
 }
 
 bool MpvItem::active() const {
@@ -205,7 +237,7 @@ bool MpvItem::active() const {
 }
 
 QQuickFramebufferObject::Renderer *MpvItem::createRenderer() const {
-    return new MpvRenderer(const_cast<MpvItem *>(this));
+    return new MpvRenderer(context_);
 }
 
 void MpvItem::initialize() {
@@ -246,7 +278,7 @@ void MpvItem::initialize() {
         throw std::runtime_error("could not initialize mpv");
     }
 
-    mpv_set_wakeup_callback(handle_, &MpvItem::onWakeup, this);
+    mpv_set_wakeup_callback(handle_, &MpvItem::onWakeup, context_.get());
     mpv_request_log_messages(handle_, "warn");
     mpv_observe_property(handle_, 1, "time-pos", MPV_FORMAT_DOUBLE);
     mpv_observe_property(handle_, 2, "duration", MPV_FORMAT_DOUBLE);
@@ -434,12 +466,17 @@ void MpvItem::togglePaused() {
 }
 
 void MpvItem::onRenderUpdate(void *context) {
-    emit static_cast<MpvItem *>(context)->renderUpdateRequested();
+    auto &state = *static_cast<MpvContext *>(context);
+    std::lock_guard lock(state.callbackMutex);
+    if (state.item) emit state.item->renderUpdateRequested();
 }
 
 void MpvItem::onWakeup(void *context) {
-    QMetaObject::invokeMethod(static_cast<MpvItem *>(context), &MpvItem::processEvents,
-                              Qt::QueuedConnection);
+    auto &state = *static_cast<MpvContext *>(context);
+    std::lock_guard lock(state.callbackMutex);
+    if (state.item) {
+        QMetaObject::invokeMethod(state.item, &MpvItem::processEvents, Qt::QueuedConnection);
+    }
 }
 
 void MpvItem::processEvents() {

--- a/apps/macos-shell/src/mpvitem.h
+++ b/apps/macos-shell/src/mpvitem.h
@@ -7,10 +7,12 @@
 
 #include <mpv/client.h>
 #include <mpv/render_gl.h>
+#include <memory>
 
 #include "powerguard.h"
 
 class MpvRenderer;
+struct MpvContext;
 
 class MpvItem : public QQuickFramebufferObject {
     Q_OBJECT
@@ -63,8 +65,8 @@ private:
     bool paused_ = true;
     bool suppressMpvLogDetails_ = false;
     bool videoPresent_ = false;
+    std::shared_ptr<MpvContext> context_;
     mpv_handle *handle_ = nullptr;
-    mpv_render_context *renderContext_ = nullptr;
     PowerGuard powerGuard_;
     QTimer hardwareDecoderTimer_;
 };

--- a/apps/macos-shell/tests/render_lifetime_guard.cpp
+++ b/apps/macos-shell/tests/render_lifetime_guard.cpp
@@ -1,0 +1,121 @@
+// macOS dyld interposition checks the real libmpv calls before invalid cleanup
+// can invoke undefined behavior. This library is linked only by the test.
+#include <mpv/client.h>
+#include <mpv/render.h>
+#include <OpenGL/OpenGL.h>
+#include <pthread.h>
+
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <mutex>
+#include <unordered_map>
+
+namespace {
+struct Context {
+    CGLContextObj gl;
+    pthread_t thread;
+    mpv_handle *core;
+    bool callback = false;
+};
+std::mutex stateMutex;
+std::unordered_map<mpv_render_context *, Context> contexts;
+std::unordered_map<mpv_handle *, bool> wakeups;
+std::atomic<int> created = 0, freed = 0, destroyed = 0;
+
+[[noreturn]] void violation(const char *reason) {
+    std::fprintf(stderr, "KINO_RENDER_LIFETIME_FAILURE %s\n", reason);
+    std::fflush(stderr);
+    std::_Exit(86);
+}
+
+Context &checkedContext(mpv_render_context *context) {
+    auto it = contexts.find(context);
+    if (it == contexts.end()) violation("unknown-context");
+    if (CGLGetCurrentContext() != it->second.gl) violation("wrong-current-context");
+    if (!pthread_equal(pthread_self(), it->second.thread)) violation("wrong-thread");
+    return it->second;
+}
+
+int checkedCreate(mpv_render_context **out, mpv_handle *core, mpv_render_param *params) {
+    int result = mpv_render_context_create(out, core, params);
+    if (result >= 0) {
+        std::lock_guard lock(stateMutex);
+        if (!CGLGetCurrentContext()) violation("create-without-current-context");
+        contexts[*out] = {CGLGetCurrentContext(), pthread_self(), core};
+        ++created;
+    }
+    return result;
+}
+
+void checkedCallback(mpv_render_context *context, mpv_render_update_fn callback, void *data) {
+    {
+        std::lock_guard lock(stateMutex);
+        checkedContext(context).callback = callback != nullptr;
+    }
+    mpv_render_context_set_update_callback(context, callback, data);
+}
+
+uint64_t checkedUpdate(mpv_render_context *context) {
+    {
+        std::lock_guard lock(stateMutex);
+        checkedContext(context);
+    }
+    return mpv_render_context_update(context);
+}
+
+int checkedRender(mpv_render_context *context, mpv_render_param *params) {
+    {
+        std::lock_guard lock(stateMutex);
+        checkedContext(context);
+    }
+    return mpv_render_context_render(context, params);
+}
+
+void checkedFree(mpv_render_context *context) {
+    {
+        std::lock_guard lock(stateMutex);
+        if (checkedContext(context).callback) violation("render-callback-still-attached");
+        contexts.erase(context);
+    }
+    mpv_render_context_free(context);
+    ++freed;
+}
+
+void checkedWakeup(mpv_handle *core, void (*callback)(void *), void *data) {
+    {
+        std::lock_guard lock(stateMutex);
+        wakeups[core] = callback != nullptr;
+    }
+    mpv_set_wakeup_callback(core, callback, data);
+}
+
+void checkedDestroy(mpv_handle *core) {
+    {
+        std::lock_guard lock(stateMutex);
+        for (const auto &[_, context] : contexts) {
+            if (context.core == core) violation("core-destroyed-before-render-context");
+        }
+        if (wakeups[core]) violation("wakeup-callback-still-attached");
+        wakeups.erase(core);
+    }
+    mpv_terminate_destroy(core);
+    ++destroyed;
+}
+} // namespace
+
+extern "C" int kino_render_contexts_created() { return created.load(); }
+extern "C" int kino_render_contexts_freed() { return freed.load(); }
+extern "C" int kino_render_cores_destroyed() { return destroyed.load(); }
+
+#define INTERPOSE(replacement, replacee) \
+    __attribute__((used)) static struct { const void *newFunction; const void *oldFunction; } \
+    interpose_##replacee __attribute__((section("__DATA,__interpose"))) = \
+    {reinterpret_cast<const void *>(replacement), reinterpret_cast<const void *>(replacee)};
+INTERPOSE(checkedCreate, mpv_render_context_create)
+INTERPOSE(checkedCallback, mpv_render_context_set_update_callback)
+INTERPOSE(checkedUpdate, mpv_render_context_update)
+INTERPOSE(checkedRender, mpv_render_context_render)
+INTERPOSE(checkedFree, mpv_render_context_free)
+INTERPOSE(checkedWakeup, mpv_set_wakeup_callback)
+INTERPOSE(checkedDestroy, mpv_terminate_destroy)

--- a/apps/macos-shell/tests/render_lifetime_test.cpp
+++ b/apps/macos-shell/tests/render_lifetime_test.cpp
@@ -1,0 +1,246 @@
+#include "mpvitem.h"
+
+#include <QGuiApplication>
+#include <QOffscreenSurface>
+#include <QOpenGLContext>
+#include <QOpenGLFramebufferObject>
+#include <QQuickGraphicsDevice>
+#include <QQuickRenderControl>
+#include <QQuickRenderTarget>
+#include <QQuickWindow>
+#include <QSignalSpy>
+#include <QSurfaceFormat>
+#include <QThread>
+#include <functional>
+#include <QtTest>
+
+#include <clocale>
+
+extern "C" int kino_render_contexts_created();
+extern "C" int kino_render_contexts_freed();
+extern "C" int kino_render_cores_destroyed();
+
+// Unlike a window's resource-release hint, invalidate() always frees the
+// scene graph. Keep the item alive to check reconstruction on the same core.
+class OffscreenScene {
+    bool threaded_;
+    QThread renderThread_;
+    QObject worker_;
+    QThread *guiThread_ = QThread::currentThread();
+
+    void onRenderThread(const std::function<void()> &action) {
+        if (threaded_) QMetaObject::invokeMethod(&worker_, action, Qt::BlockingQueuedConnection);
+        else action();
+    }
+
+public:
+    explicit OffscreenScene(bool threaded) : threaded_(threaded) {}
+    QOffscreenSurface surface;
+    QOpenGLContext context;
+    QQuickRenderControl control;
+    QQuickWindow window{&control};
+    std::unique_ptr<QOpenGLFramebufferObject> target;
+    MpvItem *player = nullptr;
+
+    bool initialize() {
+        surface.setFormat(QSurfaceFormat::defaultFormat());
+        surface.create();
+        context.setFormat(surface.format());
+        if (!context.create() || !context.makeCurrent(&surface)) return false;
+        context.doneCurrent();
+        if (threaded_) {
+            context.moveToThread(&renderThread_);
+            worker_.moveToThread(&renderThread_);
+            control.prepareThread(&renderThread_);
+            renderThread_.start();
+        }
+        window.resize(320, 180);
+        window.setColor(Qt::black);
+        window.setGraphicsDevice(QQuickGraphicsDevice::fromOpenGLContext(&context));
+        player = new MpvItem(window.contentItem());
+        player->setSize(QSizeF(320, 180));
+        return initializeRendering();
+    }
+
+    bool initializeRendering() {
+        bool initialized = false;
+        onRenderThread([&]() {
+            if (!context.makeCurrent(&surface) || !control.initialize()) return;
+            target = std::make_unique<QOpenGLFramebufferObject>(QSize(320, 180));
+            window.setRenderTarget(QQuickRenderTarget::fromOpenGLTexture(target->texture(), target->size()));
+            initialized = true;
+        });
+        if (initialized) render();
+        return initialized;
+    }
+
+    void render() {
+        control.polishItems();
+        onRenderThread([&]() {
+            context.makeCurrent(&surface);
+            control.beginFrame();
+            control.sync();
+            control.render();
+            control.endFrame();
+        });
+    }
+
+    bool hasVideoPixels() {
+        QImage frame;
+        onRenderThread([&]() {
+            context.makeCurrent(&surface);
+            frame = target->toImage();
+        });
+        QSet<QRgb> colors;
+        for (int y = 0; y < frame.height(); y += 8) {
+            for (int x = 0; x < frame.width(); x += 8) colors.insert(frame.pixel(x, y));
+        }
+        return colors.size() > 20;
+    }
+
+    void invalidate() {
+        onRenderThread([&]() {
+            context.makeCurrent(&surface);
+            control.invalidate();
+            window.setRenderTarget({});
+            target.reset();
+        });
+    }
+
+    ~OffscreenScene() {
+        if (!player) return;
+        invalidate();
+        if (threaded_) {
+            onRenderThread([&]() {
+                context.doneCurrent();
+                context.moveToThread(guiThread_);
+                control.prepareThread(guiThread_);
+                worker_.moveToThread(guiThread_);
+            });
+            renderThread_.quit();
+            renderThread_.wait();
+        }
+    }
+};
+
+class RenderLifetimeTest : public QObject {
+    Q_OBJECT
+
+    static MpvItem *createPlayer(QQuickWindow &window) {
+        window.resize(320, 180);
+        window.setPersistentGraphics(false);
+        window.setPersistentSceneGraph(false);
+        auto *player = new MpvItem(window.contentItem());
+        player->setSize(QSizeF(320, 180));
+        window.show();
+        return player;
+    }
+
+private slots:
+    void itemAndWindowDeletion_data() {
+        QTest::addColumn<bool>("itemFirst");
+        QTest::newRow("item-before-window") << true;
+        QTest::newRow("window-owns-item") << false;
+    }
+
+    void itemAndWindowDeletion() {
+        QFETCH(bool, itemFirst);
+        for (int iteration = 0; iteration < 3; ++iteration) {
+            const int created = kino_render_contexts_created();
+            const int freed = kino_render_contexts_freed();
+            const int destroyed = kino_render_cores_destroyed();
+            auto window = std::make_unique<QQuickWindow>();
+            auto *player = createPlayer(*window);
+            QVERIFY(QTest::qWaitForWindowExposed(window.get()));
+            QTRY_COMPARE(kino_render_contexts_created(), created + 1);
+            // GUI item destruction must not depend on a context Qt happened
+            // to leave current after its previous frame.
+            if (auto *context = QOpenGLContext::currentContext()) context->doneCurrent();
+            if (itemFirst) delete player;
+            window.reset();
+            QTRY_COMPARE(kino_render_contexts_freed(), freed + 1);
+            QTRY_COMPARE(kino_render_cores_destroyed(), destroyed + 1);
+        }
+    }
+
+    void sceneGraphInvalidation_data() {
+        QTest::addColumn<bool>("threaded");
+        QTest::newRow("gui-rendering") << false;
+        QTest::newRow("dedicated-render-thread") << true;
+    }
+
+    void sceneGraphInvalidation() {
+        QFETCH(bool, threaded);
+        const int created = kino_render_contexts_created();
+        const int freed = kino_render_contexts_freed();
+        const int destroyed = kino_render_cores_destroyed();
+        {
+            OffscreenScene scene(threaded);
+            QVERIFY(scene.initialize());
+            QCOMPARE(kino_render_contexts_created(), created + 1);
+            for (int iteration = 0; iteration < 3; ++iteration) {
+                scene.invalidate();
+                QCOMPARE(kino_render_contexts_freed(), freed + iteration + 1);
+                QCOMPARE(kino_render_cores_destroyed(), destroyed);
+                QVERIFY(scene.initializeRendering());
+                QCOMPARE(kino_render_contexts_created(), created + iteration + 2);
+            }
+        }
+        QCOMPARE(kino_render_contexts_freed(), freed + 4);
+        QCOMPARE(kino_render_cores_destroyed(), destroyed + 1);
+    }
+
+    void playbackAcrossInvalidation_data() { sceneGraphInvalidation_data(); }
+
+    void playbackAcrossInvalidation() {
+        QFETCH(bool, threaded);
+        const QString media = qEnvironmentVariable("KINO_LIFETIME_MEDIA");
+        if (media.isEmpty()) QSKIP("Set KINO_LIFETIME_MEDIA to a legal video fixture for playback validation.");
+        OffscreenScene scene(threaded);
+        QVERIFY(scene.initialize());
+        auto *player = scene.player;
+        QSignalSpy events(player, &MpvItem::playerEvent);
+        auto played = [&events, &scene]() {
+            scene.render();
+            for (const auto &event : events) {
+                if (event.at(0) == QStringLiteral("time") &&
+                    event.at(1).toMap().value("milliseconds").toLongLong() >= 500) return scene.hasVideoPixels();
+            }
+            return false;
+        };
+        for (int iteration = 0; iteration < 3; ++iteration) {
+            events.clear();
+            player->load(media, true);
+            QTRY_VERIFY_WITH_TIMEOUT(played(), 10'000);
+            player->stop();
+            const int freed = kino_render_contexts_freed();
+            scene.invalidate();
+            QCOMPARE(kino_render_contexts_freed(), freed + 1);
+            QVERIFY(scene.initializeRendering());
+        }
+        events.clear();
+        player->load(media, true);
+        QTRY_VERIFY_WITH_TIMEOUT(played(), 10'000);
+        // Delete the item while playback and callbacks are still active, then
+        // release the render resources that retained its core.
+        delete player;
+        scene.invalidate();
+    }
+};
+
+int main(int argc, char **argv) {
+    QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+    QSurfaceFormat format;
+    format.setDepthBufferSize(24);
+    format.setProfile(QSurfaceFormat::CoreProfile);
+    format.setRenderableType(QSurfaceFormat::OpenGL);
+    format.setVersion(4, 1);
+    QSurfaceFormat::setDefaultFormat(format);
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
+    QGuiApplication app(argc, argv);
+    std::setlocale(LC_NUMERIC, "C");
+    RenderLifetimeTest test;
+    return QTest::qExec(&test, argc, argv);
+}
+
+#include "render_lifetime_test.moc"


### PR DESCRIPTION
Deleting the QML player freed libmpv's OpenGL render context from the item's destructor, without its original GL context current. Move that resource into Qt's framebuffer renderer. A shared owner keeps the mpv core alive until the last renderer releases it, and synchronized receiver detachment prevents render and wakeup callbacks from accessing a destroyed item. Both callbacks are removed before their resources are destroyed.

Add a native regression test that interposes the real libmpv calls and fails before an invalid context, thread, callback, or destruction order can cause undefined behavior. It exercises item/window deletion and repeated scene-graph reconstruction on the GUI thread and a dedicated offscreen render thread. Optional legal video fixtures check rendered pixels after each replay and deletion during active playback. The test library is not linked into Kino.

Validation:

- The original production playback probe completed its H.264 fixture and then failed the cleanup guard with `free-with-wrong-current-context`. The updated app completes with render cleanup before core destruction.
- The permanent regression test rejects the original code with `wrong-current-context` and exit 86.
- `pnpm check` passes with 114 tests, pinned Core integrations, vendor reconstruction, and the production UI build.
- `pnpm macos:build`, `pnpm macos:check-launch`, and all four native CTest suites pass. The lifetime suite also passes with H.264 playback and OpenGL diagnostics enabled on both render threads.

Qt's forced threaded on-screen OpenGL loop aborts in AppKit on this macOS version before the player renderer is created. Dedicated-thread coverage uses Qt's supported offscreen render-control API; window deletion coverage uses the normal macOS render loop.

Closes #64.
