### PR TITLE
Preserve browse state and focus when returning from details

### DIFF
--- a/apps/desktop/src/App.module.css
+++ b/apps/desktop/src/App.module.css
@@ -112,6 +112,22 @@
   animation: enter var(--kino-duration-standard) var(--kino-ease-out);
 }
 
+.shell[hidden],
+.content[hidden] {
+  display: none;
+}
+
+.playbackMain {
+  position: fixed;
+  inset: 0;
+}
+
+.content:focus-visible,
+.content h1:focus-visible {
+  outline: 2px solid var(--kino-accent);
+  outline-offset: -2px;
+}
+
 .page {
   width: min(100%, 1500px);
   min-height: 100%;

--- a/apps/desktop/src/App.navigation.test.tsx
+++ b/apps/desktop/src/App.navigation.test.tsx
@@ -1,0 +1,199 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, expect, it, vi } from 'vitest';
+
+import { App } from './App';
+import { CoreContext } from './core/context';
+import type { CoreTransport } from './core/transport';
+import type { CatalogRequest, CoreRuntimeEvent, LibraryRequest } from './core/types';
+
+function fixture() {
+  let query = '';
+  let genre = '';
+  let libraryType: string | null = null;
+  const listeners = new Set<(event: CoreRuntimeEvent) => void>();
+  const item = {
+    id: 'silo',
+    name: 'Silo',
+    type: 'movie',
+    inLibrary: false,
+    watched: false,
+    videos: [],
+  };
+  const addon = {
+    manifest: { id: 'test', name: 'Test' },
+    transportUrl: 'https://addon.invalid/manifest.json',
+  };
+  const dispatch = vi.fn<CoreTransport['dispatch']>().mockImplementation(async (action, model) => {
+    if (model === 'search' && action.action === 'Load')
+      query = (action.args as { args: { extra: string[][] } }).args.extra[0]?.[1] ?? '';
+    if (model === 'discover' && action.action === 'Load') {
+      const args = action.args as { args: { request: CatalogRequest } | null };
+      genre = args.args?.request.path.extra.find(([name]) => name === 'genre')?.[1] ?? '';
+    }
+    if (model === 'library' && action.action === 'Load')
+      libraryType = (action.args as { args: { request: LibraryRequest } }).args.request.type;
+  });
+  const transport: CoreTransport = {
+    init: vi.fn().mockResolvedValue(undefined),
+    destroy: vi.fn(),
+    flush: vi.fn().mockResolvedValue(undefined),
+    prepareClose: vi.fn().mockResolvedValue(undefined),
+    onBeforeDestroy: () => () => {},
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    dispatch,
+    getState: async <State,>(model: string) =>
+      (model === 'ctx'
+        ? { profile: { auth: null, addons: [], settings: {} } }
+        : model === 'continue_watching_preview'
+          ? { items: [] }
+          : model === 'search'
+            ? {
+                selected: { extra: [['search', query]] },
+                catalogs: query ? [{ content: { type: 'Ready', content: [item] } }] : [],
+              }
+            : model === 'meta_details'
+              ? {
+                  metaItem: { addon, content: { type: 'Ready', content: item } },
+                  streams: [],
+                  selected: {
+                    metaPath: { resource: 'meta', type: 'movie', id: 'silo' },
+                    streamPath: { resource: 'stream', type: 'movie', id: 'silo' },
+                  },
+                }
+              : model === 'discover'
+                ? {
+                    catalog: { content: { type: 'Ready', content: [item] } },
+                    selectable: {
+                      types: [],
+                      catalogs: [{ addon, id: 'top', name: 'Top', selected: true }],
+                      extra: [
+                        {
+                          name: 'genre',
+                          isRequired: false,
+                          options: ['', 'Drama'].map((value) => ({
+                            value: value || null,
+                            selected: genre === value,
+                            deepLinks: {
+                              discover: `#/discover/${encodeURIComponent(addon.transportUrl)}/movie/top?genre=${value}`,
+                            },
+                          })),
+                        },
+                      ],
+                    },
+                  }
+                : model === 'library'
+                  ? {
+                      catalog: [{ _id: item.id, name: item.name, type: item.type }],
+                      selected: { request: { page: 1, sort: 'lastwatched', type: libraryType } },
+                      selectable: {
+                        types: [null, 'movie'].map((type) => ({
+                          type,
+                          selected: type === libraryType,
+                        })),
+                      },
+                    }
+                  : { catalogs: [] }) as State,
+  };
+  render(
+    <CoreContext.Provider
+      value={{ transport, status: 'ready', error: null, session: 'guest', selectSession: vi.fn() }}
+    >
+      <App />
+    </CoreContext.Provider>,
+  );
+  return {
+    dispatch,
+    async publish() {
+      await act(async () => {
+        listeners.forEach((listener) =>
+          listener({ name: 'NewState', args: ['ctx', 'meta_details', 'search'] }),
+        );
+      });
+    },
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+it.each(['Discover', 'Library'])(
+  'preserves the selected %s filter and results on Back',
+  async (route) => {
+    const { dispatch } = fixture();
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: route }));
+    if (route === 'Discover')
+      await user.selectOptions(await screen.findByRole('combobox', { name: 'Genre' }), '1');
+    else await user.click(await screen.findByRole('button', { name: 'Movie' }));
+    await waitFor(() => {
+      if (route === 'Discover')
+        expect(screen.getByRole('combobox', { name: 'Genre' })).toHaveValue('1');
+      else
+        expect(screen.getByRole('button', { name: 'Movie' })).toHaveAttribute(
+          'aria-pressed',
+          'true',
+        );
+    });
+    const card = screen.getByRole('button', { name: /Silo/ });
+    const before = dispatch.mock.calls.filter(([, model]) => model === route.toLowerCase()).length;
+    await user.click(card);
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+    expect(screen.getByRole('button', { name: /Silo/ })).toBe(card);
+    expect(card).toHaveFocus();
+    if (route === 'Discover')
+      expect(screen.getByRole('combobox', { name: 'Genre' })).toHaveValue('1');
+    else
+      expect(screen.getByRole('button', { name: 'Movie' })).toHaveAttribute('aria-pressed', 'true');
+    expect(dispatch.mock.calls.filter(([, model]) => model === route.toLowerCase())).toHaveLength(
+      before,
+    );
+  },
+);
+
+it('restores the query, results, scroll and originating card focus without reloading search', async () => {
+  const { dispatch } = fixture();
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('button', { name: 'Search' }));
+  const input = screen.getByRole('searchbox');
+  await user.type(input, 'Silo');
+  fireEvent.submit(input.closest('form')!);
+  const card = await screen.findByRole('button', { name: /Silo/ });
+  const main = screen.getByRole('main');
+  main.scrollTop = 640;
+  const before = dispatch.mock.calls.filter(([, model]) => model === 'search').length;
+  await user.click(card);
+  expect(screen.getByRole('heading', { name: 'Silo' })).toHaveFocus();
+  expect(screen.getByRole('button', { name: 'Search' })).toHaveAttribute('aria-current', 'page');
+  await user.click(screen.getByRole('button', { name: 'Back' }));
+  expect(screen.getByRole('searchbox')).toHaveValue('Silo');
+  expect(screen.getByRole('button', { name: /Silo/ })).toBe(card);
+  expect(card).toHaveFocus();
+  expect(screen.getByRole('main').scrollTop).toBe(640);
+  expect(dispatch.mock.calls.filter(([, model]) => model === 'search')).toHaveLength(before);
+});
+
+it('moves focus with navigation and skip, then leaves it alone during background updates', async () => {
+  const { publish } = fixture();
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('button', { name: 'Settings' }));
+  expect(screen.getByRole('heading', { name: 'Settings' })).toHaveFocus();
+  await user.click(screen.getByRole('link', { name: 'Skip to content' }));
+  expect(screen.getByRole('main')).toHaveFocus();
+  const control = screen.getByRole('switch', { name: 'Skip intro button' });
+  control.focus();
+  await publish();
+  expect(control).toHaveFocus();
+  await user.click(screen.getByRole('button', { name: 'Search' }));
+  const input = screen.getByRole('searchbox');
+  await user.type(input, 'Silo');
+  fireEvent.submit(input.closest('form')!);
+  await waitFor(() => expect(screen.getByRole('button', { name: /Silo/ })).toBeInTheDocument());
+  await publish();
+  expect(input).toHaveFocus();
+});

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -7,7 +7,7 @@ import {
   Toolbox,
   type Icon,
 } from '@phosphor-icons/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import logo from './assets/kino.svg';
 import styles from './App.module.css';
@@ -17,6 +17,13 @@ import { sourceKey } from './core/sources';
 import type { CoreMetaPreview, ProfileState } from './core/types';
 import { useCoreModel } from './core/useCoreModel';
 import { t as enUS } from './locales';
+import {
+  BrowseStateContext,
+  initialBrowseState,
+  type BrowseScreen,
+  type NavigationEntry,
+  type UpdateBrowseState,
+} from './navigation';
 import { AddonsScreen } from './screens/AddonsScreen';
 import { DiscoverScreen } from './screens/DiscoverScreen';
 import { HomeScreen } from './screens/HomeScreen';
@@ -27,12 +34,12 @@ import { SearchScreen } from './screens/SearchScreen';
 import { SettingsScreen } from './screens/SettingsScreen';
 import { defaultSettings, loadSettings, saveSettings, type KinoSettings } from './settings';
 
-type Screen = 'home' | 'search' | 'discover' | 'library' | 'addons' | 'settings' | 'detail';
+type Screen = BrowseScreen | 'detail';
 
 interface NavigationItem {
   icon: Icon;
   label: string;
-  screen: Screen;
+  screen: BrowseScreen;
 }
 
 const primaryNavigation: NavigationItem[] = [
@@ -54,7 +61,7 @@ function NavigationButton({
 }: {
   active: boolean;
   item: NavigationItem;
-  onSelect: (screen: Screen) => void;
+  onSelect: (screen: BrowseScreen) => void;
 }) {
   const IconComponent = item.icon;
 
@@ -83,7 +90,16 @@ function accountInitial(profile: ProfileState | null) {
 
 export function App() {
   const [screen, setScreen] = useState<Screen>('home');
-  const [previousScreen, setPreviousScreen] = useState<Exclude<Screen, 'detail'>>('home');
+  const [entry, setEntry] = useState<NavigationEntry>(() => ({
+    screen: 'home',
+    state: initialBrowseState(),
+    scrollTop: 0,
+    focus: null,
+  }));
+  const browseMain = useRef<HTMLElement>(null);
+  const detailMain = useRef<HTMLElement>(null);
+  const playerMain = useRef<HTMLElement>(null);
+  const previousView = useRef<string | null>(null);
   const [detail, setDetail] = useState<CoreMetaPreview | null>(null);
   const [detailVideoId, setDetailVideoId] = useState<string | null>(null);
   const [playback, setPlayback] = useState<PlaybackSelection | null>(null);
@@ -98,8 +114,35 @@ export function App() {
     saveSettings(window.localStorage, settings);
   }, [settings]);
 
+  const updateBrowseState = useCallback<UpdateBrowseState>((key, value) => {
+    setEntry((previous) => ({
+      ...previous,
+      state: {
+        ...previous.state,
+        [key]: typeof value === 'function' ? value(previous.state[key]) : value,
+      },
+    }));
+  }, []);
+  const browseContext = useMemo(
+    () => ({ state: entry.state, update: updateBrowseState }),
+    [entry.state, updateBrowseState],
+  );
+
+  const navigate = (next: BrowseScreen) => {
+    if (next !== entry.screen) {
+      setEntry({ screen: next, state: initialBrowseState(), scrollTop: 0, focus: null });
+    }
+    setScreen(next);
+  };
+
   const openDetail = (item: CoreMetaPreview, videoId?: string | null) => {
-    if (screen !== 'detail') setPreviousScreen(screen);
+    if (screen !== 'detail') {
+      const active = document.activeElement;
+      const scrollTop = browseMain.current?.scrollTop ?? 0;
+      const focus =
+        active instanceof HTMLElement && browseMain.current?.contains(active) ? active : null;
+      setEntry((previous) => ({ ...previous, scrollTop, focus }));
+    }
     setDetail(item);
     setDetailVideoId(videoId ?? null);
     setFailedSources(new Map());
@@ -120,26 +163,43 @@ export function App() {
     [playback],
   );
 
-  if (playback) {
-    return (
-      <PlayerScreen
-        onBack={closePlayer}
-        onSettingsChange={setSettings}
-        onSourceFailure={reportSourceFailure}
-        onUpNext={(video) => {
-          setDetailVideoId(video.id);
-          setFailedSources(new Map());
-          setPlayback(null);
-        }}
-        preferredSubtitleLanguage={profile.state?.profile.settings?.subtitlesLanguage ?? null}
-        selection={playback}
-        settings={settings}
-      />
-    );
-  }
+  const view = playback
+    ? 'player'
+    : screen === 'detail'
+      ? `detail:${detail?.type}:${detail?.id}`
+      : screen;
+  useLayoutEffect(() => {
+    const previous = previousView.current;
+    if (previous === view) return;
+    previousView.current = view;
+    const main =
+      view === 'player'
+        ? playerMain.current
+        : screen === 'detail'
+          ? detailMain.current
+          : browseMain.current;
+    if (!main) return;
+    if (screen !== 'detail' && !playback && previous?.startsWith('detail:')) {
+      main.scrollTop = entry.scrollTop;
+      if (entry.focus?.isConnected && main.contains(entry.focus)) {
+        entry.focus.focus({ preventScroll: true });
+        // A library update can reorder cards while details is open.
+        const card = entry.focus.getBoundingClientRect();
+        const region = main.getBoundingClientRect();
+        if (card.bottom < region.top || card.top > region.bottom)
+          entry.focus.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+        return;
+      }
+    }
+    const heading = main.querySelector<HTMLElement>('h1');
+    const target =
+      heading && !heading.classList.contains(styles.visuallyHidden ?? '') ? heading : main;
+    target.tabIndex = -1;
+    target.focus({ preventScroll: true });
+  }, [entry, playback, screen, view]);
 
   const content = (() => {
-    switch (screen) {
+    switch (entry.screen) {
       case 'home':
         return <HomeScreen onOpen={openDetail} />;
       case 'search':
@@ -152,76 +212,125 @@ export function App() {
         return <AddonsScreen />;
       case 'settings':
         return <SettingsScreen onChange={setSettings} settings={settings} />;
-      case 'detail':
-        return detail ? (
-          <MetaDetailsScreen
-            failedSources={failedSources}
-            key={detail.id}
-            initialVideoId={detailVideoId}
-            item={detail}
-            onBack={() => setScreen(previousScreen)}
-            onPlay={(selection) => {
-              // Details unmounts during playback. Keep its chosen episode in
-              // navigation state so Back and failure return to the same source list.
-              setDetailVideoId(selection.video?.id ?? null);
-              setPlayback(selection);
-            }}
-          />
-        ) : (
-          <HomeScreen onOpen={openDetail} />
-        );
     }
   })();
 
   return (
-    <div className={styles.shell}>
-      <a className={styles.skipLink} href="#main-content">
-        {enUS.navigation.skipToContent}
-      </a>
-      <aside className={styles.sidebar} aria-label={enUS.navigation.primary}>
-        <button
-          aria-label={enUS.navigation.kinoHome}
-          className={styles.logoButton}
-          onClick={() => setScreen('home')}
-          type="button"
+    <>
+      <div className={styles.shell} hidden={Boolean(playback)}>
+        <a
+          className={styles.skipLink}
+          href="#main-content"
+          onClick={(event) => {
+            event.preventDefault();
+            (screen === 'detail' ? detailMain.current : browseMain.current)?.focus();
+          }}
         >
-          <img src={logo} alt="" />
-        </button>
-        <nav className={styles.navGroup}>
-          {primaryNavigation.map((item) => (
-            <NavigationButton
-              active={screen === item.screen}
-              item={item}
-              key={item.screen}
-              onSelect={setScreen}
-            />
-          ))}
-        </nav>
-        <div className={styles.divider} />
-        <nav className={styles.navGroup}>
-          {utilityNavigation.map((item) => (
-            <NavigationButton
-              active={screen === item.screen}
-              item={item}
-              key={item.screen}
-              onSelect={setScreen}
-            />
-          ))}
-        </nav>
-        <button
-          aria-label={profile.state?.profile.auth ? 'Stremio account' : 'Sign in to Stremio'}
-          className={styles.profileButton}
-          onClick={() => setAccountOpen(true)}
-          title={profile.state?.profile.auth ? 'Stremio account' : 'Sign in to Stremio'}
-          type="button"
+          {enUS.navigation.skipToContent}
+        </a>
+        <aside className={styles.sidebar} aria-label={enUS.navigation.primary}>
+          <button
+            aria-label={enUS.navigation.kinoHome}
+            className={styles.logoButton}
+            onClick={() => navigate('home')}
+            type="button"
+          >
+            <img src={logo} alt="" />
+          </button>
+          <nav className={styles.navGroup}>
+            {primaryNavigation.map((item) => (
+              <NavigationButton
+                active={entry.screen === item.screen}
+                item={item}
+                key={item.screen}
+                onSelect={navigate}
+              />
+            ))}
+          </nav>
+          <div className={styles.divider} />
+          <nav className={styles.navGroup}>
+            {utilityNavigation.map((item) => (
+              <NavigationButton
+                active={entry.screen === item.screen}
+                item={item}
+                key={item.screen}
+                onSelect={navigate}
+              />
+            ))}
+          </nav>
+          <button
+            aria-label={profile.state?.profile.auth ? 'Stremio account' : 'Sign in to Stremio'}
+            className={styles.profileButton}
+            onClick={() => setAccountOpen(true)}
+            title={profile.state?.profile.auth ? 'Stremio account' : 'Sign in to Stremio'}
+            type="button"
+          >
+            {accountInitial(profile.state)}
+          </button>
+        </aside>
+        {/* Keep the return entry's results and Core subscription alive through details and playback. */}
+        <main
+          className={styles.content}
+          hidden={screen === 'detail'}
+          id={screen !== 'detail' ? 'main-content' : undefined}
+          key={entry.screen}
+          aria-label={
+            [...primaryNavigation, ...utilityNavigation].find(
+              (item) => item.screen === entry.screen,
+            )?.label
+          }
+          ref={browseMain}
+          tabIndex={-1}
         >
-          {accountInitial(profile.state)}
-        </button>
-      </aside>
-      <main className={styles.content} id="main-content" key={screen}>
-        {content}
-      </main>
-      {accountOpen ? <AccountDialog onClose={() => setAccountOpen(false)} /> : null}
-    </div>
+          <BrowseStateContext.Provider value={browseContext}>{content}</BrowseStateContext.Provider>
+        </main>
+        {screen === 'detail' && detail && !playback ? (
+          <main
+            className={styles.content}
+            id="main-content"
+            key={`detail:${detail.type}:${detail.id}`}
+            aria-label={detail.name}
+            ref={detailMain}
+            tabIndex={-1}
+          >
+            <MetaDetailsScreen
+              failedSources={failedSources}
+              key={`${detail.type}:${detail.id}`}
+              initialVideoId={detailVideoId}
+              item={detail}
+              onBack={() => setScreen(entry.screen)}
+              onPlay={(selection) => {
+                // Details unmounts during playback so Up Next can select a new episode on return.
+                setDetailVideoId(selection.video?.id ?? null);
+                setPlayback(selection);
+              }}
+            />
+          </main>
+        ) : null}
+        {accountOpen ? <AccountDialog onClose={() => setAccountOpen(false)} /> : null}
+      </div>
+      {playback ? (
+        <main
+          className={styles.playbackMain}
+          aria-label={playback.meta.name}
+          ref={playerMain}
+          tabIndex={-1}
+        >
+          <PlayerScreen
+            onBack={closePlayer}
+            onSettingsChange={setSettings}
+            onSourceFailure={reportSourceFailure}
+            onUpNext={(video) => {
+              setDetailVideoId(video.id);
+              setFailedSources(new Map());
+              setPlayback(null);
+            }}
+            preferredSubtitleLanguage={profile.state?.profile.settings?.subtitlesLanguage ?? null}
+            selection={playback}
+            settings={settings}
+          />
+        </main>
+      ) : null}
+    </>
   );
 }

--- a/apps/desktop/src/navigation.ts
+++ b/apps/desktop/src/navigation.ts
@@ -1,0 +1,47 @@
+import { createContext, useCallback, useContext, useState, type SetStateAction } from 'react';
+
+import type { CatalogRequest, LibraryRequest } from './core/types';
+
+export type BrowseScreen = 'home' | 'search' | 'discover' | 'library' | 'addons' | 'settings';
+
+export interface BrowseState {
+  search: { query: string; submittedQuery: string };
+  discover: CatalogRequest | null;
+  library: LibraryRequest | null;
+}
+
+export function initialBrowseState(): BrowseState {
+  return { search: { query: '', submittedQuery: '' }, discover: null, library: null };
+}
+
+export interface NavigationEntry {
+  screen: BrowseScreen;
+  state: BrowseState;
+  scrollTop: number;
+  focus: HTMLElement | null;
+}
+
+export type UpdateBrowseState = <Key extends keyof BrowseState>(
+  key: Key,
+  value: SetStateAction<BrowseState[Key]>,
+) => void;
+
+export const BrowseStateContext = createContext<{
+  state: BrowseState;
+  update: UpdateBrowseState;
+} | null>(null);
+
+// Standalone screens can still own their state; App stores it in the return entry.
+export function useBrowseState<Key extends keyof BrowseState>(key: Key) {
+  const context = useContext(BrowseStateContext);
+  const [local, setLocal] = useState(() => initialBrowseState()[key]);
+  const update = context?.update;
+  const setValue = useCallback(
+    (value: SetStateAction<BrowseState[Key]>) => {
+      if (update) update(key, value);
+      else setLocal(value);
+    },
+    [key, update],
+  );
+  return [context ? context.state[key] : local, setValue] as const;
+}

--- a/apps/desktop/src/screens/DiscoverScreen.tsx
+++ b/apps/desktop/src/screens/DiscoverScreen.tsx
@@ -1,20 +1,20 @@
 import { CaretDown } from '@phosphor-icons/react';
-import { useState } from 'react';
 
 import styles from '../App.module.css';
 import { MediaCard } from '../components/MediaCard';
 import { loadCatalogAction } from '../core/actions';
 import { catalogRequestFromDeepLink, catalogRequestKey } from '../core/catalog';
-import type { CatalogRequest, CatalogWithFiltersState, CoreMetaPreview } from '../core/types';
+import type { CatalogWithFiltersState, CoreMetaPreview } from '../core/types';
 import { useCoreModel } from '../core/useCoreModel';
 import { t as enUS } from '../locales';
+import { useBrowseState } from '../navigation';
 
 function typeLabel(type: string) {
   return type.charAt(0).toUpperCase() + type.slice(1);
 }
 
 export function DiscoverScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => void }) {
-  const [request, setRequest] = useState<CatalogRequest | null>(null);
+  const [request, setRequest] = useBrowseState('discover');
   const result = useCoreModel<CatalogWithFiltersState>(
     'discover',
     loadCatalogAction(request),

--- a/apps/desktop/src/screens/LibraryScreen.tsx
+++ b/apps/desktop/src/screens/LibraryScreen.tsx
@@ -1,10 +1,10 @@
 import styles from '../App.module.css';
 import { MediaCard } from '../components/MediaCard';
 import { loadLibraryAction } from '../core/actions';
-import type { CoreMetaPreview, LibraryState, LibraryRequest } from '../core/types';
+import type { CoreMetaPreview, LibraryState } from '../core/types';
 import { useCoreModel } from '../core/useCoreModel';
 import { t as enUS } from '../locales';
-import { useState } from 'react';
+import { useBrowseState } from '../navigation';
 
 function typeLabel(type: string | null) {
   if (!type) return enUS.library.all;
@@ -12,7 +12,7 @@ function typeLabel(type: string | null) {
 }
 
 export function LibraryScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => void }) {
-  const [request, setRequest] = useState<LibraryRequest | null>(null);
+  const [request, setRequest] = useBrowseState('library');
   const result = useCoreModel<LibraryState>(
     'library',
     loadLibraryAction(request),

--- a/apps/desktop/src/screens/SearchScreen.tsx
+++ b/apps/desktop/src/screens/SearchScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import styles from '../App.module.css';
 import { MediaCard } from '../components/MediaCard';
@@ -7,18 +7,21 @@ import { useCore } from '../core/context';
 import type { BoardState, CoreMetaPreview } from '../core/types';
 import { useCoreModel } from '../core/useCoreModel';
 import { t as enUS } from '../locales';
+import { useBrowseState } from '../navigation';
 
 export function SearchScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => void }) {
   const { transport } = useCore();
-  const [query, setQuery] = useState('');
-  const [submittedQuery, setSubmittedQuery] = useState('');
+  const [{ query, submittedQuery }, setSearch] = useBrowseState('search');
   const normalizedQuery = query.trim();
 
   useEffect(() => {
     if (normalizedQuery === submittedQuery) return;
-    const timer = window.setTimeout(() => setSubmittedQuery(normalizedQuery), 300);
+    const timer = window.setTimeout(
+      () => setSearch((previous) => ({ ...previous, submittedQuery: normalizedQuery })),
+      300,
+    );
     return () => window.clearTimeout(timer);
-  }, [normalizedQuery, submittedQuery]);
+  }, [normalizedQuery, submittedQuery, setSearch]);
 
   const result = useCoreModel<BoardState>(
     'search',
@@ -56,7 +59,7 @@ export function SearchScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => vo
       <form
         onSubmit={(event) => {
           event.preventDefault();
-          setSubmittedQuery(normalizedQuery);
+          setSearch((previous) => ({ ...previous, submittedQuery: normalizedQuery }));
         }}
         role="search"
       >
@@ -64,13 +67,14 @@ export function SearchScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => vo
           {enUS.search.placeholder}
         </label>
         <input
-          autoFocus
           className={styles.searchInput}
           id="catalog-search"
           onChange={(event) => {
             const value = event.target.value;
-            setQuery(value);
-            if (!value.trim()) setSubmittedQuery('');
+            setSearch((previous) => ({
+              query: value,
+              submittedQuery: value.trim() ? previous.submittedQuery : '',
+            }));
           }}
           placeholder={enUS.search.placeholder}
           type="search"


### PR DESCRIPTION
Opening a title unmounted its browse screen, so Back lost Search queries and results, Discover and Library filters, scroll position, and the focused card. The navigation entry now records query/filter state and the return position, while the originating screen keeps its results and Core subscription through details and playback.

The selected parent navigation item stays active in details. Navigation focuses the new heading or main region, Back restores the originating card, and the skip link explicitly focuses the active main region. Background Core updates leave focus alone. Details still unmounts during playback so returning to sources preserves the selected episode and Up Next behavior.

Validation:

- `pnpm check` passes, including 123 tests, type checking, lint, pinned Core checks, vendor reconstruction, and the production web build.
- Four focused navigation regressions cover Search, Discover, Library, skip focus, and background updates. The original Search and focus regressions failed before the fix.
- Actual Chrome and native Qt WebEngine checks cover keyboard skip activation, heading/main focus, exact scroll and card restoration, retained filters, parent navigation, hidden content exclusion, and the playback round trip. Chrome also covers 320px layout and reduced motion.

Closes #40
Closes #44

Hosted CI passed on retry after the repository became public: https://github.com/chriscorbell/kino/actions/runs/33975529561/attempts/2.

