### PR TITLE
Keep account dialog focus inside the modal and restore its trigger

### DIFF
--- a/apps/desktop/src/App.module.css
+++ b/apps/desktop/src/App.module.css
@@ -912,23 +912,21 @@
   font-variant-numeric: tabular-nums;
 }
 
-.dialogBackdrop {
-  position: fixed;
-  z-index: calc(var(--kino-layer-dialog) + 1);
-  inset: 0;
-  display: grid;
-  padding: 24px;
-  place-items: center;
+.accountDialog::backdrop {
   background: rgb(0 0 0 / 72%);
   backdrop-filter: blur(12px);
 }
 
 .accountDialog {
-  position: relative;
-  width: min(100%, 420px);
+  position: fixed;
+  inset: 0;
+  width: min(calc(100% - 48px), 420px);
+  max-height: calc(100% - 48px);
+  margin: auto;
   padding: 34px;
   border: 1px solid var(--kino-border);
   border-radius: var(--kino-panel-radius);
+  color: var(--kino-text);
   background: var(--kino-surface);
   box-shadow: 0 24px 80px rgb(0 0 0 / 48%);
   animation: enter var(--kino-duration-standard) var(--kino-ease-out);

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -1,11 +1,32 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import { App } from './App';
 import { SETTINGS_STORAGE_KEY } from './settings';
 
 describe('App', () => {
+  // jsdom lacks the native dialog methods and browser-generated cancel event.
+  beforeAll(() => {
+    Object.defineProperties(HTMLDialogElement.prototype, {
+      showModal: {
+        configurable: true,
+        value(this: HTMLDialogElement) {
+          this.open = true;
+        },
+      },
+      close: {
+        configurable: true,
+        value(this: HTMLDialogElement) {
+          this.open = false;
+        },
+      },
+    });
+  });
+  afterAll(() => {
+    Reflect.deleteProperty(HTMLDialogElement.prototype, 'showModal');
+    Reflect.deleteProperty(HTMLDialogElement.prototype, 'close');
+  });
   beforeEach(() => {
     window.localStorage.clear();
   });
@@ -55,9 +76,10 @@ describe('App', () => {
 
     expect(screen.getByRole('dialog', { name: 'Sign in to Stremio' })).toBeInTheDocument();
 
-    await user.keyboard('{Escape}');
+    fireEvent(screen.getByRole('dialog'), new Event('cancel', { cancelable: true }));
 
     expect(screen.queryByRole('dialog', { name: 'Sign in to Stremio' })).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Home' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign in to Stremio' })).toHaveFocus();
   });
 });

--- a/apps/desktop/src/components/AccountDialog.tsx
+++ b/apps/desktop/src/components/AccountDialog.tsx
@@ -1,5 +1,5 @@
 import { X } from '@phosphor-icons/react';
-import { useCallback, useEffect, useState, type FormEvent } from 'react';
+import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react';
 
 import logo from '../assets/kino.svg';
 import styles from '../App.module.css';
@@ -19,6 +19,10 @@ export function AccountDialog({ onClose }: { onClose: () => void }) {
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const user = profile.state?.profile.auth?.user;
+  const signedIn = Boolean(user);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const emailRef = useRef<HTMLInputElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
 
   const close = useCallback(() => {
     if (!user) selectSession('guest');
@@ -30,12 +34,21 @@ export function AccountDialog({ onClose }: { onClose: () => void }) {
   }, [selectSession, session]);
 
   useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape' && !submitting) close();
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const trigger = document.activeElement;
+    dialog.showModal();
+    return () => {
+      dialog.close();
+      if (trigger instanceof HTMLElement && trigger.isConnected) trigger.focus();
     };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [close, submitting]);
+  }, []);
+
+  useEffect(() => {
+    if (submitting) dialogRef.current?.focus();
+    else if (signedIn || status !== 'ready') closeRef.current?.focus();
+    else emailRef.current?.focus();
+  }, [signedIn, status, submitting]);
 
   const submit = async (event: FormEvent) => {
     event.preventDefault();
@@ -85,79 +98,113 @@ export function AccountDialog({ onClose }: { onClose: () => void }) {
   };
 
   return (
-    <div className={styles.dialogBackdrop} role="presentation">
-      <section
-        aria-labelledby="account-title"
-        aria-modal="true"
-        className={styles.accountDialog}
-        role="dialog"
+    <dialog
+      aria-labelledby="account-title"
+      aria-modal="true"
+      className={styles.accountDialog}
+      onKeyDown={(event) => {
+        if (event.key !== 'Tab' || event.altKey || event.ctrlKey || event.metaKey) return;
+        const dialog = event.currentTarget;
+        const controls = Array.from(
+          dialog.querySelectorAll<HTMLElement>(
+            'button:not(:disabled), input:not(:disabled), a[href]',
+          ),
+        ).filter((control) => control.tabIndex >= 0 && control.getClientRects().length > 0);
+        const first = controls[0];
+        const last = controls.at(-1);
+        if (!first || !last) {
+          event.preventDefault();
+          dialog.focus();
+        } else if (
+          event.shiftKey &&
+          (document.activeElement === first || document.activeElement === dialog)
+        ) {
+          event.preventDefault();
+          last.focus();
+        } else if (
+          !event.shiftKey &&
+          (document.activeElement === last || document.activeElement === dialog)
+        ) {
+          event.preventDefault();
+          first.focus();
+        }
+      }}
+      ref={dialogRef}
+      onCancel={(event) => {
+        event.preventDefault();
+        if (!submitting) close();
+      }}
+    >
+      <button
+        aria-label="Close"
+        className={styles.dialogClose}
+        disabled={submitting}
+        onClick={close}
+        ref={closeRef}
+        type="button"
       >
-        <button
-          aria-label="Close"
-          className={styles.dialogClose}
-          disabled={submitting}
-          onClick={close}
-          type="button"
-        >
-          <X aria-hidden size={18} />
-        </button>
-        <img alt="" src={logo} />
-        {user ? (
-          <>
-            <h1 id="account-title">Stremio account</h1>
-            <p>{user.email || user.name || 'Signed in'}</p>
-            <button
-              className={styles.secondaryAction}
-              onClick={() => {
-                if (!transport) return;
-                void transport
-                  .dispatch({ action: 'Ctx', args: { action: 'Logout' } })
-                  .finally(() => {
-                    selectSession('guest');
-                    onClose();
-                  });
-              }}
-              type="button"
-            >
-              Sign out
-            </button>
-          </>
-        ) : (
-          <form onSubmit={submit}>
-            <h1 id="account-title">Sign in to Stremio</h1>
-            <p>Your credentials go directly to Stremio. Kino keeps guest activity separate.</p>
-            <label htmlFor="stremio-email">Email</label>
-            <input
-              autoComplete="username"
-              autoFocus
-              disabled={status !== 'ready' || submitting}
-              id="stremio-email"
-              onChange={(event) => setEmail(event.target.value)}
-              required
-              type="email"
-              value={email}
-            />
-            <label htmlFor="stremio-password">Password</label>
-            <input
-              autoComplete="current-password"
-              disabled={status !== 'ready' || submitting}
-              id="stremio-password"
-              onChange={(event) => setPassword(event.target.value)}
-              required
-              type="password"
-              value={password}
-            />
-            {error ? <p className={styles.formError}>{error}</p> : null}
-            <button
-              className={styles.primaryAction}
-              disabled={status !== 'ready' || submitting}
-              type="submit"
-            >
-              {status !== 'ready' ? 'Preparing account…' : submitting ? 'Signing in…' : 'Sign in'}
-            </button>
-          </form>
-        )}
-      </section>
-    </div>
+        <X aria-hidden size={18} />
+      </button>
+      <img alt="" src={logo} />
+      {user ? (
+        <>
+          <h1 id="account-title">Stremio account</h1>
+          <p>{user.email || user.name || 'Signed in'}</p>
+          <button
+            className={styles.secondaryAction}
+            onClick={() => {
+              if (!transport) return;
+              void transport.dispatch({ action: 'Ctx', args: { action: 'Logout' } }).finally(() => {
+                selectSession('guest');
+                onClose();
+              });
+            }}
+            type="button"
+          >
+            Sign out
+          </button>
+        </>
+      ) : (
+        <form onSubmit={submit}>
+          <h1 id="account-title">Sign in to Stremio</h1>
+          <p>Your credentials go directly to Stremio. Kino keeps guest activity separate.</p>
+          <label htmlFor="stremio-email">Email</label>
+          <input
+            autoComplete="username"
+            aria-describedby={error ? 'account-error' : undefined}
+            disabled={status !== 'ready' || submitting}
+            id="stremio-email"
+            ref={emailRef}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+            type="email"
+            value={email}
+          />
+          <label htmlFor="stremio-password">Password</label>
+          <input
+            aria-describedby={error ? 'account-error' : undefined}
+            autoComplete="current-password"
+            disabled={status !== 'ready' || submitting}
+            id="stremio-password"
+            onChange={(event) => setPassword(event.target.value)}
+            required
+            type="password"
+            value={password}
+          />
+          {error ? (
+            <p className={styles.formError} id="account-error" role="alert">
+              {error}
+            </p>
+          ) : null}
+          <button
+            className={styles.primaryAction}
+            disabled={status !== 'ready' || submitting}
+            type="submit"
+          >
+            {status !== 'ready' ? 'Preparing account…' : submitting ? 'Signing in…' : 'Sign in'}
+          </button>
+        </form>
+      )}
+    </dialog>
   );
 }


### PR DESCRIPTION
The account overlay declared itself modal while allowing keyboard focus into the background. Replace it with a native modal dialog, retain the existing layout and backdrop, and wrap Tab and Shift+Tab between its enabled controls. Focus moves to Close while Core prepares or an account is signed in, then to Email when sign-in is ready. Pending sign-in retains focus inside the dialog. Dismissal restores the account trigger.

Authentication errors have an alert role and are associated with both fields. Adapt the existing app test to dispatch the native dialog cancel event and verify trigger focus restoration; jsdom does not implement the browser's modal APIs.

Validation: `pnpm check` passes with 114 tests and all pinned Core/vendor/build checks. Actual Chrome checks reproduce the original focus failure and pass for both account states after the fix: initial and ready focus, repeated Tab/Shift+Tab, inert background, pending sign-in, error association, Escape and Close dismissal, and trigger restoration. Layout checks and screenshots pass at 1280px and 320px widths.

Closes #43.
