### PR TITLE
Make fullscreen a synchronized toggle with Escape exit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,7 @@ jobs:
           ctest --test-dir build/macos --output-on-failure --timeout 30
           pnpm macos:check-launch
           pnpm macos:check-engine
+          pnpm macos:check-fullscreen
 
   validate:
     name: Validate

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The shell loads the packaged Kino UI, keeps Stremio authentication material in a
 pnpm macos:check-launch
 ```
 
+The fullscreen button and F toggle the current window state. Escape exits fullscreen after closing any open subtitle menu. The native bridge follows Qt window visibility, including changes through macOS window controls. Run `pnpm macos:check-fullscreen` to verify the actual WebChannel property and change notifications through repeated entry and exit.
+
 Validate the playback contract against generated legal fixtures — codecs, HDR ranges, audio formats, subtitles, chapters, and failure paths — with:
 
 ```sh

--- a/apps/desktop/src/App.module.css
+++ b/apps/desktop/src/App.module.css
@@ -681,6 +681,13 @@
   font-size: 16px;
 }
 
+.fullscreenError {
+  margin-bottom: 8px;
+  color: var(--kino-text);
+  font-size: 13px;
+  text-align: center;
+}
+
 .skipIntro {
   position: absolute;
   right: 36px;

--- a/apps/desktop/src/locales/en-US.ts
+++ b/apps/desktop/src/locales/en-US.ts
@@ -120,6 +120,9 @@ export const enUS = {
     inLibrary: 'In Library',
   },
   player: {
+    enterFullscreen: 'Enter fullscreen',
+    exitFullscreen: 'Exit fullscreen',
+    fullscreenFailed: 'Fullscreen could not be changed. Try again.',
     saveFailed: 'Progress could not be saved. Try closing playback again.',
     upNext: 'Up Next',
     chooseSource: 'Choose source',

--- a/apps/desktop/src/native/player.ts
+++ b/apps/desktop/src/native/player.ts
@@ -9,6 +9,11 @@ export interface NativeEngineEvent {
 }
 
 export interface NativePlayer {
+  readonly fullscreen: boolean;
+  fullscreenChanged: {
+    connect(listener: () => void): void;
+    disconnect(listener: () => void): void;
+  };
   addSubtitles(url: string, title: string, lang: string): void;
   load(url: string, forceStereo: boolean, headers: Record<string, string>): void;
   pauseAndSnapshot(): Promise<{ duration: number; time: number }>;

--- a/apps/desktop/src/player/useFullscreen.test.tsx
+++ b/apps/desktop/src/player/useFullscreen.test.tsx
@@ -1,0 +1,65 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+import { useFullscreen } from './useFullscreen';
+
+const container = { current: document.createElement('div') };
+let current: Element | null = null;
+const enter = vi.fn();
+const exit = vi.fn();
+
+beforeEach(() => {
+  current = null;
+  enter.mockReset().mockResolvedValue(undefined);
+  exit.mockReset().mockResolvedValue(undefined);
+  Object.defineProperty(document, 'fullscreenElement', { configurable: true, get: () => current });
+  Object.defineProperty(document, 'exitFullscreen', { configurable: true, value: exit });
+  container.current.requestFullscreen = enter;
+});
+afterEach(() => {
+  Reflect.deleteProperty(document, 'fullscreenElement');
+  Reflect.deleteProperty(document, 'exitFullscreen');
+});
+
+it('follows browser events and actual fullscreen state instead of assuming requests succeeded', () => {
+  const { result } = renderHook(() => useFullscreen(container, null));
+  act(() => result.current.toggle());
+  expect(enter).toHaveBeenCalledOnce();
+  expect(result.current.fullscreen).toBe(false);
+  act(() => {
+    current = container.current;
+    document.dispatchEvent(new Event('fullscreenchange'));
+  });
+  expect(result.current.fullscreen).toBe(true);
+  act(() => result.current.toggle());
+  expect(exit).toHaveBeenCalledOnce();
+  act(() => {
+    current = null;
+    document.dispatchEvent(new Event('fullscreenchange'));
+  });
+  expect(result.current.fullscreen).toBe(false);
+});
+
+it('handles rejected requests and allows a successful retry', async () => {
+  enter.mockRejectedValueOnce(new TypeError('User activation required'));
+  const { result } = renderHook(() => useFullscreen(container, null));
+  act(() => result.current.toggle());
+  await waitFor(() =>
+    expect(result.current.error).toBe('Fullscreen could not be changed. Try again.'),
+  );
+  expect(result.current.fullscreen).toBe(false);
+  act(() => result.current.toggle());
+  expect(result.current.error).toBeNull();
+  expect(enter).toHaveBeenCalledTimes(2);
+});
+
+it('reports browser fullscreen errors and removes event listeners on unmount', () => {
+  const remove = vi.spyOn(document, 'removeEventListener');
+  const { result, unmount } = renderHook(() => useFullscreen(container, null));
+  act(() => document.dispatchEvent(new Event('fullscreenerror')));
+  expect(result.current.error).toBe('Fullscreen could not be changed. Try again.');
+  unmount();
+  expect(remove).toHaveBeenCalledWith('fullscreenchange', expect.any(Function));
+  expect(remove).toHaveBeenCalledWith('fullscreenerror', expect.any(Function));
+  remove.mockRestore();
+});

--- a/apps/desktop/src/player/useFullscreen.ts
+++ b/apps/desktop/src/player/useFullscreen.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useState, type RefObject } from 'react';
+
+import { t } from '../locales';
+import type { NativePlayer } from '../native/player';
+
+export function useFullscreen(
+  container: RefObject<HTMLElement | null>,
+  nativePlayer: NativePlayer | null,
+) {
+  const [fullscreen, setFullscreen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const changed = () => {
+      setFullscreen(
+        nativePlayer ? nativePlayer.fullscreen : document.fullscreenElement === container.current,
+      );
+      setError(null);
+    };
+    if (nativePlayer) {
+      nativePlayer.fullscreenChanged.connect(changed);
+      changed();
+      return () => nativePlayer.fullscreenChanged.disconnect(changed);
+    }
+    const failed = () => setError(t.player.fullscreenFailed);
+    document.addEventListener('fullscreenchange', changed);
+    document.addEventListener('fullscreenerror', failed);
+    changed();
+    return () => {
+      document.removeEventListener('fullscreenchange', changed);
+      document.removeEventListener('fullscreenerror', failed);
+    };
+  }, [container, nativePlayer]);
+
+  const change = useCallback(
+    async (enabled: boolean) => {
+      setError(null);
+      try {
+        if (nativePlayer) {
+          nativePlayer.setFullscreen(enabled);
+        } else if (enabled) {
+          if (!container.current) return;
+          await container.current.requestFullscreen();
+        } else if (document.fullscreenElement) {
+          await document.exitFullscreen();
+        }
+      } catch {
+        setError(t.player.fullscreenFailed);
+      }
+    },
+    [container, nativePlayer],
+  );
+
+  const toggle = useCallback(() => {
+    const current = nativePlayer
+      ? nativePlayer.fullscreen
+      : document.fullscreenElement === container.current;
+    void change(!current);
+  }, [change, container, nativePlayer]);
+  const exit = useCallback(() => void change(false), [change]);
+
+  return { error, exit, fullscreen, toggle };
+}

--- a/apps/desktop/src/screens/PlayerScreen.discovery.test.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.discovery.test.tsx
@@ -12,6 +12,8 @@ const fixture = vi.hoisted(() => ({
   native: {
     load: vi.fn(),
     stop: vi.fn(),
+    fullscreen: false,
+    fullscreenChanged: { connect: vi.fn(), disconnect: vi.fn() },
     playerEvent: { connect: vi.fn(), disconnect: vi.fn() },
     setSubtitleScale: vi.fn(),
     setSubtitlePosition: vi.fn(),

--- a/apps/desktop/src/screens/PlayerScreen.keyboard.test.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.keyboard.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, expect, it, vi } from 'vitest';
 
@@ -7,7 +7,14 @@ import { PlayerScreen } from './PlayerScreen';
 
 const fixture = vi.hoisted(() => ({
   stream: { url: 'https://media.invalid/fixture.mp4', deepLinks: { player: '' } },
+  transport: { dispatch: vi.fn().mockResolvedValue(undefined) },
+  unload: vi.fn().mockResolvedValue(undefined),
   native: {
+    fullscreen: false,
+    fullscreenChanged: {
+      connect: vi.fn<(listener: () => void) => void>(),
+      disconnect: vi.fn(),
+    },
     load: vi.fn(),
     stop: vi.fn(),
     pauseAndSnapshot: vi.fn().mockResolvedValue({ time: 0, duration: 0 }),
@@ -27,19 +34,20 @@ vi.mock('../native/player', () => ({
   connectNativePlayer: async () => fixture.native,
 }));
 vi.mock('../core/context', () => ({
-  useCore: () => ({ transport: { dispatch: async () => {} } }),
+  useCore: () => ({ transport: fixture.transport }),
 }));
 vi.mock('../core/useCoreModel', () => ({
   useCoreModel: () => ({
     state: { stream: { type: 'Ready', content: fixture.stream } },
     loading: false,
     error: null,
-    unload: async () => {},
+    unload: fixture.unload,
   }),
 }));
 
 beforeEach(() => {
   vi.clearAllMocks();
+  fixture.native.fullscreen = false;
 });
 
 async function mountPlayer() {
@@ -115,4 +123,34 @@ it('keeps unmodified playback shortcuts available on the player background', asy
   expect(fixture.native.setPaused).toHaveBeenCalledExactlyOnceWith(false);
   expect(fireEvent.keyDown(window, { key: 'ArrowRight', code: 'ArrowRight' })).toBe(false);
   expect(fixture.native.seek).toHaveBeenCalledExactlyOnceWith(10);
+});
+
+it('toggles from actual native fullscreen state and exits with Escape from focused controls', async () => {
+  await mountPlayer();
+  fireEvent.click(screen.getByRole('button', { name: 'Enter fullscreen' }));
+  expect(fixture.native.setFullscreen).toHaveBeenLastCalledWith(true);
+  act(() => {
+    fixture.native.fullscreen = true;
+    fixture.native.fullscreenChanged.connect.mock.lastCall?.[0]();
+  });
+  const exit = screen.getByRole('button', { name: 'Exit fullscreen' });
+  fireEvent.click(exit);
+  expect(fixture.native.setFullscreen).toHaveBeenLastCalledWith(false);
+  fixture.native.setFullscreen.mockClear();
+  fireEvent.keyDown(window, { key: 'f', code: 'KeyF' });
+  expect(fixture.native.setFullscreen).toHaveBeenLastCalledWith(false);
+  fixture.native.setFullscreen.mockClear();
+  fireEvent.keyDown(exit, { key: 'Escape', code: 'Escape' });
+  expect(fixture.native.setFullscreen).toHaveBeenLastCalledWith(false);
+});
+
+it('uses Escape to close subtitles before exiting fullscreen', async () => {
+  fixture.native.fullscreen = true;
+  await mountPlayer();
+  fireEvent.click(screen.getByRole('button', { name: 'Subtitles' }));
+  fireEvent.keyDown(window, { key: 'Escape', code: 'Escape' });
+  expect(screen.queryByRole('button', { name: 'Off' })).not.toBeInTheDocument();
+  expect(fixture.native.setFullscreen).not.toHaveBeenCalled();
+  fireEvent.keyDown(window, { key: 'Escape', code: 'Escape' });
+  expect(fixture.native.setFullscreen).toHaveBeenLastCalledWith(false);
 });

--- a/apps/desktop/src/screens/PlayerScreen.shutdown.test.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.shutdown.test.tsx
@@ -16,6 +16,8 @@ const native = vi.hoisted(() => {
     setSubtitleScale: vi.fn(),
     setSubtitlePosition: vi.fn(),
     setNowPlayingMetadata: vi.fn(),
+    fullscreen: false,
+    fullscreenChanged: { connect: vi.fn(), disconnect: vi.fn() },
     playerEvent: {
       connect: (listener: (name: string, payload: Record<string, unknown>) => void) =>
         listeners.add(listener),

--- a/apps/desktop/src/screens/PlayerScreen.subtitles.test.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.subtitles.test.tsx
@@ -11,6 +11,8 @@ const fixture = vi.hoisted(() => ({
   native: {
     load: vi.fn(),
     stop: vi.fn(),
+    fullscreen: false,
+    fullscreenChanged: { connect: vi.fn(), disconnect: vi.fn() },
     playerEvent: { connect: vi.fn(), disconnect: vi.fn() },
     setSubtitleTrack: vi.fn(),
     setSubtitleScale: vi.fn(),

--- a/apps/desktop/src/screens/PlayerScreen.test.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.test.tsx
@@ -10,6 +10,8 @@ const native = vi.hoisted(() => ({
   load: vi.fn(),
   pauseAndSnapshot: vi.fn().mockResolvedValue({ time: 0, duration: 0 }),
   stop: vi.fn(),
+  fullscreen: false,
+  fullscreenChanged: { connect: vi.fn(), disconnect: vi.fn() },
   playerEvent: { connect: vi.fn(), disconnect: vi.fn() },
   setSubtitleScale: vi.fn(),
   setSubtitlePosition: vi.fn(),

--- a/apps/desktop/src/screens/PlayerScreen.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.tsx
@@ -1,5 +1,6 @@
 import {
   ArrowLeft,
+  ArrowsIn,
   ArrowsOut,
   Minus,
   Pause,
@@ -44,6 +45,7 @@ import {
 } from '../player/torrent';
 import { subtitlePositionRange, subtitleSizeRange, type KinoSettings } from '../settings';
 import { videoParams } from '../player/videoParams';
+import { useFullscreen } from '../player/useFullscreen';
 
 function formatTime(milliseconds: number) {
   const seconds = Math.max(0, Math.floor(milliseconds / 1000));
@@ -147,6 +149,12 @@ export function PlayerScreen({
   const [muted, setMuted] = useState(false);
   const [buffering, setBuffering] = useState(false);
   const [nativePlayer, setNativePlayer] = useState<NativePlayer | null>(null);
+  const {
+    error: fullscreenError,
+    exit: exitFullscreen,
+    fullscreen,
+    toggle: toggleFullscreen,
+  } = useFullscreen(containerRef, nativePlayer);
   const [chapterCues, setChapterCues] = useState<ChapterCue[]>([]);
   const [communityMarker, setCommunityMarker] = useState<IntroMarker | null>(null);
   const [automaticSkipComplete, setAutomaticSkipComplete] = useState(false);
@@ -366,14 +374,6 @@ export function PlayerScreen({
     }
   }, [muted, nativePlayer]);
 
-  const enterFullscreen = useCallback(() => {
-    if (nativePlayer) {
-      nativePlayer.setFullscreen(true);
-    } else {
-      void containerRef.current?.requestFullscreen();
-    }
-  }, [nativePlayer]);
-
   const selectSubtitleTrack = (id: number | null) => {
     if (!nativePlayer) return;
     subtitleAutoDoneRef.current = true;
@@ -449,7 +449,10 @@ export function PlayerScreen({
       if (!subtitleMenuRef.current?.contains(event.target as Node)) setSubtitleMenuOpen(false);
     };
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setSubtitleMenuOpen(false);
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setSubtitleMenuOpen(false);
+      }
     };
     window.addEventListener('pointerdown', onPointerDown);
     window.addEventListener('keydown', onKeyDown);
@@ -662,6 +665,13 @@ export function PlayerScreen({
         event.shiftKey
       )
         return;
+      if (event.key === 'Escape') {
+        if (!subtitleMenuOpen && fullscreen) {
+          event.preventDefault();
+          exitFullscreen();
+        }
+        return;
+      }
       // Focused controls own Space, arrows, and text entry. In particular the
       // timeline's native arrow step must not become a global ten-second seek.
       if (
@@ -690,12 +700,22 @@ export function PlayerScreen({
         toggleMuted();
       } else if (event.key.toLowerCase() === 'f') {
         event.preventDefault();
-        enterFullscreen();
+        toggleFullscreen();
       }
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [enterFullscreen, nativePlayer, reportProgress, seekTo, toggleMuted, togglePlayback]);
+  }, [
+    exitFullscreen,
+    fullscreen,
+    nativePlayer,
+    reportProgress,
+    seekTo,
+    subtitleMenuOpen,
+    toggleFullscreen,
+    toggleMuted,
+    togglePlayback,
+  ]);
 
   const insideIntro = Boolean(marker && time >= marker.startMs && time < marker.endMs);
   const markerStyle = useMemo(() => {
@@ -911,6 +931,11 @@ export function PlayerScreen({
               </div>
             </div>
           ) : null}
+          {fullscreenError ? (
+            <div className={styles.fullscreenError} role="alert">
+              {fullscreenError}
+            </div>
+          ) : null}
           <div className={styles.timeline}>
             {markerStyle ? <span className={styles.introRange} style={markerStyle} /> : null}
             <input
@@ -951,8 +976,16 @@ export function PlayerScreen({
                 <Subtitles aria-hidden size={20} />
               </button>
             ) : null}
-            <button aria-label="Fullscreen" onClick={enterFullscreen} type="button">
-              <ArrowsOut aria-hidden size={20} />
+            <button
+              aria-label={fullscreen ? enUS.player.exitFullscreen : enUS.player.enterFullscreen}
+              onClick={toggleFullscreen}
+              type="button"
+            >
+              {fullscreen ? (
+                <ArrowsIn aria-hidden size={20} />
+              ) : (
+                <ArrowsOut aria-hidden size={20} />
+              )}
             </button>
           </div>
         </div>

--- a/apps/macos-shell/qml/Main.qml
+++ b/apps/macos-shell/qml/Main.qml
@@ -61,6 +61,7 @@ ApplicationWindow {
 
         readonly property string platform: "macos"
         readonly property string shellVersion: Qt.application.version
+        readonly property bool fullscreen: root.visibility === Window.FullScreen
 
         signal playerEvent(string name, var payload)
         signal streamingEngineChanged(string url, string error)

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "macos:check-engine": "./scripts/check-macos-engine.sh",
     "macos:check-engine-ui": "node scripts/check-macos-engine-ui.mjs",
     "macos:check-engine-retry": "node scripts/check-macos-engine-retry.mjs",
+    "macos:check-fullscreen": "node scripts/check-macos-fullscreen.mjs",
     "macos:check-launch": "./scripts/check-macos-launch.sh",
     "macos:check-playback": "node scripts/check-macos-playback.mjs",
     "macos:check-request-headers": "node scripts/check-macos-request-headers.mjs",

--- a/scripts/check-macos-fullscreen.mjs
+++ b/scripts/check-macos-fullscreen.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { createServer } from 'node:http';
+import { resolve } from 'node:path';
+
+const binary = process.env.KINO_APP_BINARY ?? resolve('build/macos/Kino.app/Contents/MacOS/Kino');
+let report;
+const server = createServer((request, response) => {
+  if (request.url === '/result') {
+    let body = '';
+    request.on('data', (chunk) => {
+      body += chunk;
+    });
+    request.on('end', () => {
+      report = JSON.parse(body);
+      response.end('received');
+    });
+    return;
+  }
+  response.setHeader('Content-Type', 'text/html');
+  response.end(`<!doctype html><meta charset="utf-8"><title>Kino fullscreen check</title>
+<script src="qrc:///qtwebchannel/qwebchannel.js"></script><script>
+new QWebChannel(qt.webChannelTransport, async channel => {
+  const native = channel.objects.kinoNative, lifecycle = channel.objects.kinoLifecycle;
+  lifecycle.closeRequested.connect(id => lifecycle.acknowledgeClose(id, true));
+  const result = { initial: native.fullscreen, changes: [] };
+  try {
+    if (typeof native.fullscreen !== 'boolean' || !native.fullscreenChanged)
+      throw new Error('Fullscreen property and change signal are required.');
+    for (const enabled of [true, false, true, false]) {
+      await new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('Fullscreen state did not change.')), 5000);
+        const changed = () => {
+          if (native.fullscreen !== enabled) return;
+          result.changes.push(native.fullscreen);
+          clearTimeout(timer);
+          native.fullscreenChanged.disconnect(changed);
+          resolve();
+        };
+        native.fullscreenChanged.connect(changed);
+        native.setFullscreen(enabled);
+      });
+      // Allow macOS to finish its window transition before reversing it.
+      await new Promise(resolve => setTimeout(resolve, 750));
+    }
+  } catch (error) { result.error = error.message; }
+  await fetch('/result', { method: 'POST', body: JSON.stringify(result) });
+  lifecycle.setReady(true);
+});
+</script>`);
+});
+let child;
+let timer;
+try {
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const origin = `http://127.0.0.1:${server.address().port}`;
+  child = spawn(binary, [], {
+    env: { ...process.env, KINO_UI_URL: origin, KINO_CLOSE_PROBE: 'window' },
+    stdio: ['ignore', 'ignore', 'pipe'],
+  });
+  let diagnostics = '';
+  child.stderr.on('data', (data) => {
+    diagnostics = (diagnostics + data).slice(-8000);
+  });
+  const result = await Promise.race([
+    once(child, 'exit'),
+    new Promise((_resolve, reject) => {
+      timer = setTimeout(
+        () => reject(new Error(`Fullscreen probe timed out: ${diagnostics}`)),
+        30000,
+      );
+    }),
+  ]);
+  assert.deepEqual(result, [0, null], `The native shell must close normally: ${diagnostics}`);
+  assert.deepEqual(report, { initial: false, changes: [true, false, true, false] });
+  console.log('Native WebChannel reports actual fullscreen state through repeated entry and exit.');
+} finally {
+  clearTimeout(timer);
+  if (child && child.exitCode === null && child.signalCode === null) {
+    const exited = once(child, 'exit');
+    child.kill('SIGKILL');
+    await exited;
+  }
+  server.closeAllConnections();
+  await new Promise((resolve) => server.close(resolve));
+}


### PR DESCRIPTION
Fullscreen controls always requested entry, so repeating the button or F could not leave fullscreen. Expose Qt's actual window visibility through a read-only WebChannel property and subscribe to its notifications. The player now toggles the current native or browser state, changes its icon and action label, and exits with Escape even when a control is focused. An open subtitle menu consumes Escape first.

Browser fullscreen events keep the state current. Rejected requests display a retryable message above the timeline without ending playback. Add a production WebChannel probe to native CI for repeated entry and exit. Native fixtures include the new property, with stable transport callbacks to avoid reloading the player during state updates.

Validation:

- Two new player interaction regressions failed before implementation and pass after it.
- `pnpm check` passes with 119 tests, pinned Core integrations, vendor reconstruction, and the production UI build. `actionlint` passes.
- Real Chrome checks pass for button entry/exit, F, Escape from a focused control, rejected request and retry, and subtitle-menu Escape priority.
- `pnpm macos:build` and `pnpm macos:check-fullscreen` pass. The probe reads the real Qt WebChannel property and receives `[true, false, true, false]` from window changes.

Closes #46.
