### PR TITLE
Open Stremio account creation in the system browser

### DIFF
--- a/apps/desktop/src/App.module.css
+++ b/apps/desktop/src/App.module.css
@@ -1033,6 +1033,14 @@
   color: var(--kino-danger);
 }
 
+.accountCreate {
+  justify-self: center;
+  margin-top: 20px;
+  color: var(--kino-text-muted);
+  font-size: 13px;
+  text-underline-offset: 4px;
+}
+
 @keyframes pulse {
   from {
     opacity: 0.55;

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -75,6 +75,10 @@ describe('App', () => {
     await user.click(screen.getByRole('button', { name: 'Sign in to Stremio' }));
 
     expect(screen.getByRole('dialog', { name: 'Sign in to Stremio' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Create account' })).toHaveAttribute(
+      'href',
+      'https://www.stremio.com/register',
+    );
 
     fireEvent(screen.getByRole('dialog'), new Event('cancel', { cancelable: true }));
 

--- a/apps/desktop/src/components/AccountDialog.tsx
+++ b/apps/desktop/src/components/AccountDialog.tsx
@@ -6,6 +6,8 @@ import styles from '../App.module.css';
 import { useCore } from '../core/context';
 import type { CoreRuntimeEvent, ProfileState } from '../core/types';
 import { useCoreModel } from '../core/useCoreModel';
+import { t as enUS } from '../locales';
+import { nativeShellPresent, openAccountCreation } from '../native/player';
 
 function authError(event: CoreRuntimeEvent) {
   return event.name === 'CoreEvent' && event.args.event === 'Error';
@@ -18,6 +20,8 @@ export function AccountDialog({ onClose }: { onClose: () => void }) {
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [creationError, setCreationError] = useState(false);
+  const [openingRegistration, setOpeningRegistration] = useState(false);
   const user = profile.state?.profile.auth?.user;
   const signedIn = Boolean(user);
   const dialogRef = useRef<HTMLDialogElement>(null);
@@ -203,6 +207,31 @@ export function AccountDialog({ onClose }: { onClose: () => void }) {
           >
             {status !== 'ready' ? 'Preparing account…' : submitting ? 'Signing in…' : 'Sign in'}
           </button>
+          <a
+            aria-describedby={creationError ? 'account-creation-error' : undefined}
+            aria-disabled={openingRegistration || undefined}
+            className={styles.accountCreate}
+            href="https://www.stremio.com/register"
+            onClick={(event) => {
+              if (!nativeShellPresent()) return;
+              event.preventDefault();
+              if (openingRegistration) return;
+              setCreationError(false);
+              setOpeningRegistration(true);
+              void openAccountCreation()
+                .catch(() => setCreationError(true))
+                .finally(() => setOpeningRegistration(false));
+            }}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {enUS.account.create}
+          </a>
+          {creationError ? (
+            <p className={styles.formError} id="account-creation-error" role="alert">
+              {enUS.account.createFailed}
+            </p>
+          ) : null}
         </form>
       )}
     </dialog>

--- a/apps/desktop/src/locales/en-US.ts
+++ b/apps/desktop/src/locales/en-US.ts
@@ -1,5 +1,9 @@
 export const enUS = {
   appName: 'Kino',
+  account: {
+    create: 'Create account',
+    createFailed: 'The registration page could not be opened. Try again.',
+  },
   navigation: {
     primary: 'Primary navigation',
     home: 'Home',

--- a/apps/desktop/src/native/player.ts
+++ b/apps/desktop/src/native/player.ts
@@ -14,6 +14,7 @@ export interface NativePlayer {
     connect(listener: () => void): void;
     disconnect(listener: () => void): void;
   };
+  openAccountCreation(): Promise<boolean>;
   addSubtitles(url: string, title: string, lang: string): void;
   load(url: string, forceStereo: boolean, headers: Record<string, string>): void;
   pauseAndSnapshot(): Promise<{ duration: number; time: number }>;
@@ -154,6 +155,13 @@ function connectNativeShell(): Promise<NativeShellConnection | null> {
 
 export async function connectNativePlayer() {
   return (await connectNativeShell())?.player ?? null;
+}
+
+export async function openAccountCreation() {
+  const player = await connectNativePlayer();
+  if (!player || !(await player.openAccountCreation())) {
+    throw new Error('Account creation could not be opened.');
+  }
 }
 
 export async function connectNativeLifecycle() {

--- a/apps/macos-shell/qml/Main.qml
+++ b/apps/macos-shell/qml/Main.qml
@@ -66,6 +66,10 @@ ApplicationWindow {
         signal playerEvent(string name, var payload)
         signal streamingEngineChanged(string url, string error)
 
+        function openAccountCreation() {
+            return Qt.openUrlExternally("https://www.stremio.com/register")
+        }
+
         function startStreamingEngine() {
             if (streamEngine.url) {
                 nativeBridge.streamingEngineChanged(streamEngine.url, streamEngine.error)


### PR DESCRIPTION
Adds Create account to the signed-out account dialog. The packaged app opens Stremio's official registration page through a no-argument native method with a fixed URL; the web app uses a normal external link. Opening failures are announced and can be retried. The dialog and entered credentials remain available on return.

Validation: `pnpm check` passes all 114 tests, Core integration checks, vendor reconstruction, and build. The macOS app builds. Isolated Chrome checks cover the external link, zero-argument native call, failure/retry, and retained form values. A probe through the built app's production QML/WebChannel captures the exact URL at Qt's URL-opening API and verifies both successful and failed return values.

Closes #51.

Integration validation: the combined branch passes `pnpm check` (123 tests). Hosted CI passed for `79ecbde`: https://github.com/chriscorbell/kino/actions/runs/33976545125.
