### PR TITLE
Distinguish add-on loading, failures, and empty results

### DIFF
--- a/apps/desktop/src/App.navigation.test.tsx
+++ b/apps/desktop/src/App.navigation.test.tsx
@@ -56,7 +56,17 @@ function fixture() {
           : model === 'search'
             ? {
                 selected: { extra: [['search', query]], type: null },
-                catalogs: query ? [{ content: { type: 'Ready', content: [item] } }] : [],
+                catalogs: query
+                  ? [
+                      {
+                        addon,
+                        id: 'top',
+                        name: 'Top',
+                        type: 'movie',
+                        content: { type: 'Ready', content: [item] },
+                      },
+                    ]
+                  : [],
               }
             : model === 'meta_details'
               ? {
@@ -73,7 +83,7 @@ function fixture() {
               : model === 'discover'
                 ? {
                     catalog: { content: { type: 'Ready', content: [item] } },
-                    selected: null,
+                    selected: { request: catalogRequest(genre) },
                     selectable: {
                       nextPage: false,
                       types: [],

--- a/apps/desktop/src/components/ResourceFailures.tsx
+++ b/apps/desktop/src/components/ResourceFailures.tsx
@@ -1,0 +1,35 @@
+import styles from '../App.module.css';
+import { t } from '../locales';
+
+export function ResourceFailures({
+  names,
+  error,
+  pending,
+  onRetry,
+}: {
+  names: string[];
+  error?: string | null;
+  pending: boolean;
+  onRetry: () => void;
+}) {
+  const message = names.length ? t.resources.failed([...new Set(names)].join(', ')) : error;
+  return (
+    <div aria-live="polite">
+      {message ? (
+        <>
+          <p role="alert" className={styles.loadError}>
+            {message}
+          </p>
+          <button
+            className={styles.secondaryButton}
+            disabled={pending}
+            onClick={onRetry}
+            type="button"
+          >
+            {t.resources.retry}
+          </button>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/core/useCoreModel.ts
+++ b/apps/desktop/src/core/useCoreModel.ts
@@ -10,10 +10,12 @@ interface CoreModelResult<State> {
   loading: boolean;
   state: State | null;
   unload(): Promise<void>;
+  retry(): void;
 }
 
-interface CoreModelSnapshot<State> extends Omit<CoreModelResult<State>, 'unload'> {
+interface CoreModelSnapshot<State> extends Omit<CoreModelResult<State>, 'unload' | 'retry'> {
   actionKey: string | null;
+  revision: number;
   transport: CoreTransport | null;
 }
 
@@ -30,6 +32,8 @@ export function useCoreModel<Model extends CoreModelName>(
   options?: { beforeUnload: (transport: CoreTransport, loaded: Promise<void>) => Promise<void> },
 ): CoreModelResult<CoreStateMap[Model]> {
   type State = CoreStateMap[Model];
+  const [revision, setRevision] = useState(0);
+  const retry = useCallback(() => setRevision((value) => value + 1), []);
   const { error: coreError, status, transport } = useCore();
   const dispatchLoad = useEffectEvent(async (target: CoreTransport, targetModel: CoreModelName) => {
     if (action) await target.dispatch(action, targetModel);
@@ -43,6 +47,7 @@ export function useCoreModel<Model extends CoreModelName>(
   const unload = useCallback(() => release.current(), []);
   const [result, setResult] = useState<CoreModelSnapshot<State>>({
     actionKey: null,
+    revision: -1,
     error: null,
     loading: true,
     state: null,
@@ -56,12 +61,14 @@ export function useCoreModel<Model extends CoreModelName>(
     const read = async () => {
       try {
         const state = await transport.getState(model);
-        if (!disposed) setResult({ actionKey, error: null, loading: false, state, transport });
+        if (!disposed)
+          setResult({ actionKey, revision, error: null, loading: false, state, transport });
       } catch (error) {
         console.error(`[kino:core] ${model} state failed`, failureDetail(error));
         if (!disposed)
           setResult({
             actionKey,
+            revision,
             error: failureMessage(error),
             loading: false,
             state: null,
@@ -107,6 +114,7 @@ export function useCoreModel<Model extends CoreModelName>(
         if (!disposed)
           setResult({
             actionKey,
+            revision,
             error: failureMessage(error),
             loading: false,
             state: null,
@@ -126,13 +134,17 @@ export function useCoreModel<Model extends CoreModelName>(
         void transport.dispatch({ action: 'Unload' }, model).catch(() => undefined);
       }
     };
-  }, [actionKey, managedUnload, model, status, transport]);
+  }, [actionKey, managedUnload, model, revision, status, transport]);
 
   if (status !== 'ready' || !transport) {
-    return { error: coreError, loading: status === 'loading', state: null, unload };
+    return { error: coreError, loading: status === 'loading', state: null, unload, retry };
   }
-  if (result.actionKey === actionKey && result.transport === transport)
-    return { ...result, unload };
+  if (
+    result.actionKey === actionKey &&
+    result.transport === transport &&
+    result.revision === revision
+  )
+    return { ...result, unload, retry };
   // A new selection reloads the model. Keeping the previous state while that
   // happens stops the screen collapsing and losing its scroll position; a
   // different transport is a different session, so that state is dropped.
@@ -141,5 +153,6 @@ export function useCoreModel<Model extends CoreModelName>(
     loading: true,
     state: result.transport === transport ? result.state : null,
     unload,
+    retry,
   };
 }

--- a/apps/desktop/src/core/useResourceStates.ts
+++ b/apps/desktop/src/core/useResourceStates.ts
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+
+import type { Loadable } from './types';
+
+export interface ResourceInput<Value> {
+  id: string;
+  name: string;
+  content: Loadable<Value> | null;
+}
+
+interface Snapshot<Value> {
+  scope: unknown;
+  key: string | null;
+  resources: readonly ResourceInput<Value>[] | null;
+  known: readonly ResourceInput<Value>[] | null;
+  values: Map<string, Value>;
+}
+
+function remember<Value>(
+  scope: unknown,
+  key: string | null,
+  resources: readonly ResourceInput<Value>[] | null,
+  previous?: Snapshot<Value>,
+): Snapshot<Value> {
+  const sameSelection = previous?.scope === scope && previous?.key === key;
+  const known = resources ?? (sameSelection ? previous!.known : null);
+  const values = new Map<string, Value>();
+  for (const resource of known ?? []) {
+    if (resources && resource.content?.type === 'Ready') {
+      values.set(resource.id, resource.content.content);
+    } else if (sameSelection && previous!.values.has(resource.id)) {
+      values.set(resource.id, previous!.values.get(resource.id)!);
+    }
+  }
+  return { scope, key, resources, known, values };
+}
+
+// Keep successful responses visible during a retry, while preserving the actual
+// request status. In particular, retained sources are never marked current.
+export function useResourceStates<Value>(
+  scope: unknown,
+  key: string | null,
+  resources: readonly ResourceInput<Value>[] | null,
+  reloading: boolean,
+) {
+  const [previous, setPrevious] = useState(() => remember(scope, key, resources));
+  // Core can temporarily clear its selected path while reloading metadata.
+  const resolvedKey = key ?? (previous.scope === scope ? previous.key : null);
+  let current = previous;
+  if (
+    previous.scope !== scope ||
+    previous.key !== resolvedKey ||
+    previous.resources !== resources
+  ) {
+    current = remember(scope, resolvedKey, resources, previous);
+    setPrevious(current);
+  }
+  const rows = (resources ?? current.known ?? []).map((resource) => ({
+    ...resource,
+    value: current.values.get(resource.id) ?? null,
+    current: !reloading && resources !== null && resource.content?.type === 'Ready',
+  }));
+  return {
+    rows,
+    pending:
+      reloading ||
+      resources === null ||
+      resources.some((resource) => !resource.content || resource.content.type === 'Loading'),
+    failures:
+      resources
+        ?.filter((resource) => resource.content?.type === 'Err')
+        .map((resource) => resource.name) ?? [],
+  };
+}

--- a/apps/desktop/src/locales/en-US.ts
+++ b/apps/desktop/src/locales/en-US.ts
@@ -41,15 +41,24 @@ export const enUS = {
     movies: 'Movies',
     series: 'Series',
     catalogs: 'Catalogs',
+    loadingCatalogs: 'Loading catalogs…',
     catalogsEmpty: 'No catalogs are available from the installed add-ons.',
     catalogsUnavailable: 'Installed add-ons are present, but their catalogs returned no items.',
     catalogsError: 'Catalogs could not be loaded. Check the local log and try again.',
+  },
+  resources: {
+    catalog: 'the selected add-on',
+    retry: 'Retry add-ons',
+    failed: (names: string) => `Could not load results from ${names}.`,
   },
   search: {
     title: 'Search',
     placeholder: 'Search movies and series',
     idle: 'Search across catalogs from your installed add-ons.',
     loading: 'Searching installed add-ons…',
+    count: (count: number) => `${count} ${count === 1 ? 'result' : 'results'}`,
+    partial: (count: number) =>
+      `${count} ${count === 1 ? 'result' : 'results'}. Searching installed add-ons…`,
     error: 'Search could not be completed.',
   },
   discover: {

--- a/apps/desktop/src/screens/DiscoverScreen.filters.test.tsx
+++ b/apps/desktop/src/screens/DiscoverScreen.filters.test.tsx
@@ -31,16 +31,20 @@ it('renders all required and optional choices and follows requests that preserve
         : [['genre', year]],
     },
   });
+  const snapshots = new Map<string, unknown>();
   model.read.mockImplementation((_name, action) => {
+    const cacheKey = JSON.stringify(action);
+    if (snapshots.has(cacheKey)) return snapshots.get(cacheKey);
     const selected = action.args.args?.request as CatalogRequest | undefined;
     const year = selected?.path.extra.find(([key]) => key === 'genre')?.[1] ?? '2026';
     const language = selected
       ? (selected.path.extra.find(([key]) => key === 'language')?.[1] ?? null)
       : 'English';
-    return {
+    const result = {
       loading: false,
       error: null,
       state: {
+        selected: { request: request(year, language) },
         catalog: { content: { type: 'Ready', content: [] } },
         selectable: {
           nextPage: false,
@@ -78,6 +82,8 @@ it('renders all required and optional choices and follows requests that preserve
         },
       },
     };
+    snapshots.set(cacheKey, result);
+    return result;
   });
   render(<DiscoverScreen onOpen={vi.fn()} />);
   expect(screen.getAllByRole('combobox')).toHaveLength(2);

--- a/apps/desktop/src/screens/DiscoverScreen.resources.test.tsx
+++ b/apps/desktop/src/screens/DiscoverScreen.resources.test.tsx
@@ -1,0 +1,82 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { expect, it, vi } from 'vitest';
+
+import { CoreContext } from '../core/context';
+import type { CoreTransport } from '../core/transport';
+import type { CatalogWithFiltersState, CoreRuntimeEvent } from '../core/types';
+import { preview } from '../test/coreState';
+import { DiscoverScreen } from './DiscoverScreen';
+
+it('distinguishes pending, failed, and empty catalogs and retains titles during retry', async () => {
+  const request = {
+    base: 'https://fixture.invalid/manifest.json',
+    path: { resource: 'catalog', type: 'movie', id: 'test', extra: [] },
+  };
+  let state: CatalogWithFiltersState = {
+    selected: { request },
+    catalog: { content: { type: 'Loading' } },
+    selectable: {
+      types: [],
+      extra: [],
+      nextPage: false,
+      catalogs: [
+        {
+          id: 'test',
+          name: 'Test',
+          addon: { manifest: { id: 'test', name: 'Test provider' } },
+          request,
+          selected: true,
+        },
+      ],
+    },
+  };
+  const listeners = new Set<(event: CoreRuntimeEvent) => void>();
+  const target: CoreTransport = {
+    init: vi.fn(),
+    destroy: vi.fn(),
+    flush: vi.fn(),
+    prepareClose: vi.fn(),
+    onBeforeDestroy: () => () => {},
+    getState: (async () => state) as CoreTransport['getState'],
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    dispatch: vi.fn(async (action) => {
+      if (action.action === 'Load') state = { ...state, catalog: { content: { type: 'Loading' } } };
+    }),
+  };
+  const publish = async (content: NonNullable<CatalogWithFiltersState['catalog']>['content']) => {
+    await act(async () => {
+      state = { ...state, catalog: { content } };
+      listeners.forEach((listener) => listener({ name: 'NewState', args: ['discover'] }));
+    });
+  };
+  render(
+    <CoreContext.Provider
+      value={{
+        transport: target,
+        session: 'guest',
+        status: 'ready',
+        error: null,
+        selectSession: vi.fn(),
+      }}
+    >
+      <DiscoverScreen onOpen={vi.fn()} />
+    </CoreContext.Provider>,
+  );
+  await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Loading catalog'));
+  expect(screen.queryByText('This catalog returned no titles.')).not.toBeInTheDocument();
+  await publish({ type: 'Ready', content: [preview({ id: 'one', name: 'One title' })] });
+  expect(screen.getByText('One title')).toBeVisible();
+  await publish({ type: 'Err', content: { kind: 'Env', message: 'Unavailable' } });
+  expect(screen.getByRole('alert')).toHaveTextContent('Test provider');
+  expect(screen.queryByText('This catalog returned no titles.')).not.toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: 'Retry add-ons' }));
+  await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Loading catalog'));
+  expect(screen.getByText('One title')).toBeVisible();
+  expect(target.dispatch).toHaveBeenCalledWith({ action: 'Unload' }, 'discover');
+  await publish({ type: 'Ready', content: [] });
+  expect(screen.getByRole('status')).toHaveTextContent('This catalog returned no titles.');
+  expect(screen.queryByText('One title')).not.toBeInTheDocument();
+});

--- a/apps/desktop/src/screens/DiscoverScreen.tsx
+++ b/apps/desktop/src/screens/DiscoverScreen.tsx
@@ -1,7 +1,9 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { CaretDown } from '@phosphor-icons/react';
 
 import styles from '../App.module.css';
+import { ResourceFailures } from '../components/ResourceFailures';
+import { useResourceStates } from '../core/useResourceStates';
 import { MediaCard } from '../components/MediaCard';
 import { LoadMore } from '../components/LoadMore';
 import { useCore } from '../core/context';
@@ -56,8 +58,27 @@ export function DiscoverScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => 
       .finally(() => setOperation((previous) => (previous === current ? null : previous)));
   };
   const selectable = result.state?.selectable;
-  const content = result.state?.catalog?.content ?? null;
-  const items = content?.type === 'Ready' ? content.content : [];
+  const inputs = useMemo(() => {
+    const state = result.state;
+    if (!state || (request && catalogRequestKey(state.selected?.request ?? null) !== key))
+      return null;
+    return state.catalog
+      ? [
+          {
+            id: key,
+            name:
+              state.selectable?.catalogs.find((catalog) => catalog.selected)?.addon.manifest.name ??
+              enUS.resources.catalog,
+            content: state.catalog.content,
+          },
+        ]
+      : state.selected
+        ? null
+        : [];
+  }, [key, request, result.state]);
+  const resources = useResourceStates(transport, key, inputs, result.loading);
+  const items = resources.rows.flatMap((row) => row.value ?? []);
+  const pending = !result.error && resources.pending;
   const filters = selectable?.extra.filter((extra) => extra.options.length > 0) ?? [];
 
   // The adapter already turned each choice into a request or marked it
@@ -149,14 +170,23 @@ export function DiscoverScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => 
       ) : null}
 
       <div aria-live="polite">
-        {result.loading ? <p className={styles.inlineEmpty}>{enUS.discover.loading}</p> : null}
-        {result.error || content?.type === 'Err' ? (
-          <p className={styles.loadError}>{enUS.discover.error}</p>
+        {pending ? (
+          <p role="status" className={styles.inlineEmpty}>
+            {enUS.discover.loading}
+          </p>
         ) : null}
-        {!result.loading && items.length === 0 && content?.type !== 'Err' ? (
-          <p className={styles.inlineEmpty}>{enUS.discover.empty}</p>
+        {!pending && !result.error && !resources.failures.length && items.length === 0 ? (
+          <p role="status" className={styles.inlineEmpty}>
+            {enUS.discover.empty}
+          </p>
         ) : null}
       </div>
+      <ResourceFailures
+        names={resources.failures}
+        error={result.error ? enUS.discover.error : null}
+        pending={pending}
+        onRetry={result.retry}
+      />
 
       {items.length > 0 ? (
         <div className={styles.mediaGrid}>
@@ -166,7 +196,7 @@ export function DiscoverScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => 
         </div>
       ) : null}
       {selectable?.nextPage || loadingPage || pagingError ? (
-        <LoadMore error={pagingError} loading={result.loading || loadingPage} onLoad={loadMore} />
+        <LoadMore error={pagingError} loading={pending || loadingPage} onLoad={loadMore} />
       ) : null}
     </div>
   );

--- a/apps/desktop/src/screens/HomeScreen.tsx
+++ b/apps/desktop/src/screens/HomeScreen.tsx
@@ -5,28 +5,22 @@ import { X } from '@phosphor-icons/react';
 import styles from '../App.module.css';
 import { ActionFeedback } from '../components/ActionFeedback';
 import { useActionFeedback } from '../components/useActionFeedback';
+import { ResourceFailures } from '../components/ResourceFailures';
+import { useResourceStates } from '../core/useResourceStates';
 import { MediaCard } from '../components/MediaCard';
 import { loadBoardAction, rewindLibraryItemAction } from '../core/actions';
 import { useCore } from '../core/context';
 import { savedTitlePreview } from '../core/preview';
-import type { CoreCatalog, CoreMetaPreview } from '../core/types';
+import type { CoreMetaPreview } from '../core/types';
 import { useCoreModel } from '../core/useCoreModel';
 import { t as enUS } from '../locales';
 
 const rowItemLimit = 12;
 
-function rowItems(catalogs: CoreCatalog[], type: string) {
-  const seen = new Set<string>();
-  const items: CoreMetaPreview[] = [];
-  for (const catalog of catalogs) {
-    if (catalog.type !== type || catalog.content?.type !== 'Ready') continue;
-    for (const item of catalog.content.content) {
-      if (seen.has(item.id)) continue;
-      seen.add(item.id);
-      items.push(item);
-    }
-  }
-  return items.slice(0, rowItemLimit);
+function rowItems(values: CoreMetaPreview[], type: string) {
+  return [
+    ...new Map(values.filter((item) => item.type === type).map((item) => [item.id, item])).values(),
+  ].slice(0, rowItemLimit);
 }
 
 function RowSkeleton() {
@@ -52,25 +46,34 @@ export function HomeScreen({
   const catalogs = board.state?.catalogs ?? [];
 
   useEffect(() => {
-    if (!core.transport || catalogs.length === 0) return;
-    void core.transport.dispatch(
-      {
-        action: 'CatalogsWithExtra',
-        args: { action: 'LoadRange', args: { start: 0, end: catalogs.length } },
-      },
-      'board',
-    );
-  }, [catalogs.length, core.transport]);
+    if (!core.transport || board.loading || catalogs.length === 0) return;
+    void core.transport
+      .dispatch(
+        {
+          action: 'CatalogsWithExtra',
+          args: { action: 'LoadRange', args: { start: 0, end: catalogs.length } },
+        },
+        'board',
+      )
+      .catch(() => undefined);
+  }, [board.loading, catalogs.length, core.transport]);
 
+  const inputs = useMemo(
+    () =>
+      board.state?.catalogs.map((catalog, index) => ({
+        id: JSON.stringify([index, catalog.addon.manifest.id, catalog.type, catalog.id]),
+        name: catalog.addon.manifest.name,
+        content: catalog.content,
+      })) ?? null,
+    [board.state],
+  );
+  const resources = useResourceStates(core.transport, 'board', inputs, board.loading);
+  const values = resources.rows.flatMap((row) => row.value ?? []);
   const typedRows = [
-    { id: 'home-movies', items: rowItems(catalogs, 'movie'), title: enUS.home.movies },
-    { id: 'home-series', items: rowItems(catalogs, 'series'), title: enUS.home.series },
+    { id: 'home-movies', items: rowItems(values, 'movie'), title: enUS.home.movies },
+    { id: 'home-series', items: rowItems(values, 'series'), title: enUS.home.series },
   ].filter((row) => row.items.length > 0);
-  const failedCatalogs = catalogs.some((catalog) => catalog.content?.type === 'Err');
-  const loadingCatalogs = catalogs.filter(
-    (catalog) => catalog.content === null || catalog.content?.type === 'Loading',
-  ).length;
-  const catalogsPending = board.loading || (catalogs.length > 0 && loadingCatalogs > 0);
+  const catalogsPending = !board.error && resources.pending;
   const continueItems = useMemo(
     () => continueWatching.state?.items.slice(0, 10) ?? [],
     [continueWatching.state],
@@ -98,7 +101,7 @@ export function HomeScreen({
       <section className={styles.homeSection} aria-labelledby="continue-watching-title">
         <h2 id="continue-watching-title">{enUS.home.continueWatching}</h2>
         {continueWatching.loading ? <RowSkeleton /> : null}
-        {!continueWatching.loading && continueItems.length === 0 ? (
+        {!continueWatching.loading && !continueWatching.error && continueItems.length === 0 ? (
           <p className={styles.inlineEmpty}>{enUS.home.continueEmpty}</p>
         ) : null}
         {continueItems.length > 0 ? (
@@ -142,21 +145,29 @@ export function HomeScreen({
           <RowSkeleton />
         </section>
       ) : null}
-      {board.error ? <p className={styles.loadError}>{enUS.home.catalogsError}</p> : null}
+      {catalogsPending ? (
+        <p role="status" className={styles.inlineEmpty}>
+          {enUS.home.loadingCatalogs}
+        </p>
+      ) : null}
+      <ResourceFailures
+        names={resources.failures}
+        error={board.error ? enUS.home.catalogsError : null}
+        pending={catalogsPending}
+        onRetry={board.retry}
+      />
       {core.error ? <p className={styles.loadError}>Stremio Core failed: {core.error}</p> : null}
-      {!catalogsPending && !board.error && typedRows.length === 0 ? (
+      {!catalogsPending && !board.error && !resources.failures.length && typedRows.length === 0 ? (
         <section className={styles.homeSection} aria-label={enUS.home.catalogs}>
           <h2>{enUS.home.catalogs}</h2>
           <p className={styles.inlineEmpty}>
-            {failedCatalogs
-              ? enUS.home.catalogsError
-              : context.loading
-                ? 'Loading the guest profile…'
-                : context.error
-                  ? `Guest profile failed: ${context.error}`
-                  : context.state?.profile.addons.length
-                    ? enUS.home.catalogsUnavailable
-                    : enUS.home.catalogsEmpty}
+            {context.loading
+              ? 'Loading the guest profile…'
+              : context.error
+                ? `Guest profile failed: ${context.error}`
+                : context.state?.profile.addons.length
+                  ? enUS.home.catalogsUnavailable
+                  : enUS.home.catalogsEmpty}
           </p>
         </section>
       ) : null}

--- a/apps/desktop/src/screens/MetaDetailsScreen.profile.test.tsx
+++ b/apps/desktop/src/screens/MetaDetailsScreen.profile.test.tsx
@@ -132,7 +132,7 @@ it('announces library failure, rolls back the optimistic state, and retries the 
   target.dispatch.mockResolvedValue(undefined);
   fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
   await waitFor(() =>
-    expect(screen.getByRole('status')).toHaveTextContent('Added to your library.'),
+    expect(screen.getByText('Added to your library.')).toHaveAttribute('role', 'status'),
   );
   expect(screen.getByRole('button', { name: 'In Library' })).toBeEnabled();
   expect(target.flush).toHaveBeenCalledOnce();

--- a/apps/desktop/src/screens/MetaDetailsScreen.test.tsx
+++ b/apps/desktop/src/screens/MetaDetailsScreen.test.tsx
@@ -378,3 +378,58 @@ describe('Start Over', () => {
     );
   });
 });
+
+it('announces pending and failed stream providers, keeps successful sources, and retries', async () => {
+  const pending = details('ep1');
+  pending.streams[0]!.content = { type: 'Loading' };
+  const test = mountDetails(pending);
+  await waitFor(() =>
+    expect(screen.getByText('Refreshing sources…')).toHaveAttribute('role', 'status'),
+  );
+  expect(screen.queryByText('No sources were returned for this title.')).not.toBeInTheDocument();
+  const partial = details('ep1');
+  partial.streams.push({
+    addon: {
+      ...addon,
+      manifest: { ...addon.manifest, id: 'failed', name: 'Failed provider' },
+      transportUrl: 'https://failed.invalid/manifest.json',
+    },
+    content: { type: 'Err', content: { kind: 'Env', message: 'Unavailable' } },
+  });
+  await test.publish(partial);
+  expect(screen.getByRole('alert')).toHaveTextContent('Failed provider');
+  expect(screen.getByRole('button', { name: /ep1 source/ })).toBeEnabled();
+  expect(screen.queryByText('No sources were returned for this title.')).not.toBeInTheDocument();
+  await act(async () => fireEvent.click(screen.getByRole('button', { name: 'Retry add-ons' })));
+  expect(test.dispatch).toHaveBeenCalledWith({ action: 'Unload' }, 'meta_details');
+  await test.publish({
+    ...pending,
+    metaItem: { addon, content: { type: 'Loading' } },
+    selected: null,
+    streams: [],
+  });
+  expect(screen.getByRole('button', { name: /ep1 source/ })).toBeDisabled();
+  await test.publish(pending);
+  expect(screen.getByRole('button', { name: /ep1 source/ })).toBeDisabled();
+  fireEvent.click(screen.getByRole('button', { name: /ep1 source/ }));
+  expect(test.onPlay).not.toHaveBeenCalled();
+  const empty = details('ep1');
+  empty.streams[0]!.content = { type: 'Ready', content: [] };
+  await test.publish(empty);
+  expect(screen.getByText('No sources were returned for this title.')).toHaveAttribute(
+    'role',
+    'status',
+  );
+  expect(screen.queryByRole('button', { name: /ep1 source/ })).not.toBeInTheDocument();
+});
+
+it('identifies metadata provider failure and offers retry without an empty-source claim', async () => {
+  const failed = details('ep1');
+  failed.metaItem!.content = { type: 'Err', content: { kind: 'Env', message: 'Unavailable' } };
+  failed.streams = [];
+  mountDetails(failed);
+  expect(await screen.findByRole('alert')).toHaveTextContent('Test add-on');
+  expect(screen.getByRole('button', { name: 'Retry add-ons' })).toBeEnabled();
+  expect(screen.queryByText('No sources were returned for this title.')).not.toBeInTheDocument();
+  expect(screen.queryByText('Refreshing sources…')).not.toBeInTheDocument();
+});

--- a/apps/desktop/src/screens/MetaDetailsScreen.tsx
+++ b/apps/desktop/src/screens/MetaDetailsScreen.tsx
@@ -4,6 +4,8 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import styles from '../App.module.css';
 import { ActionFeedback } from '../components/ActionFeedback';
 import { useActionFeedback } from '../components/useActionFeedback';
+import { ResourceFailures } from '../components/ResourceFailures';
+import { useResourceStates } from '../core/useResourceStates';
 import { ExternalSourceDialog } from '../components/ExternalSourceDialog';
 import { ExpandableText } from '../components/ExpandableText';
 import {
@@ -27,6 +29,7 @@ import { useCoreModel } from '../core/useCoreModel';
 import { t as enUS } from '../locales';
 
 interface SourceChoice {
+  current: boolean;
   addonName: string;
   source: CoreSource;
   transportUrl: string;
@@ -132,23 +135,53 @@ export function MetaDetailsScreen({
     sourcesRef.current?.scrollIntoView({ behavior: 'auto', block: 'start' });
   }, [sourcesCurrent, videoId]);
 
-  const sources = useMemo<SourceChoice[]>(
+  const streamInputs = useMemo(
     () =>
-      result.state?.streams.flatMap((resource) =>
-        resource.content.type === 'Ready'
-          ? resource.content.content.map((source) => ({
-              addonName: resource.addon.manifest.name,
-              source,
-              transportUrl: resource.addon.transportUrl ?? '',
-            }))
-          : [],
-      ) ?? [],
+      result.state &&
+      result.state.streams.length === 0 &&
+      (!result.state.metaItem || result.state.metaItem.content.type === 'Loading')
+        ? null
+        : (result.state?.streams.map((resource, index) => ({
+            id: JSON.stringify([index, resource.addon.transportUrl, resource.addon.manifest.id]),
+            name: resource.addon.manifest.name,
+            content:
+              resource.content.type === 'Ready'
+                ? {
+                    type: 'Ready' as const,
+                    content: resource.content.content.map((source) => ({
+                      addonName: resource.addon.manifest.name,
+                      source,
+                      transportUrl: resource.addon.transportUrl ?? '',
+                      current: true,
+                    })),
+                  }
+                : resource.content,
+          })) ?? null),
     [result.state],
   );
+  const streamResources = useResourceStates(
+    transport,
+    selected?.streamPath ? `${item.type}:${item.id}:${selected.streamPath.id}` : null,
+    streamInputs,
+    result.loading,
+  );
+  const sources: SourceChoice[] = streamResources.rows.flatMap((row) =>
+    (row.value ?? []).map((choice) => ({ ...choice, current: row.current })),
+  );
+  const metaFailed = resource?.content.type === 'Err';
+  const sourcesPending =
+    !result.error && !metaFailed && (!sourcesCurrent || streamResources.pending);
+  const failures = [
+    ...(metaFailed ? [resource.addon.manifest.name] : []),
+    ...streamResources.failures,
+  ];
+
   const display = meta ?? item;
   const sourceSelection = { meta: display, video: activeVideo };
   const visibleSourceKeys = new Set(
-    sources.map((choice) => sourceKey(choice.source, choice.transportUrl, sourceSelection)),
+    sources
+      .filter((choice) => choice.current)
+      .map((choice) => sourceKey(choice.source, choice.transportUrl, sourceSelection)),
   );
   const [externalChoice, setExternalChoice] = useState<{
     key: string;
@@ -257,10 +290,17 @@ export function MetaDetailsScreen({
       </header>
 
       <div className={styles.detailBody}>
-        {result.loading && !meta ? (
-          <p className={styles.inlineEmpty}>{enUS.details.loading}</p>
+        {!result.error && !metaFailed && !meta ? (
+          <p role="status" className={styles.inlineEmpty}>
+            {enUS.details.loading}
+          </p>
         ) : null}
-        {result.error ? <p className={styles.loadError}>{enUS.details.error}</p> : null}
+        <ResourceFailures
+          names={failures}
+          error={result.error ? enUS.details.error : null}
+          pending={sourcesPending}
+          onRetry={result.retry}
+        />
         {item.type === 'series' && videos.length > 0 ? (
           <section className={styles.detailSection} aria-labelledby="episodes-heading">
             <div className={styles.detailSectionHeading}>
@@ -325,7 +365,7 @@ export function MetaDetailsScreen({
         >
           <div className={styles.detailSectionHeading}>
             <h2 id="sources-heading">{enUS.details.sources}</h2>
-            {!sourcesCurrent && !result.error ? <span>{enUS.details.refreshing}</span> : null}
+            {sourcesPending ? <span role="status">{enUS.details.refreshing}</span> : null}
           </div>
           {canResume ? (
             <div
@@ -356,8 +396,14 @@ export function MetaDetailsScreen({
               {currentFailure}
             </p>
           ) : null}
-          {sourcesCurrent && sources.length === 0 ? (
-            <p className={styles.inlineEmpty}>{enUS.details.noSources}</p>
+          {sourcesCurrent &&
+          !sourcesPending &&
+          !result.error &&
+          failures.length === 0 &&
+          sources.length === 0 ? (
+            <p role="status" className={styles.inlineEmpty}>
+              {enUS.details.noSources}
+            </p>
           ) : null}
           <div className={styles.sourceList}>
             {sources.map((choice, index) => {
@@ -380,9 +426,9 @@ export function MetaDetailsScreen({
                 <div className={styles.sourceRow} key={`${choice.transportUrl}:${index}`}>
                   <button
                     className={styles.sourceButton}
-                    disabled={!selectable || !sourcesCurrent}
+                    disabled={!selectable || !sourcesCurrent || !choice.current}
                     onClick={() => {
-                      if (!sourcesCurrent) return;
+                      if (!sourcesCurrent || !choice.current) return;
                       if (external) {
                         setExternalChoice({ key, url: external, transport });
                         return;

--- a/apps/desktop/src/screens/SearchScreen.test.tsx
+++ b/apps/desktop/src/screens/SearchScreen.test.tsx
@@ -65,6 +65,10 @@ function setup() {
     ...view,
     requests,
     target,
+    publishState(next: BoardState) {
+      state = next;
+      publish();
+    },
     finish(query: string) {
       state = {
         selected: { extra: [['search', query]], type: null },
@@ -136,4 +140,56 @@ it('cancels pending typing when leaving Search', async () => {
   fixture.unmount();
   await act(async () => vi.advanceTimersByTimeAsync(500));
   expect(fixture.requests).toEqual([]);
+});
+
+it('keeps pending resources distinct from empty and retains successful results while retrying failures', async () => {
+  const fixture = setup();
+  await type('matrix', 300);
+  expect(screen.getByRole('status')).toHaveTextContent('Searching installed add-ons');
+  expect(screen.queryByText('0 results')).not.toBeInTheDocument();
+  const catalog = (id: string, content: BoardState['catalogs'][number]['content']) => ({
+    id,
+    name: id,
+    type: 'movie',
+    addon: { manifest: { id, name: id } },
+    content,
+  });
+  const successful = catalog('one', {
+    type: 'Ready',
+    content: [preview({ id: 'matrix', name: 'Matrix result' })],
+  });
+  await act(async () =>
+    fixture.publishState({
+      selected: { extra: [['search', 'matrix']], type: null },
+      catalogs: [
+        successful,
+        catalog('two', { type: 'Loading' }),
+        catalog('three', {
+          type: 'Err',
+          content: { kind: 'Env', message: 'Provider unavailable' },
+        }),
+      ],
+    }),
+  );
+  expect(screen.getByText('Matrix result')).toBeVisible();
+  expect(screen.getByRole('status')).toHaveTextContent('Searching installed add-ons');
+  expect(screen.getByRole('alert')).toHaveTextContent('three');
+  await act(async () =>
+    fixture.publishState({
+      selected: { extra: [['search', 'matrix']], type: null },
+      catalogs: [
+        successful,
+        catalog('two', { type: 'Ready', content: [] }),
+        catalog('three', {
+          type: 'Err',
+          content: { kind: 'Env', message: 'Provider unavailable' },
+        }),
+      ],
+    }),
+  );
+  expect(screen.getByRole('status')).toHaveTextContent('1 result');
+  await act(async () => fireEvent.click(screen.getByRole('button', { name: 'Retry add-ons' })));
+  expect(fixture.requests).toHaveLength(6);
+  expect(screen.getByText('Matrix result')).toBeVisible();
+  expect(screen.getByRole('status')).toHaveTextContent('Searching installed add-ons');
 });

--- a/apps/desktop/src/screens/SearchScreen.tsx
+++ b/apps/desktop/src/screens/SearchScreen.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo } from 'react';
 
 import styles from '../App.module.css';
+import { ResourceFailures } from '../components/ResourceFailures';
+import { useResourceStates } from '../core/useResourceStates';
 import { MediaCard } from '../components/MediaCard';
 import { loadSearchAction } from '../core/actions';
 import { useCore } from '../core/context';
@@ -34,24 +36,38 @@ export function SearchScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => vo
   const pending = normalizedQuery !== submittedQuery;
 
   useEffect(() => {
-    if (!transport || !submittedQuery || catalogCount === 0) return;
-    void transport.dispatch(
-      {
-        action: 'CatalogsWithExtra',
-        args: { action: 'LoadRange', args: { start: 0, end: catalogCount } },
-      },
-      'search',
-    );
-  }, [catalogCount, submittedQuery, transport]);
-  const items = useMemo(() => {
-    if (pending || !submittedQuery) return [];
-    const unique = new Map<string, CoreMetaPreview>();
-    currentState?.catalogs.forEach((catalog) => {
-      if (catalog.content?.type !== 'Ready') return;
-      catalog.content.content.forEach((item) => unique.set(`${item.type}:${item.id}`, item));
-    });
-    return [...unique.values()];
-  }, [currentState, pending, submittedQuery]);
+    if (!transport || result.loading || !submittedQuery || catalogCount === 0) return;
+    void transport
+      .dispatch(
+        {
+          action: 'CatalogsWithExtra',
+          args: { action: 'LoadRange', args: { start: 0, end: catalogCount } },
+        },
+        'search',
+      )
+      .catch(() => undefined);
+  }, [catalogCount, result.loading, submittedQuery, transport]);
+  const inputs = useMemo(
+    () =>
+      currentState?.catalogs.map((catalog, index) => ({
+        id: JSON.stringify([index, catalog.addon.manifest.id, catalog.type, catalog.id]),
+        name: catalog.addon.manifest.name,
+        content: catalog.content,
+      })) ?? null,
+    [currentState],
+  );
+  const resources = useResourceStates(transport, submittedQuery, inputs, result.loading);
+  const items =
+    pending || !submittedQuery
+      ? []
+      : [
+          ...new Map(
+            resources.rows
+              .flatMap((resource) => resource.value ?? [])
+              .map((item) => [`${item.type}:${item.id}`, item]),
+          ).values(),
+        ];
+  const searching = pending || (!result.error && resources.pending);
 
   return (
     <div className={styles.page}>
@@ -83,12 +99,25 @@ export function SearchScreen({ onOpen }: { onOpen: (item: CoreMetaPreview) => vo
       </form>
       {normalizedQuery ? (
         <p className={styles.searchHelp} role="status">
-          {pending || result.loading ? enUS.search.loading : `${items.length} results`}
+          {searching
+            ? items.length
+              ? enUS.search.partial(items.length)
+              : enUS.search.loading
+            : result.error || (resources.failures.length && !items.length)
+              ? enUS.search.error
+              : enUS.search.count(items.length)}
         </p>
       ) : (
         <p className={styles.searchHelp}>{enUS.search.idle}</p>
       )}
-      {!pending && result.error ? <p className={styles.loadError}>{enUS.search.error}</p> : null}
+      {!pending && submittedQuery ? (
+        <ResourceFailures
+          names={resources.failures}
+          error={result.error ? enUS.search.error : null}
+          pending={searching}
+          onRetry={result.retry}
+        />
+      ) : null}
       {items.length > 0 ? (
         <div className={styles.mediaGrid}>
           {items.map((item) => (


### PR DESCRIPTION
Search, Discover, Home, and media details now distinguish pending resources, failed add-ons, partial results, and settled empty responses. Failure messages identify the add-ons and offer a retry for the current selection. Search no longer reports zero results while requests are pending, and details no longer claims that no sources exist when their providers failed.

Retry unloads and reloads the current Core model, then requests its catalog range again where needed. Successful responses stay visible through the retry, including Core's temporary missing-selection state. Retained sources stay disabled until their add-on returns them again. Profile, query, filter, and episode boundaries keep unrelated responses separate.

Closes #41.

Validation:
- `pnpm check` passed with 216 tests, pinned Core checks, vendor verification, and a production build.
- Focused screen tests cover nested Loading/Err/Ready states, partial results, retry, settled empty responses, stale source protection, metadata failure, and navigation preservation.
- A pinned WASM probe verified unload/reload issues fresh requests and recovers failed Search, Discover, and MetaDetails resources.
- Inspected the production Search screen in an isolated native shell: one failed add-on was named beside one successful result, the result remained visible while retrying, and recovery produced two results.
