### PR TITLE
Open episode sources in a dialog and preserve series navigation

### DIFF
--- a/apps/desktop/src/App.module.css
+++ b/apps/desktop/src/App.module.css
@@ -1095,6 +1095,7 @@
   font-variant-numeric: tabular-nums;
 }
 
+.sourcePickerDialog::backdrop,
 .accountDialog::backdrop {
   background: rgb(0 0 0 / 72%);
   backdrop-filter: blur(12px);
@@ -1881,6 +1882,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .sourcePickerDialog,
   .accountDialog,
   .content,
   .skipIntro,
@@ -2013,4 +2015,44 @@
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
+}
+
+.sourcePickerDialog {
+  position: fixed;
+  inset: 0;
+  margin: auto;
+  width: min(704px, calc(100vw - 32px));
+  max-height: calc(100dvh - 32px);
+  padding: 24px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border: 1px solid var(--kino-border);
+  border-radius: var(--kino-panel-radius);
+  color: var(--kino-text);
+  background: var(--kino-surface);
+  animation: enter var(--kino-duration-standard) var(--kino-ease-out);
+}
+
+.sourcePickerHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.sourcePickerHeader h2 {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  margin: 0;
+  font-size: 20px;
+  line-height: 1.35;
+}
+
+.sourcePickerHeader .dialogClose {
+  position: static;
+  flex-shrink: 0;
+}
+
+.sourcePickerDialog .detailSection {
+  margin-top: 24px;
 }

--- a/apps/desktop/src/App.sourceFailure.test.tsx
+++ b/apps/desktop/src/App.sourceFailure.test.tsx
@@ -148,6 +148,7 @@ it.each(['Back from playback', 'Fail playback', 'Up Next'])(
     expect(screen.getByText('Playing Season two episode five')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: exit }));
     const title = exit === 'Up Next' ? 'Season two episode six' : 'Season two episode five';
+    expect(await screen.findByRole('dialog', { name: title })).toBeInTheDocument();
     await waitFor(() =>
       expect(screen.getByRole('button', { name: new RegExp(title) })).toHaveAttribute(
         'aria-current',

--- a/apps/desktop/src/components/SourcePickerDialog.tsx
+++ b/apps/desktop/src/components/SourcePickerDialog.tsx
@@ -1,0 +1,76 @@
+import { X } from '@phosphor-icons/react';
+import { useEffect, useRef, type ReactNode, type RefObject } from 'react';
+import styles from '../App.module.css';
+import { t } from '../locales';
+
+export function SourcePickerDialog({
+  children,
+  title,
+  onClose,
+  returnFocus,
+}: {
+  children: ReactNode;
+  title: string;
+  onClose: () => void;
+  returnFocus: RefObject<HTMLElement | null>;
+}) {
+  const dialog = useRef<HTMLDialogElement>(null);
+  const close = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    const element = dialog.current;
+    if (!element) return;
+    const trigger = document.activeElement;
+    element.showModal();
+    close.current?.focus({ preventScroll: true });
+    return () => {
+      element.close();
+      const target =
+        trigger instanceof HTMLElement && trigger !== document.body && trigger.isConnected
+          ? trigger
+          : returnFocus.current;
+      target?.focus({ preventScroll: true });
+    };
+  }, [returnFocus]);
+  return (
+    <dialog
+      aria-labelledby="episode-source-title"
+      className={styles.sourcePickerDialog}
+      ref={dialog}
+      onKeyDown={(event) => {
+        if (event.key !== 'Tab' || event.altKey || event.ctrlKey || event.metaKey) return;
+        const controls = Array.from(
+          event.currentTarget.querySelectorAll<HTMLElement>(
+            'button:not(:disabled), a[href], summary, [tabindex="0"]',
+          ),
+        ).filter((control) => control.tabIndex >= 0 && control.getClientRects().length > 0);
+        const first = controls[0];
+        const last = controls.at(-1);
+        if (event.shiftKey && document.activeElement === first && last) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last && first) {
+          event.preventDefault();
+          first.focus();
+        }
+      }}
+      onCancel={(event) => {
+        event.preventDefault();
+        onClose();
+      }}
+    >
+      <header className={styles.sourcePickerHeader}>
+        <h2 id="episode-source-title">{title}</h2>
+        <button
+          aria-label={t.details.closeSources}
+          className={styles.dialogClose}
+          ref={close}
+          type="button"
+          onClick={onClose}
+        >
+          <X aria-hidden size={20} />
+        </button>
+      </header>
+      {children}
+    </dialog>
+  );
+}

--- a/apps/desktop/src/locales/en-US.ts
+++ b/apps/desktop/src/locales/en-US.ts
@@ -225,6 +225,7 @@ export const enUS = {
     error: 'Title details could not be loaded.',
     episodes: 'Episodes',
     sources: 'Sources',
+    closeSources: 'Close source picker',
     inspectSource: 'Source details',
     filename: 'Filename',
     playSource: 'Play',

--- a/apps/desktop/src/screens/MetaDetailsScreen.test.tsx
+++ b/apps/desktop/src/screens/MetaDetailsScreen.test.tsx
@@ -104,6 +104,28 @@ describe('episode source identity', () => {
     Element.prototype.scrollIntoView = vi.fn();
   });
 
+  it('opens sources as an episode dialog without scrolling the series page, then restores focus', async () => {
+    const { publish } = mountDetails(details('ep1'), meta, null);
+    const episode = await screen.findByRole('button', { name: /Episode two/ });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /ep1 source/ })).not.toBeInTheDocument();
+    episode.focus();
+    fireEvent.click(episode);
+    const dialog = screen.getByRole('dialog', { name: 'Episode two' });
+    expect(dialog).toHaveAttribute('open');
+    expect(screen.getByRole('button', { name: 'Close source picker' })).toHaveFocus();
+    await publish(details('ep2'));
+    expect(screen.getByRole('button', { name: /ep2 source/ })).toBeEnabled();
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Close source picker' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(episode).toHaveFocus();
+    fireEvent.click(episode);
+    fireEvent(screen.getByRole('dialog'), new Event('cancel', { bubbles: true, cancelable: true }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(episode).toHaveFocus();
+  });
+
   it('gives a seasonless episode no season tab and still lists it', async () => {
     // Core reports an absent season as null. A tab per distinct season must skip
     // that, and the episode itself still belongs in the list.
@@ -269,17 +291,21 @@ describe('external source approval', () => {
     expect(source).toHaveTextContent('Open in browser · watch.example');
     source.focus();
     fireEvent.click(source);
-    expect(screen.getByRole('dialog')).toHaveTextContent(
+    expect(screen.getByRole('dialog', { name: 'Open in your browser?' })).toHaveTextContent(
       'https://watch.example/title/123?region=us',
     );
     expect(openExternalUrl).not.toHaveBeenCalled();
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Open in your browser?' })).not.toBeInTheDocument();
     expect(source).toHaveFocus();
     expect(openExternalUrl).not.toHaveBeenCalled();
     fireEvent.click(source);
     fireEvent.click(screen.getByRole('link', { name: 'Open in browser' }));
-    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('dialog', { name: 'Open in your browser?' }),
+      ).not.toBeInTheDocument(),
+    );
     expect(openExternalUrl).toHaveBeenCalledExactlyOnceWith(
       'https://watch.example/title/123?region=us',
     );
@@ -295,7 +321,11 @@ describe('external source approval', () => {
       'The browser could not be opened. Try again.',
     );
     fireEvent.click(screen.getByRole('link', { name: 'Open in browser' }));
-    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('dialog', { name: 'Open in your browser?' }),
+      ).not.toBeInTheDocument(),
+    );
     expect(openExternalUrl).toHaveBeenCalledTimes(2);
     expect(onPlay).not.toHaveBeenCalled();
   });
@@ -318,11 +348,11 @@ describe('external source approval', () => {
       'This stream protocol is not supported.',
     );
     fireEvent.click(source);
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Open in your browser?' })).toBeInTheDocument();
     await publish(details('ep2'));
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Open in your browser?' })).not.toBeInTheDocument();
     await publish(externalDetails());
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Open in your browser?' })).not.toBeInTheDocument();
     expect(openExternalUrl).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/screens/MetaDetailsScreen.tsx
+++ b/apps/desktop/src/screens/MetaDetailsScreen.tsx
@@ -1,7 +1,8 @@
-import { ArrowLeft, Check, Play, Plus } from '@phosphor-icons/react';
+import { ArrowLeft, CaretRight, Check, Play, Plus } from '@phosphor-icons/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import styles from '../App.module.css';
+import { SourcePickerDialog } from '../components/SourcePickerDialog';
 import { ActionFeedback } from '../components/ActionFeedback';
 import { useActionFeedback } from '../components/useActionFeedback';
 import { ResourceFailures } from '../components/ResourceFailures';
@@ -89,8 +90,10 @@ export function MetaDetailsScreen({
   } else if (loadedMeta && loadedMeta !== lastMeta) setLastMeta(loadedMeta);
   const meta = loadedMeta ?? (profileTransport === transport ? lastMeta : null);
   const videos = useMemo(() => meta?.videos ?? [], [meta]);
-  const sourcesRef = useRef<HTMLElement>(null);
-  const episodeChosenRef = useRef(false);
+  const selectedEpisodeRef = useRef<HTMLButtonElement>(null);
+  const [sourcePickerOpen, setSourcePickerOpen] = useState(
+    () => item.type === 'series' && Boolean(initialVideoId),
+  );
 
   useEffect(() => {
     if (item.type !== 'series' || videoId !== null || videos.length === 0) return;
@@ -127,13 +130,6 @@ export function MetaDetailsScreen({
     selected.streamPath.type === item.type &&
     selected.streamPath.id === (videoId ?? activeVideo?.id ?? item.id) &&
     selected.streamPath.id === (activeVideo?.id ?? item.id);
-
-  // Wait for this episode's snapshot before moving the source list into view.
-  useEffect(() => {
-    if (!episodeChosenRef.current || !sourcesCurrent) return;
-    episodeChosenRef.current = false;
-    sourcesRef.current?.scrollIntoView({ behavior: 'auto', block: 'start' });
-  }, [sourcesCurrent, videoId]);
 
   const streamInputs = useMemo(
     () =>
@@ -242,6 +238,141 @@ export function MetaDetailsScreen({
     );
   };
 
+  const sourceSection = (
+    <section aria-labelledby="sources-heading" className={styles.detailSection}>
+      <ResourceFailures
+        names={failures}
+        error={result.error ? enUS.details.error : null}
+        pending={sourcesPending}
+        onRetry={result.retry}
+      />
+      <div className={styles.detailSectionHeading}>
+        <h2 id="sources-heading">{enUS.details.sources}</h2>
+        {sourcesPending ? <span role="status">{enUS.details.refreshing}</span> : null}
+      </div>
+      {canResume ? (
+        <div className={styles.resumeChoice} role="group" aria-label={enUS.details.playbackStart}>
+          <button
+            aria-pressed={!startOver}
+            className={!startOver ? styles.seasonActive : styles.seasonButton}
+            onClick={() => setStartOver(false)}
+            type="button"
+          >
+            {enUS.details.resume}
+          </button>
+          <button
+            aria-pressed={startOver}
+            className={startOver ? styles.seasonActive : styles.seasonButton}
+            onClick={() => setStartOver(true)}
+            type="button"
+          >
+            {enUS.details.startOver}
+          </button>
+        </div>
+      ) : null}
+      {currentFailure ? (
+        <p className={styles.loadError} role="status">
+          {currentFailure}
+        </p>
+      ) : null}
+      {sourcesCurrent &&
+      !sourcesPending &&
+      !result.error &&
+      failures.length === 0 &&
+      sources.length === 0 ? (
+        <p role="status" className={styles.inlineEmpty}>
+          {enUS.details.noSources}
+        </p>
+      ) : null}
+      <div className={styles.sourceList}>
+        {sources.map((choice, index) => {
+          const support = classifySource(choice.source.source);
+          const playable =
+            (support === 'direct' || support === 'torrent') && Boolean(choice.transportUrl);
+          const external =
+            choice.source.source.kind === 'external'
+              ? externalWebUrl(choice.source.source.externalUrl)
+              : null;
+          const selectable = playable || Boolean(external);
+          const key = sourceKey(choice.source, choice.transportUrl, sourceSelection);
+          const failed = failedSources.has(key);
+          const unavailable =
+            support === 'direct' || support === 'torrent'
+              ? enUS.details.sourceUnsupported.addon
+              : enUS.details.sourceUnsupported[unsupportedSourceReason(choice.source.source)];
+          const size = sourceSize(choice.source);
+          return (
+            <div className={styles.sourceRow} key={`${choice.transportUrl}:${index}`}>
+              <button
+                className={styles.sourceButton}
+                disabled={!selectable || !sourcesCurrent || !choice.current}
+                onClick={() => {
+                  if (!sourcesCurrent || !choice.current) return;
+                  if (external) {
+                    setExternalChoice({ key, url: external, transport });
+                    return;
+                  }
+                  if (!playable || !resource?.addon.transportUrl) return;
+                  onPlay({
+                    resumeMode: canResume && startOver ? 'start-over' : 'resume',
+                    meta: display,
+                    metaTransportUrl: resource.addon.transportUrl,
+                    nextVideo: nextEpisode,
+                    stream: choice.source,
+                    streamTransportUrl: choice.transportUrl,
+                    video: activeVideo,
+                  });
+                }}
+                type="button"
+              >
+                <span className={styles.sourcePrimary}>
+                  <strong>{sourceTitle(choice.source)}</strong>
+                  <small>{sourceDetails(choice.source)}</small>
+                  {external ? (
+                    <small className={styles.sourceExplanation}>
+                      {enUS.details.openExternal} · {external.host}
+                    </small>
+                  ) : null}
+                  {!selectable ? (
+                    <small className={styles.sourceExplanation}>{unavailable}</small>
+                  ) : null}
+                </span>
+                <span className={styles.sourceMeta}>
+                  {playable ? (
+                    <span className={styles.sourcePlay}>
+                      <Play aria-hidden size={14} weight="fill" />
+                      {enUS.details.playSource}
+                    </span>
+                  ) : null}
+                  {size ? <span>{size}</span> : null}
+                  <span>{choice.addonName}</span>
+                  {!selectable ? <em>{enUS.details.unavailable}</em> : null}
+                  {playable && failed ? <em>{enUS.details.failed}</em> : null}
+                </span>
+              </button>
+              <details className={styles.sourceDisclosure} key={key}>
+                <summary>
+                  {enUS.details.inspectSource}
+                  <span className={styles.visuallyHidden}> {sourceTitle(choice.source)}</span>
+                </summary>
+                <div className={styles.sourceDescription}>
+                  <p>{choice.source.description?.trim() || sourceDetails(choice.source)}</p>
+                  {choice.source.hints.filename ? (
+                    <dl>
+                      <dt>{enUS.details.filename}</dt>
+                      <dd>{choice.source.hints.filename}</dd>
+                    </dl>
+                  ) : null}
+                  {!selectable ? <p>{unavailable}</p> : null}
+                </div>
+              </details>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+
   return (
     <div className={styles.detailPage}>
       <header className={styles.detailHero}>
@@ -295,12 +426,14 @@ export function MetaDetailsScreen({
             {enUS.details.loading}
           </p>
         ) : null}
-        <ResourceFailures
-          names={failures}
-          error={result.error ? enUS.details.error : null}
-          pending={sourcesPending}
-          onRetry={result.retry}
-        />
+        {item.type === 'series' && !sourcePickerOpen ? (
+          <ResourceFailures
+            names={failures}
+            error={result.error ? enUS.details.error : null}
+            pending={sourcesPending}
+            onRetry={result.retry}
+          />
+        ) : null}
         {item.type === 'series' && videos.length > 0 ? (
           <section className={styles.detailSection} aria-labelledby="episodes-heading">
             <div className={styles.detailSectionHeading}>
@@ -330,10 +463,12 @@ export function MetaDetailsScreen({
                 >
                   <button
                     aria-current={video.id === videoId ? 'true' : undefined}
+                    ref={video.id === videoId ? selectedEpisodeRef : undefined}
+                    aria-haspopup="dialog"
                     className={styles.episodeButton}
                     onClick={() => {
-                      episodeChosenRef.current = true;
                       chooseVideo(video.id);
+                      setSourcePickerOpen(true);
                     }}
                     type="button"
                   >
@@ -341,7 +476,7 @@ export function MetaDetailsScreen({
                       {String(video.episode ?? 0).padStart(2, '0')}
                     </span>
                     <strong>{video.title || `Episode ${video.episode}`}</strong>
-                    <Play aria-hidden size={16} weight="fill" />
+                    <CaretRight aria-hidden size={16} />
                   </button>
                   {video.overview ? (
                     <ExpandableText
@@ -358,141 +493,17 @@ export function MetaDetailsScreen({
           </section>
         ) : null}
 
-        <section
-          aria-labelledby="sources-heading"
-          className={styles.detailSection}
-          ref={sourcesRef}
-        >
-          <div className={styles.detailSectionHeading}>
-            <h2 id="sources-heading">{enUS.details.sources}</h2>
-            {sourcesPending ? <span role="status">{enUS.details.refreshing}</span> : null}
-          </div>
-          {canResume ? (
-            <div
-              className={styles.resumeChoice}
-              role="group"
-              aria-label={enUS.details.playbackStart}
-            >
-              <button
-                aria-pressed={!startOver}
-                className={!startOver ? styles.seasonActive : styles.seasonButton}
-                onClick={() => setStartOver(false)}
-                type="button"
-              >
-                {enUS.details.resume}
-              </button>
-              <button
-                aria-pressed={startOver}
-                className={startOver ? styles.seasonActive : styles.seasonButton}
-                onClick={() => setStartOver(true)}
-                type="button"
-              >
-                {enUS.details.startOver}
-              </button>
-            </div>
-          ) : null}
-          {currentFailure ? (
-            <p className={styles.loadError} role="status">
-              {currentFailure}
-            </p>
-          ) : null}
-          {sourcesCurrent &&
-          !sourcesPending &&
-          !result.error &&
-          failures.length === 0 &&
-          sources.length === 0 ? (
-            <p role="status" className={styles.inlineEmpty}>
-              {enUS.details.noSources}
-            </p>
-          ) : null}
-          <div className={styles.sourceList}>
-            {sources.map((choice, index) => {
-              const support = classifySource(choice.source.source);
-              const playable =
-                (support === 'direct' || support === 'torrent') && Boolean(choice.transportUrl);
-              const external =
-                choice.source.source.kind === 'external'
-                  ? externalWebUrl(choice.source.source.externalUrl)
-                  : null;
-              const selectable = playable || Boolean(external);
-              const key = sourceKey(choice.source, choice.transportUrl, sourceSelection);
-              const failed = failedSources.has(key);
-              const unavailable =
-                support === 'direct' || support === 'torrent'
-                  ? enUS.details.sourceUnsupported.addon
-                  : enUS.details.sourceUnsupported[unsupportedSourceReason(choice.source.source)];
-              const size = sourceSize(choice.source);
-              return (
-                <div className={styles.sourceRow} key={`${choice.transportUrl}:${index}`}>
-                  <button
-                    className={styles.sourceButton}
-                    disabled={!selectable || !sourcesCurrent || !choice.current}
-                    onClick={() => {
-                      if (!sourcesCurrent || !choice.current) return;
-                      if (external) {
-                        setExternalChoice({ key, url: external, transport });
-                        return;
-                      }
-                      if (!playable || !resource?.addon.transportUrl) return;
-                      onPlay({
-                        resumeMode: canResume && startOver ? 'start-over' : 'resume',
-                        meta: display,
-                        metaTransportUrl: resource.addon.transportUrl,
-                        nextVideo: nextEpisode,
-                        stream: choice.source,
-                        streamTransportUrl: choice.transportUrl,
-                        video: activeVideo,
-                      });
-                    }}
-                    type="button"
-                  >
-                    <span className={styles.sourcePrimary}>
-                      <strong>{sourceTitle(choice.source)}</strong>
-                      <small>{sourceDetails(choice.source)}</small>
-                      {external ? (
-                        <small className={styles.sourceExplanation}>
-                          {enUS.details.openExternal} · {external.host}
-                        </small>
-                      ) : null}
-                      {!selectable ? (
-                        <small className={styles.sourceExplanation}>{unavailable}</small>
-                      ) : null}
-                    </span>
-                    <span className={styles.sourceMeta}>
-                      {playable ? (
-                        <span className={styles.sourcePlay}>
-                          <Play aria-hidden size={14} weight="fill" />
-                          {enUS.details.playSource}
-                        </span>
-                      ) : null}
-                      {size ? <span>{size}</span> : null}
-                      <span>{choice.addonName}</span>
-                      {!selectable ? <em>{enUS.details.unavailable}</em> : null}
-                      {playable && failed ? <em>{enUS.details.failed}</em> : null}
-                    </span>
-                  </button>
-                  <details className={styles.sourceDisclosure} key={key}>
-                    <summary>
-                      {enUS.details.inspectSource}
-                      <span className={styles.visuallyHidden}> {sourceTitle(choice.source)}</span>
-                    </summary>
-                    <div className={styles.sourceDescription}>
-                      <p>{choice.source.description?.trim() || sourceDetails(choice.source)}</p>
-                      {choice.source.hints.filename ? (
-                        <dl>
-                          <dt>{enUS.details.filename}</dt>
-                          <dd>{choice.source.hints.filename}</dd>
-                        </dl>
-                      ) : null}
-                      {!selectable ? <p>{unavailable}</p> : null}
-                    </div>
-                  </details>
-                </div>
-              );
-            })}
-          </div>
-        </section>
+        {item.type !== 'series' ? sourceSection : null}
       </div>
+      {item.type === 'series' && sourcePickerOpen ? (
+        <SourcePickerDialog
+          returnFocus={selectedEpisodeRef}
+          title={activeVideo?.title || display.name}
+          onClose={() => setSourcePickerOpen(false)}
+        >
+          {sourceSection}
+        </SourcePickerDialog>
+      ) : null}
       {currentExternal ? (
         <ExternalSourceDialog url={currentExternal.url} onClose={() => setExternalChoice(null)} />
       ) : null}

--- a/apps/desktop/src/test/setup.ts
+++ b/apps/desktop/src/test/setup.ts
@@ -1,6 +1,24 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup } from '@testing-library/react';
-import { afterEach } from 'vitest';
+import { afterEach, beforeEach } from 'vitest';
+
+beforeEach(() => {
+  if (typeof HTMLDialogElement.prototype.showModal === 'function') return;
+  Object.defineProperties(HTMLDialogElement.prototype, {
+    showModal: {
+      configurable: true,
+      value: function (this: HTMLDialogElement) {
+        this.setAttribute('open', '');
+      },
+    },
+    close: {
+      configurable: true,
+      value: function (this: HTMLDialogElement) {
+        this.removeAttribute('open');
+      },
+    },
+  });
+});
 
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
Closes #25.

Choosing an episode now opens its source picker in a modal dialog over the series page. Closing returns focus to the episode without scrolling the page. Episode rows use a navigation chevron instead of a decorative play icon. Movies keep their inline sources.

The same picker opens for the saved episode when returning from playback, after a source failure, or through Up Next. It retains source-loading and failure feedback, full source details, and Resume/Start over choices. Native dialog focus stays inside the picker and returns to the initiating or selected episode on close.

Validation:
- `pnpm check` passed all 223 tests, Core contract checks, vendor verification, and production build.
- Focused tests cover opening without page scrolling, close/cancel focus restoration, stale source protection, nested external-source confirmation, and reopening the correct episode after Back, failure, and Up Next.
- Native UI checked at 100% and 200% scale, including loading, source selection, full descriptions/filenames, dialog scrolling, Tab/Shift+Tab focus cycling, and Escape restoring the episode's focus and page position.
