### PR TITLE
Recover failed Core startup and guest catalog initialization

### DIFF
--- a/apps/desktop/src/App.module.css
+++ b/apps/desktop/src/App.module.css
@@ -1943,3 +1943,14 @@
   color: var(--kino-danger);
   font-size: 13px;
 }
+
+.coreRecovery {
+  margin-block-end: 24px;
+  overflow-wrap: anywhere;
+}
+
+.coreRecoveryActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 
 import logo from './assets/kino.svg';
 import styles from './App.module.css';
+import { CoreRecovery } from './components/CoreRecovery';
 import { AccountDialog } from './components/AccountDialog';
 import type { PlaybackSelection } from './core/actions';
 import { sourceKey } from './core/sources';
@@ -296,6 +297,7 @@ export function App() {
           ref={browseMain}
           tabIndex={-1}
         >
+          {!playback && screen !== 'detail' && !accountOpen ? <CoreRecovery /> : null}
           {!playback && screen !== 'detail' ? <UpdateNotice updates={updates} /> : null}
           <BrowseStateContext.Provider value={browseContext}>{content}</BrowseStateContext.Provider>
         </main>
@@ -308,6 +310,7 @@ export function App() {
             ref={detailMain}
             tabIndex={-1}
           >
+            {!accountOpen ? <CoreRecovery /> : null}
             <UpdateNotice updates={updates} />
             <MetaDetailsScreen
               failedSources={failedSources}

--- a/apps/desktop/src/components/AccountDialog.tsx
+++ b/apps/desktop/src/components/AccountDialog.tsx
@@ -1,6 +1,7 @@
 import { X } from '@phosphor-icons/react';
 import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react';
 
+import { CoreRecovery } from './CoreRecovery';
 import logo from '../assets/kino.svg';
 import styles from '../App.module.css';
 import { useCore } from '../core/context';
@@ -150,6 +151,7 @@ export function AccountDialog({ onClose }: { onClose: () => void }) {
         <X aria-hidden size={18} />
       </button>
       <img alt="" src={logo} />
+      <CoreRecovery onGuest={onClose} />
       {user ? (
         <>
           <h1 id="account-title">Stremio account</h1>
@@ -205,7 +207,13 @@ export function AccountDialog({ onClose }: { onClose: () => void }) {
             disabled={status !== 'ready' || submitting}
             type="submit"
           >
-            {status !== 'ready' ? 'Preparing account…' : submitting ? 'Signing in…' : 'Sign in'}
+            {status === 'error'
+              ? enUS.core.accountUnavailable
+              : status !== 'ready'
+                ? 'Preparing account…'
+                : submitting
+                  ? 'Signing in…'
+                  : 'Sign in'}
           </button>
           <a
             aria-describedby={creationError ? 'account-creation-error' : undefined}

--- a/apps/desktop/src/components/CoreRecovery.tsx
+++ b/apps/desktop/src/components/CoreRecovery.tsx
@@ -1,0 +1,44 @@
+import styles from '../App.module.css';
+import { useCore, useCoreRecovery } from '../core/context';
+import { t } from '../locales';
+
+export function CoreRecovery({ onGuest }: { onGuest?: () => void }) {
+  const { error, selectSession, session, status } = useCore();
+  const { retry, retryCatalog, catalogLoading, catalogError } = useCoreRecovery();
+  if (status === 'loading' || catalogLoading) {
+    return (
+      <p role="status" className={styles.inlineEmpty}>
+        {status === 'loading' ? t.core.starting : t.core.catalogLoading}
+      </p>
+    );
+  }
+  if (!error && !catalogError) return null;
+  return (
+    <section className={styles.coreRecovery} aria-label={t.core.retry}>
+      <p className={styles.loadError} role="alert">
+        {error ?? catalogError}
+      </p>
+      <div className={styles.coreRecoveryActions}>
+        <button
+          className={styles.secondaryAction}
+          onClick={error ? retry : retryCatalog}
+          type="button"
+        >
+          {error ? t.core.retry : t.core.retryCatalog}
+        </button>
+        {error && session === 'account' ? (
+          <button
+            className={styles.secondaryAction}
+            onClick={() => {
+              selectSession('guest');
+              onGuest?.();
+            }}
+            type="button"
+          >
+            {t.core.guest}
+          </button>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/apps/desktop/src/core/CoreProvider.recovery.test.tsx
+++ b/apps/desktop/src/core/CoreProvider.recovery.test.tsx
@@ -1,0 +1,178 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+import { App } from '../App';
+import { CoreRecovery } from '../components/CoreRecovery';
+import { profile } from '../test/coreState';
+import { CoreProvider } from './CoreProvider';
+import { useCore } from './context';
+import type { CoreSession } from './storage';
+import type { CoreTransport } from './transport';
+
+const control = vi.hoisted(() => ({
+  init: vi.fn(),
+  transports: [] as CoreTransport[],
+}));
+vi.mock('./transport', () => ({
+  createCoreTransport: (session: CoreSession) => {
+    const transport: CoreTransport = {
+      init: () => control.init(session),
+      destroy: vi.fn().mockResolvedValue(undefined),
+      dispatch: vi.fn().mockResolvedValue(undefined),
+      flush: vi.fn().mockResolvedValue(undefined),
+      prepareClose: vi.fn().mockResolvedValue(undefined),
+      onBeforeDestroy: () => () => {},
+      getState: vi.fn(async (model: string) => {
+        if (model === 'ctx') return profile();
+        if (model === 'board') return { catalogs: [], selected: null };
+        return { items: [] };
+      }) as CoreTransport['getState'],
+      subscribe: () => () => {},
+    };
+    control.transports.push(transport);
+    return transport;
+  },
+}));
+
+beforeEach(() => {
+  window.localStorage.clear();
+  control.transports.length = 0;
+  control.init.mockReset().mockResolvedValue(undefined);
+  vi.stubGlobal('Worker', class {});
+  vi.stubGlobal(
+    'fetch',
+    vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ id: 'com.linvo.cinemeta', name: 'Cinemeta' })),
+      ),
+  );
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  Object.defineProperties(HTMLDialogElement.prototype, {
+    showModal: {
+      configurable: true,
+      value(this: HTMLDialogElement) {
+        this.open = true;
+      },
+    },
+    close: {
+      configurable: true,
+      value(this: HTMLDialogElement) {
+        this.open = false;
+      },
+    },
+  });
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  Reflect.deleteProperty(HTMLDialogElement.prototype, 'showModal');
+  Reflect.deleteProperty(HTMLDialogElement.prototype, 'close');
+});
+
+function Probe() {
+  const core = useCore();
+  return (
+    <>
+      <output data-testid="status">{core.status}</output>
+      <CoreRecovery />
+      <button onClick={() => core.selectSession('account')}>Account</button>
+    </>
+  );
+}
+
+it('keeps Core and Settings usable after an optional catalog failure, then retries without replacing Core', async () => {
+  vi.mocked(fetch).mockRejectedValueOnce(new Error('Offline'));
+  render(
+    <CoreProvider>
+      <App />
+    </CoreProvider>,
+  );
+  expect(await screen.findByRole('button', { name: 'Retry guest catalog' })).toBeVisible();
+  fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
+  expect(screen.getByRole('switch', { name: 'Skip intro button' })).toBeEnabled();
+  fireEvent.click(screen.getByRole('button', { name: 'Retry guest catalog' }));
+  await waitFor(() =>
+    expect(screen.queryByRole('button', { name: 'Retry guest catalog' })).not.toBeInTheDocument(),
+  );
+  await waitFor(() =>
+    expect(control.transports[0]!.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ args: expect.objectContaining({ action: 'InstallAddon' }) }),
+    ),
+  );
+  expect(control.transports).toHaveLength(1);
+});
+
+it('retries failed startup with a new transport and waits for teardown', async () => {
+  control.init.mockRejectedValueOnce(new Error('WASM could not load.'));
+  render(
+    <CoreProvider>
+      <Probe />
+    </CoreProvider>,
+  );
+  expect(await screen.findByRole('alert')).toHaveTextContent('WASM could not load.');
+  let finish!: () => void;
+  vi.mocked(control.transports[0]!.destroy).mockReturnValue(
+    new Promise<void>((resolve) => {
+      finish = resolve;
+    }),
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'Retry Stremio Core' }));
+  expect(screen.getByTestId('status')).toHaveTextContent('loading');
+  await waitFor(() => expect(control.transports[0]!.destroy).toHaveBeenCalledOnce());
+  expect(control.transports).toHaveLength(1);
+  await act(async () => finish());
+  await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('ready'));
+  expect(control.transports).toHaveLength(2);
+});
+
+it('shows account initialization failures with retry and a working guest escape', async () => {
+  control.init.mockImplementation((session: CoreSession) =>
+    session === 'account'
+      ? Promise.reject(new Error('Account storage unavailable.'))
+      : Promise.resolve(),
+  );
+  render(
+    <CoreProvider>
+      <App />
+    </CoreProvider>,
+  );
+  await waitFor(() => expect(control.init).toHaveBeenCalledWith('guest'));
+  fireEvent.click(screen.getByRole('button', { name: 'Sign in to Stremio' }));
+  const dialog = within(screen.getByRole('dialog'));
+  expect(await dialog.findByRole('alert')).toHaveTextContent('Account storage unavailable.');
+  expect(dialog.queryByRole('button', { name: 'Preparing account…' })).not.toBeInTheDocument();
+  fireEvent.click(dialog.getByRole('button', { name: 'Retry Stremio Core' }));
+  await waitFor(() =>
+    expect(control.init.mock.calls.filter(([session]) => session === 'account')).toHaveLength(2),
+  );
+  fireEvent.click(await dialog.findByRole('button', { name: 'Continue as guest' }));
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  await waitFor(() =>
+    expect(control.init.mock.calls.filter(([session]) => session === 'guest')).toHaveLength(2),
+  );
+});
+
+it('does not install a late guest manifest after changing sessions', async () => {
+  let respond!: (response: Response) => void;
+  vi.mocked(fetch).mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        respond = resolve;
+      }),
+  );
+  render(
+    <CoreProvider>
+      <Probe />
+    </CoreProvider>,
+  );
+  await waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+  const guest = control.transports[0]!;
+  fireEvent.click(screen.getByRole('button', { name: 'Account' }));
+  await waitFor(() => expect(control.transports).toHaveLength(2));
+  await act(async () =>
+    respond(new Response(JSON.stringify({ id: 'com.linvo.cinemeta', name: 'Cinemeta' }))),
+  );
+  expect(guest.dispatch).not.toHaveBeenCalled();
+  expect(screen.getByTestId('status')).toHaveTextContent('ready');
+});

--- a/apps/desktop/src/core/CoreProvider.tsx
+++ b/apps/desktop/src/core/CoreProvider.tsx
@@ -1,23 +1,34 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 
+import { t } from '../locales';
 import { connectNativeLifecycle } from '../native/player';
 
-import { ensureGuestCatalog } from './bootstrap';
-import { CoreContext, type CoreContextValue } from './context';
+import { ensureGuestCatalog, GuestCatalogError } from './bootstrap';
+import { CoreContext, CoreRecoveryContext, type CoreContextValue } from './context';
 import { coreFailureDetail, coreFailureMessage } from './errors';
 import { loadSession, saveSession, type CoreSession } from './storage';
 import { createCoreTransport, type CoreTransport } from './transport';
 
 interface RuntimeState {
+  attempt: number;
   error: string | null;
   session: CoreSession | null;
   status: 'error' | 'ready' | 'unavailable';
   transport: CoreTransport | null;
 }
 
-const startupFailed = 'Stremio Core could not start.';
+const startupFailed = t.core.startupFailed;
 
 export function CoreProvider({ children }: { children: ReactNode }) {
+  const [attempt, setAttempt] = useState(0);
+  const [catalogAttempt, setCatalogAttempt] = useState(0);
+  const retry = useCallback(() => setAttempt((value) => value + 1), []);
+  const retryCatalog = useCallback(() => setCatalogAttempt((value) => value + 1), []);
+  const [catalog, setCatalog] = useState({
+    attempt: -1,
+    error: null as string | null,
+    transport: null as CoreTransport | null,
+  });
   const teardown = useRef(Promise.resolve());
   const activeTransport = useRef<CoreTransport | null>(null);
   const [session, setSession] = useState<CoreSession>(() =>
@@ -28,6 +39,7 @@ export function CoreProvider({ children }: { children: ReactNode }) {
     saveSession(window.localStorage, session);
   }, [session]);
   const [runtime, setRuntime] = useState<RuntimeState>({
+    attempt: -1,
     error: null,
     session: null,
     status: 'unavailable',
@@ -65,42 +77,75 @@ export function CoreProvider({ children }: { children: ReactNode }) {
     if (typeof Worker === 'undefined') return;
 
     let disposed = false;
-    const transport = createCoreTransport(session);
-    activeTransport.current = transport;
+    let transport: CoreTransport | null = null;
     const previousTeardown = teardown.current;
+    const fail = (error: unknown) => {
+      console.error('[kino:core] initialization failed', coreFailureDetail(error, startupFailed));
+      if (!disposed) {
+        setRuntime({
+          attempt,
+          error: coreFailureMessage(error, startupFailed),
+          session,
+          status: 'error',
+          transport: null,
+        });
+      }
+    };
     void previousTeardown
       .then(async () => {
-        if (!disposed) await transport.init();
+        if (disposed) return;
+        transport = createCoreTransport(session, fail);
+        activeTransport.current = transport;
+        await transport.init();
+        // Reading ctx is required; fetching the default catalog is optional.
+        await transport.getState('ctx');
+        if (!disposed) setRuntime({ attempt, error: null, session, status: 'ready', transport });
       })
-      .then(async () => {
-        if (!disposed && session === 'guest') await ensureGuestCatalog(transport);
-      })
-      .then(() => {
-        if (!disposed) setRuntime({ error: null, session, status: 'ready', transport });
-      })
-      .catch((error: unknown) => {
-        // Guest initialization reads ctx through the adapter, so a contract
-        // failure reaches this catch and renders on Home.
-        console.error('[kino:core] initialization failed', coreFailureDetail(error, startupFailed));
-        if (!disposed) {
+      .catch(fail);
+
+    return () => {
+      disposed = true;
+      teardown.current = previousTeardown
+        .then(() => transport?.destroy())
+        .catch(() => {
+          console.error('[kino:core] session ended before all data could be saved');
+        });
+    };
+  }, [attempt, session]);
+
+  useEffect(() => {
+    if (
+      runtime.attempt !== attempt ||
+      runtime.session !== session ||
+      runtime.status !== 'ready' ||
+      !runtime.transport ||
+      session !== 'guest'
+    )
+      return;
+    const transport = runtime.transport;
+    const controller = new AbortController();
+    void ensureGuestCatalog(transport, controller.signal).then(
+      () => {
+        if (!controller.signal.aborted)
+          setCatalog({ attempt: catalogAttempt, error: null, transport });
+      },
+      (error: unknown) => {
+        if (controller.signal.aborted) return;
+        if (error instanceof GuestCatalogError) {
+          setCatalog({ attempt: catalogAttempt, error: t.core.catalogFailed, transport });
+        } else {
           setRuntime({
+            attempt,
             error: coreFailureMessage(error, startupFailed),
             session,
             status: 'error',
             transport: null,
           });
         }
-      });
-
-    return () => {
-      disposed = true;
-      teardown.current = previousTeardown
-        .then(() => transport.destroy())
-        .catch(() => {
-          console.error('[kino:core] session ended before all data could be saved');
-        });
-    };
-  }, [session]);
+      },
+    );
+    return () => controller.abort();
+  }, [attempt, catalogAttempt, runtime, session]);
 
   const context = useMemo<CoreContextValue>(() => {
     if (typeof Worker === 'undefined') {
@@ -112,7 +157,7 @@ export function CoreProvider({ children }: { children: ReactNode }) {
         transport: null,
       };
     }
-    if (runtime.session !== session) {
+    if (runtime.session !== session || runtime.attempt !== attempt) {
       return {
         error: null,
         selectSession: setSession,
@@ -122,6 +167,22 @@ export function CoreProvider({ children }: { children: ReactNode }) {
       };
     }
     return { ...runtime, selectSession: setSession, session };
-  }, [runtime, session]);
-  return <CoreContext.Provider value={context}>{children}</CoreContext.Provider>;
+  }, [attempt, runtime, session]);
+  const catalogActive = context.status === 'ready' && session === 'guest';
+  const catalogCurrent =
+    catalog.transport === context.transport && catalog.attempt === catalogAttempt;
+  const recovery = useMemo(
+    () => ({
+      retry,
+      retryCatalog,
+      catalogLoading: catalogActive && !catalogCurrent,
+      catalogError: catalogActive && catalogCurrent ? catalog.error : null,
+    }),
+    [catalog.error, catalogActive, catalogCurrent, retry, retryCatalog],
+  );
+  return (
+    <CoreContext.Provider value={context}>
+      <CoreRecoveryContext.Provider value={recovery}>{children}</CoreRecoveryContext.Provider>
+    </CoreContext.Provider>
+  );
 }

--- a/apps/desktop/src/core/bootstrap.ts
+++ b/apps/desktop/src/core/bootstrap.ts
@@ -12,19 +12,29 @@ function isManifest(value: unknown): value is Record<string, unknown> {
   );
 }
 
-export async function ensureGuestCatalog(transport: CoreTransport) {
+export class GuestCatalogError extends Error {}
+
+export async function ensureGuestCatalog(transport: CoreTransport, signal?: AbortSignal) {
   const context = await transport.getState('ctx');
   if (context.profile.addons.length > 0) return;
 
-  const response = await createAddonNetwork(fetch, import.meta.env.DEV).fetch(
-    CINEMETA_MANIFEST_URL,
-    {
-      headers: { Accept: 'application/json' },
-    },
-  );
-  if (!response.ok) throw new Error(`Cinemeta manifest returned ${response.status}.`);
-  const manifest: unknown = await response.json();
-  if (!isManifest(manifest)) throw new Error('Cinemeta returned an invalid manifest.');
+  let manifest: unknown;
+  try {
+    const response = await createAddonNetwork(fetch, import.meta.env.DEV).fetch(
+      CINEMETA_MANIFEST_URL,
+      {
+        headers: { Accept: 'application/json' },
+        signal: AbortSignal.any([AbortSignal.timeout(10_000), ...(signal ? [signal] : [])]),
+      },
+    );
+    if (!response.ok) throw new Error(`Cinemeta manifest returned ${response.status}.`);
+    manifest = await response.json();
+    if (!isManifest(manifest)) throw new Error('Cinemeta returned an invalid manifest.');
+  } catch (error) {
+    throw new GuestCatalogError('The default guest catalog could not be loaded.', { cause: error });
+  }
+  // A response arriving after a session switch must not mutate the old profile.
+  signal?.throwIfAborted();
 
   await transport.dispatch({
     action: 'Ctx',

--- a/apps/desktop/src/core/context.ts
+++ b/apps/desktop/src/core/context.ts
@@ -24,3 +24,16 @@ export const CoreContext = createContext<CoreContextValue>({
 export function useCore() {
   return useContext(CoreContext);
 }
+
+// Startup recovery is separate from the model transport so optional catalog
+// retries do not invalidate every mounted model subscription.
+export const CoreRecoveryContext = createContext({
+  retry: () => {},
+  retryCatalog: () => {},
+  catalogLoading: false,
+  catalogError: null as string | null,
+});
+
+export function useCoreRecovery() {
+  return useContext(CoreRecoveryContext);
+}

--- a/apps/desktop/src/core/transport.failure.test.ts
+++ b/apps/desktop/src/core/transport.failure.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, expect, it, vi } from 'vitest';
+
+import { createCoreTransport } from './transport';
+
+const state = vi.hoisted(() => ({
+  worker: null as EventTarget | null,
+  call: vi.fn(),
+  terminate: vi.fn(),
+}));
+vi.mock('./core.worker?worker', () => ({
+  default: class extends EventTarget {
+    constructor() {
+      super();
+      state.worker = this;
+    }
+    terminate = state.terminate;
+  },
+}));
+vi.mock('@stremio/stremio-core-web/bridge.js', () => ({
+  default: class {
+    call = state.call;
+  },
+}));
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+it.each(['error', 'messageerror'])(
+  'rejects outstanding and future RPCs after worker %s',
+  async (event) => {
+    state.call.mockImplementation(() => new Promise(() => {}));
+    const transport = createCoreTransport();
+    const result = Promise.allSettled([transport.init(), transport.getState('ctx')]);
+    state.worker!.dispatchEvent(new Event(event));
+    expect((await result).map((item) => item.status)).toEqual(['rejected', 'rejected']);
+    await expect(transport.getState('ctx')).rejects.toThrow();
+    expect(state.terminate).toHaveBeenCalledOnce();
+    await transport.destroy().catch(() => {});
+  },
+);
+
+it('bounds missing startup responses and allows teardown', async () => {
+  vi.useFakeTimers();
+  state.call.mockImplementation(() => new Promise(() => {}));
+  const transport = createCoreTransport();
+  const initialized = expect(transport.init()).rejects.toThrow(/respond|timed out/i);
+  await vi.advanceTimersByTimeAsync(30_000);
+  await initialized;
+  await transport.destroy().catch(() => {});
+  expect(state.terminate).toHaveBeenCalledOnce();
+});
+
+it('rejects an outstanding model read when a healthy worker is destroyed', async () => {
+  state.call.mockImplementation(([method]: string[]) =>
+    method === 'getState' ? new Promise(() => {}) : Promise.resolve(),
+  );
+  const transport = createCoreTransport();
+  await transport.init();
+  const read = expect(transport.getState('ctx')).rejects.toThrow();
+  await transport.destroy();
+  await read;
+  await expect(transport.getState('ctx')).rejects.toThrow();
+});

--- a/apps/desktop/src/core/transport.shutdown.test.ts
+++ b/apps/desktop/src/core/transport.shutdown.test.ts
@@ -4,7 +4,7 @@ import { createCoreTransport } from './transport';
 
 const worker = vi.hoisted(() => ({ terminate: vi.fn(), call: vi.fn() }));
 vi.mock('./core.worker?worker', () => ({
-  default: class {
+  default: class extends EventTarget {
     terminate = worker.terminate;
   },
 }));

--- a/apps/desktop/src/core/transport.ts
+++ b/apps/desktop/src/core/transport.ts
@@ -1,5 +1,6 @@
 import Bridge from '@stremio/stremio-core-web/bridge.js';
 import CoreWorker from './core.worker?worker';
+import { t } from '../locales';
 
 import { connectNativeSecureStore, nativeShellPresent } from '../native/player';
 import {
@@ -75,7 +76,10 @@ export async function migrateNativeAccountProfile() {
   await new SecureProfileStorage(local, nativeAuthStorage()).getItem('profile');
 }
 
-export function createCoreTransport(session: CoreSession = 'guest'): CoreTransport {
+export function createCoreTransport(
+  session: CoreSession = 'guest',
+  onFailure: (error: Error) => void = () => {},
+): CoreTransport {
   const listeners = new Set<CoreEventListener>();
   const worker = new CoreWorker();
   const localStorage = new NamespacedStorage(window.localStorage, session);
@@ -95,13 +99,58 @@ export function createCoreTransport(session: CoreSession = 'guest'): CoreTranspo
     },
   };
   const bridge = new Bridge(scope, worker);
+  const pending = new Set<(error: Error) => void>();
+  let stopped: Error | null = null;
+  const stop = (error: Error, failed = false) => {
+    if (stopped) return;
+    stopped = error;
+    worker.removeEventListener('error', workerFailed);
+    worker.removeEventListener('messageerror', workerFailed);
+    worker.terminate();
+    pending.forEach((reject) => reject(error));
+    pending.clear();
+    listeners.clear();
+    if (failed) onFailure(error);
+  };
+  const workerFailed = (event: Event) => {
+    event.preventDefault();
+    stop(new Error(t.core.workerFailed), true);
+  };
+  worker.addEventListener('error', workerFailed);
+  worker.addEventListener('messageerror', workerFailed);
+  const call = <Result>(path: string[], args: unknown[]): Promise<Result> => {
+    if (stopped) return Promise.reject(stopped);
+    return new Promise<Result>((resolve, reject) => {
+      const timeout = window.setTimeout(() => stop(new Error(t.core.timeout), true), 20_000);
+      const finish = () => {
+        window.clearTimeout(timeout);
+        pending.delete(cancel);
+      };
+      const cancel = (error: Error) => {
+        finish();
+        reject(error);
+      };
+      pending.add(cancel);
+      void bridge.call<Result>(path, args).then(
+        (result) => {
+          finish();
+          resolve(result);
+        },
+        (error: unknown) => {
+          finish();
+          reject(error);
+        },
+      );
+    });
+  };
   const beforeDestroy = new Set<() => Promise<void>>();
   let initializing: Promise<void> | null = null;
-  const flush = () => bridge.call<void>(['flush'], []);
+  const flush = () => call<void>(['flush'], []);
   const prepareClose = async () => {
     // Closing while Keychain/WASM startup is still running must also wait for
     // initialization's storage work before terminating the worker.
     await initializing?.catch(() => undefined);
+    if (stopped) throw stopped;
     await Promise.all([...beforeDestroy].map((callback) => callback()));
     await flush();
   };
@@ -110,22 +159,21 @@ export function createCoreTransport(session: CoreSession = 'guest'): CoreTranspo
   return {
     destroy() {
       destroying ??= prepareClose().finally(() => {
-        listeners.clear();
-        worker.terminate();
+        stop(new Error(t.core.stopped));
       });
       return destroying;
     },
     async dispatch(action, model) {
-      await bridge.call(['dispatch'], [action, model, currentHash()]);
+      await call(['dispatch'], [action, model, currentHash()]);
     },
     flush,
     // The worker adapts every model before it answers, so the response already
     // has this model's application shape.
     getState<Model extends CoreModelName>(model: Model) {
-      return bridge.call<CoreStateMap[Model]>(['getState'], [model]);
+      return call<CoreStateMap[Model]>(['getState'], [model]);
     },
     init() {
-      initializing ??= bridge.call<void>(['init'], [{ appVersion: '0.0.0', shellVersion: null }]);
+      initializing ??= call<void>(['init'], [{ appVersion: '0.0.0', shellVersion: null }]);
       return initializing;
     },
     onBeforeDestroy(callback) {

--- a/apps/desktop/src/core/useCoreModel.ts
+++ b/apps/desktop/src/core/useCoreModel.ts
@@ -30,7 +30,7 @@ export function useCoreModel<Model extends CoreModelName>(
   options?: { beforeUnload: (transport: CoreTransport, loaded: Promise<void>) => Promise<void> },
 ): CoreModelResult<CoreStateMap[Model]> {
   type State = CoreStateMap[Model];
-  const { status, transport } = useCore();
+  const { error: coreError, status, transport } = useCore();
   const dispatchLoad = useEffectEvent(async (target: CoreTransport, targetModel: CoreModelName) => {
     if (action) await target.dispatch(action, targetModel);
   });
@@ -129,7 +129,7 @@ export function useCoreModel<Model extends CoreModelName>(
   }, [actionKey, managedUnload, model, status, transport]);
 
   if (status !== 'ready' || !transport) {
-    return { error: null, loading: status === 'loading', state: null, unload };
+    return { error: coreError, loading: status === 'loading', state: null, unload };
   }
   if (result.actionKey === actionKey && result.transport === transport)
     return { ...result, unload };

--- a/apps/desktop/src/locales/en-US.ts
+++ b/apps/desktop/src/locales/en-US.ts
@@ -1,5 +1,19 @@
 export const enUS = {
   appName: 'Kino',
+  core: {
+    starting: 'Starting Stremio Core…',
+    startupFailed: 'Stremio Core could not start.',
+    workerFailed: 'Stremio Core stopped responding. Try starting it again.',
+    timeout: 'Stremio Core did not respond within 20 seconds. Try starting it again.',
+    stopped: 'Stremio Core has stopped.',
+    retry: 'Retry Stremio Core',
+    guest: 'Continue as guest',
+    catalogLoading: 'Loading the default guest catalog…',
+    catalogFailed:
+      'The default guest catalog could not be loaded. Check your connection and retry.',
+    retryCatalog: 'Retry guest catalog',
+    accountUnavailable: 'Account preparation failed',
+  },
   account: {
     create: 'Create account',
     createFailed: 'The registration page could not be opened. Try again.',


### PR DESCRIPTION
Core startup and guest catalog failures now have separate recovery paths. A failed optional catalog fetch leaves browsing, Settings, and add-on management usable; retry installs the default catalog into the running session. A failed Core or account startup shows the failure with retry, and account preparation offers a guest escape.

The upstream RPC bridge did not reject calls when the worker failed or stopped. Kino now rejects outstanding and future calls on worker errors or termination and limits response waits to 20 seconds. Startup retries wait for the previous transport to finish teardown, preserving the existing progress-save sequence. Guest manifest requests have a 10-second deadline and are cancelled when sessions change.

Closes #42.

Validation:
- `pnpm check`: 207 tests, pinned Core integration checks, vendor verification, and production build passed.
- Focused recovery tests cover worker failures, missing replies, teardown, catalog retry, startup retry, account retry/guest escape, and late catalog responses after session changes.
- A pinned WASM probe confirmed a mounted Home model updates after delayed add-on installation.
- `pnpm macos:build` passed.
- `pnpm macos:check-launch` passed; the bundled app remained healthy.
