### PR TITLE
Add verified-source Resume to Continue Watching

### DIFF
--- a/apps/desktop/src/App.module.css
+++ b/apps/desktop/src/App.module.css
@@ -326,6 +326,25 @@
   cursor: pointer;
 }
 
+.continueResume {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  margin-top: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--kino-border);
+  border-radius: var(--kino-control-radius);
+  color: var(--kino-text);
+  background: transparent;
+  cursor: pointer;
+  transition: background-color var(--kino-duration-fast) ease;
+}
+
+.continueResume:hover {
+  background: var(--kino-surface-hover);
+}
+
 .continueDismiss {
   position: absolute;
   z-index: 1;

--- a/apps/desktop/src/App.resume.test.tsx
+++ b/apps/desktop/src/App.resume.test.tsx
@@ -1,0 +1,218 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, expect, it, vi } from 'vitest';
+
+import { App } from './App';
+import type { PlaybackSelection } from './core/actions';
+import { CoreContext } from './core/context';
+import { checkResumeSource } from './core/resume';
+import type { CoreTransport } from './core/transport';
+import type { ContinueWatchingItem, CoreRuntimeEvent, MetaDetailsState } from './core/types';
+import { hints, metaItem, profile, torrentSource, urlSource, video } from './test/coreState';
+
+const episode = video({ id: 'show:2:5', title: 'Saved episode', season: 2, episode: 5 });
+const meta = metaItem({
+  id: 'show',
+  type: 'series',
+  name: 'Saved series',
+  videos: [video({ id: 'show:1:1', title: 'First episode', season: 1, episode: 1 }), episode],
+});
+const addon = {
+  manifest: { id: 'test', logo: null, name: 'Test add-on' },
+  transportUrl: 'https://addon.invalid/manifest.json',
+};
+const remembered = urlSource('https://media.invalid/saved.mp4', { name: 'Previous source' });
+const item: ContinueWatchingItem = {
+  ...meta,
+  progress: 25,
+  videoId: episode.id,
+  rememberedSource: { stream: remembered, transportUrl: addon.transportUrl },
+};
+const played = vi.hoisted(() => vi.fn());
+vi.mock('./screens/PlayerScreen', () => ({
+  PlayerScreen: ({
+    selection,
+    onSourceFailure,
+  }: {
+    selection: PlaybackSelection;
+    onSourceFailure: (message: string) => void;
+  }) => {
+    played(selection);
+    return (
+      <button onClick={() => onSourceFailure('Synthetic playback failure')}>Fail playback</button>
+    );
+  },
+}));
+
+beforeEach(() => {
+  played.mockClear();
+  window.localStorage.clear();
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+function details(): MetaDetailsState {
+  return {
+    libraryItem: { id: meta.id, videoId: episode.id, timeOffset: 30000 },
+    title: null,
+    selected: {
+      metaPath: { resource: 'meta', type: 'series', id: meta.id, extra: [] },
+      streamPath: { resource: 'stream', type: 'series', id: episode.id, extra: [] },
+      guessStream: false,
+    },
+    metaItem: { addon, content: { type: 'Ready', content: meta } },
+    streams: [{ addon, content: { type: 'Ready', content: [remembered] } }],
+  };
+}
+
+function mount() {
+  let state = details();
+  state.streams = [{ addon, content: { type: 'Loading' } }];
+  const listeners = new Set<(event: CoreRuntimeEvent) => void>();
+  const transport: CoreTransport = {
+    destroy: vi.fn(),
+    init: vi.fn().mockResolvedValue(undefined),
+    dispatch: vi.fn().mockResolvedValue(undefined),
+    flush: vi.fn().mockResolvedValue(undefined),
+    prepareClose: vi.fn().mockResolvedValue(undefined),
+    onBeforeDestroy: () => () => {},
+    getState: (async (model: string) => {
+      if (model === 'ctx') return profile();
+      if (model === 'continue_watching_preview') return { items: [item] };
+      if (model === 'board') return { catalogs: [] };
+      return state;
+    }) as CoreTransport['getState'],
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+  const app = (target = transport) => (
+    <CoreContext.Provider
+      value={{
+        error: null,
+        status: 'ready',
+        session: 'guest',
+        transport: target,
+        selectSession: vi.fn(),
+      }}
+    >
+      <App />
+    </CoreContext.Provider>
+  );
+  const view = render(app());
+  return {
+    async ready(next = details()) {
+      await act(async () => {
+        state = next;
+        listeners.forEach((listener) => listener({ name: 'NewState', args: ['meta_details'] }));
+      });
+    },
+    changeProfile() {
+      view.rerender(app({ ...transport }));
+    },
+  };
+}
+
+it('waits for the remembered add-on and resumes once, returning to selection after failure', async () => {
+  const fixture = mount();
+  fireEvent.click(await screen.findByRole('button', { name: 'Resume Saved series' }));
+  expect(await screen.findByText('Checking the previous source…')).toBeInTheDocument();
+  expect(played).not.toHaveBeenCalled();
+  await fixture.ready();
+  await screen.findByRole('button', { name: 'Fail playback' });
+  expect(played).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      video: episode,
+      stream: remembered,
+      resumeMode: 'resume',
+      streamTransportUrl: addon.transportUrl,
+    }),
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'Fail playback' }));
+  expect(await screen.findByRole('dialog', { name: 'Saved episode' })).toBeInTheDocument();
+  const source = await screen.findByRole('button', { name: /Previous source/ });
+  await waitFor(() => expect(source).toBeEnabled());
+  expect(screen.queryByRole('button', { name: 'Fail playback' })).not.toBeInTheDocument();
+  expect(screen.getByText('Synthetic playback failure')).toBeInTheDocument();
+});
+
+it('keeps the saved episode and resume mode when the remembered URL has changed', async () => {
+  const fixture = mount();
+  fireEvent.click(await screen.findByRole('button', { name: 'Resume Saved series' }));
+  const next = details();
+  const replacement = urlSource('https://media.invalid/replacement.mp4', {
+    name: 'Changed source',
+  });
+  next.streams = [{ addon, content: { type: 'Ready', content: [replacement] } }];
+  await fixture.ready(next);
+  expect(await screen.findByText(/previous source is unavailable or changed/)).toBeInTheDocument();
+  expect(screen.getByRole('dialog', { name: 'Saved episode' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Resume' })).toHaveAttribute('aria-pressed', 'true');
+  expect(played).not.toHaveBeenCalled();
+  fireEvent.click(screen.getByRole('button', { name: /Changed source/ }));
+  expect(played).toHaveBeenLastCalledWith(
+    expect.objectContaining({ video: episode, stream: replacement, resumeMode: 'resume' }),
+  );
+});
+
+it.each(['close', 'profile'])(
+  'does not start playback after %s cancels a pending check',
+  async (cancel) => {
+    const fixture = mount();
+    fireEvent.click(await screen.findByRole('button', { name: 'Resume Saved series' }));
+    await screen.findByText('Checking the previous source…');
+    if (cancel === 'close')
+      fireEvent(
+        screen.getByRole('dialog', { name: 'Saved episode' }),
+        new Event('cancel', { bubbles: true, cancelable: true }),
+      );
+    else fixture.changeProfile();
+    await fixture.ready();
+    await waitFor(() =>
+      expect(screen.queryByText('Checking the previous source…')).not.toBeInTheDocument(),
+    );
+    expect(played).not.toHaveBeenCalled();
+  },
+);
+
+it('rejects another add-on, changed request headers, torrent file changes, and unsupported sources', () => {
+  const next = details();
+  next.streams = [
+    {
+      addon: { ...addon, transportUrl: 'https://other.invalid/manifest.json' },
+      content: { type: 'Ready', content: [remembered] },
+    },
+  ];
+  expect(checkResumeSource(item, next, false, null)).toBe('unavailable');
+  const savedTorrent = torrentSource({ fileIdx: 0 });
+  const torrentItem = {
+    ...item,
+    rememberedSource: { stream: savedTorrent, transportUrl: addon.transportUrl },
+  };
+  next.streams = [{ addon, content: { type: 'Ready', content: [torrentSource({ fileIdx: 1 })] } }];
+  expect(checkResumeSource(torrentItem, next, false, null)).toBe('unavailable');
+  next.streams = [{ addon, content: { type: 'Ready', content: [savedTorrent] } }];
+  expect(checkResumeSource(torrentItem, next, false, null)).toMatchObject({ stream: savedTorrent });
+  next.streams = [
+    { addon, content: { type: 'Err', content: { message: 'Unavailable', kind: 'provider' } } },
+  ];
+  expect(checkResumeSource(item, next, false, null)).toBe('unavailable');
+  for (const stream of [
+    urlSource('https://media.invalid/saved.mp4', {
+      hints: hints({ proxyRequestHeaders: { Authorization: 'changed' } }),
+    }),
+    torrentSource({ fileIdx: 1 }),
+    urlSource('http://media.invalid/saved.mp4'),
+  ]) {
+    expect(
+      checkResumeSource(
+        { ...item, rememberedSource: { stream, transportUrl: addon.transportUrl } },
+        details(),
+        false,
+        null,
+      ),
+    ).toBe('unavailable');
+  }
+  expect(checkResumeSource({ ...item, rememberedSource: null }, details(), false, null)).toBe(
+    'unavailable',
+  );
+});

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -14,6 +14,9 @@ import styles from './App.module.css';
 import { CoreRecovery } from './components/CoreRecovery';
 import { AccountDialog } from './components/AccountDialog';
 import type { PlaybackSelection } from './core/actions';
+import { useCore } from './core/context';
+import { savedTitlePreview } from './core/preview';
+import type { ResumeRequest } from './core/resume';
 import { sourceKey } from './core/sources';
 import type { CoreMetaPreview, ProfileState } from './core/types';
 import { useCoreModel } from './core/useCoreModel';
@@ -94,6 +97,7 @@ function accountInitial(profile: ProfileState | null) {
 }
 
 export function App() {
+  const { transport } = useCore();
   const updates = useUpdates();
   const [screen, setScreen] = useState<Screen>('home');
   const [entry, setEntry] = useState<NavigationEntry>(() => ({
@@ -108,6 +112,7 @@ export function App() {
   const previousView = useRef<string | null>(null);
   const [detail, setDetail] = useState<CoreMetaPreview | null>(null);
   const [detailVideoId, setDetailVideoId] = useState<string | null>(null);
+  const [resumeRequest, setResumeRequest] = useState<ResumeRequest | null>(null);
   const [playback, setPlayback] = useState<PlaybackSelection | null>(null);
   const [failedSources, setFailedSources] = useState<ReadonlyMap<string, string>>(new Map());
   const [accountOpen, setAccountOpen] = useState(false);
@@ -152,12 +157,17 @@ export function App() {
       setEntry((previous) => ({ ...previous, scrollTop, focus }));
     }
     setDetail(item);
+    setResumeRequest(null);
     setDetailVideoId(videoId ?? null);
     setFailedSources(new Map());
     setScreen('detail');
   };
 
   const closePlayer = useCallback(() => setPlayback(null), []);
+  const cancelResume = useCallback(() => setResumeRequest(null), []);
+  const resumeUnavailable = useCallback(() => {
+    setResumeRequest((request) => (request ? { ...request, checking: false } : null));
+  }, []);
   // Stable across settings re-renders: an unstable identity would restart the
   // player's load effect while a stream is playing.
   const reportSourceFailure = useCallback(
@@ -209,7 +219,15 @@ export function App() {
   const content = (() => {
     switch (entry.screen) {
       case 'home':
-        return <HomeScreen onOpen={openDetail} />;
+        return (
+          <HomeScreen
+            onOpen={openDetail}
+            onResume={(item) => {
+              openDetail(savedTitlePreview(item), item.videoId);
+              setResumeRequest({ checking: true, item, transport });
+            }}
+          />
+        );
       case 'search':
         return <SearchScreen onOpen={openDetail} />;
       case 'discover':
@@ -317,10 +335,14 @@ export function App() {
               key={`${detail.type}:${detail.id}`}
               initialVideoId={detailVideoId}
               item={detail}
+              resumeRequest={resumeRequest}
+              onCancelResume={cancelResume}
+              onResumeUnavailable={resumeUnavailable}
               onBack={() => setScreen(entry.screen)}
               onPlay={(selection) => {
                 // Details unmounts during playback so Up Next can select a new episode on return.
                 setDetailVideoId(selection.video?.id ?? null);
+                setResumeRequest(null);
                 setPlayback(selection);
               }}
             />

--- a/apps/desktop/src/core/adapters.test.ts
+++ b/apps/desktop/src/core/adapters.test.ts
@@ -8,6 +8,7 @@ import {
 } from './actions';
 import {
   adaptCoreState,
+  adaptContinueWatchingState,
   adaptDiscoverState,
   adaptLibraryState,
   adaptMetaDetailsState,
@@ -424,6 +425,44 @@ describe('sources and playback', () => {
       progress: 25,
       videoId: 'kino-fixture:1:1',
     });
+  });
+
+  it('ignores missing, malformed, and mismatched remembered-source links without losing progress', () => {
+    const base = {
+      _id: 'show',
+      type: 'series',
+      name: 'Saved series',
+      progress: 25,
+      posterShape: 'poster',
+      state: { videoId: 'show:2:5' },
+    };
+    for (const player of [
+      null,
+      '#/player/%ZZ/a/b/series/show/show%3A2%3A5',
+      '#/player/encoded/a/b/movie/show/show%3A2%3A5',
+      '#/player/encoded/a/b/series/show/show%3A1%3A1',
+    ]) {
+      const state = adaptContinueWatchingState(
+        { items: [{ ...base, deepLinks: { player } }] },
+        () => ({ url: 'https://media.invalid/saved.mp4' }),
+      );
+      expect(state.items[0]).toMatchObject({
+        rememberedSource: null,
+        progress: 25,
+        videoId: 'show:2:5',
+      });
+    }
+    const state = adaptContinueWatchingState(
+      {
+        items: [
+          { ...base, deepLinks: { player: '#/player/encoded/a/b/series/show/show%3A2%3A5' } },
+        ],
+      },
+      () => {
+        throw new Error('Unsupported stream format');
+      },
+    );
+    expect(state.items[0]?.rememberedSource).toBeNull();
   });
 });
 

--- a/apps/desktop/src/core/adapters.ts
+++ b/apps/desktop/src/core/adapters.ts
@@ -730,7 +730,37 @@ export function adaptLibraryState(raw: unknown): LibraryState {
   };
 }
 
-export function adaptContinueWatchingState(raw: unknown): ContinueWatchingState {
+// Core owns the compressed stream format. A missing or obsolete deep link only
+// disables direct resume; it must not hide the title or its saved progress.
+function rememberedSource(
+  item: Record<string, unknown>,
+  site: Site,
+  decodeStream?: (encoded: string) => unknown,
+): ContinueWatchingItem['rememberedSource'] {
+  if (!decodeStream) return null;
+  try {
+    const links = record(item.deepLinks, at(site, 'deepLinks'));
+    const link = text(links.player, at(site, 'deepLinks.player'));
+    if (!link.startsWith('#/player/')) return null;
+    const parts = link.slice('#/player/'.length).split('?')[0]?.split('/').map(decodeURIComponent);
+    if (!parts || parts.length !== 6) return null;
+    const [encoded, transportUrl, , type, id, videoId] = parts;
+    const state = record(item.state, at(site, 'state'));
+    if (!encoded || !transportUrl || type !== item.type || id !== item._id) return null;
+    if (videoId !== (state.videoId ?? (type === 'series' ? null : id))) return null;
+    return {
+      stream: adaptSource(decodeStream(encoded), at(site, 'deepLinks.player')),
+      transportUrl,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function adaptContinueWatchingState(
+  raw: unknown,
+  decodeStream?: (encoded: string) => unknown,
+): ContinueWatchingState {
   const site = { field: '', model: 'continue_watching_preview' };
   const source = record(raw, site);
   return {
@@ -743,6 +773,7 @@ export function adaptContinueWatchingState(raw: unknown): ContinueWatchingState 
         poster: displayText(item.poster, at(entrySite, 'poster')),
         posterShape: posterShape(item.posterShape, at(entrySite, 'posterShape')),
         progress: numberOr(item.progress, at(entrySite, 'progress'), 0),
+        rememberedSource: rememberedSource(item, entrySite, decodeStream),
         type: identity(item.type, at(entrySite, 'type')),
         videoId: displayText(state.videoId, at(entrySite, 'state.videoId')),
       };

--- a/apps/desktop/src/core/core.worker.ts
+++ b/apps/desktop/src/core/core.worker.ts
@@ -2,7 +2,7 @@
 
 import Bridge from '@stremio/stremio-core-web/bridge.js';
 import wasmUrl from '@stremio/stremio-core-web/stremio_core_web_bg.wasm?url';
-import { adaptCoreState, adaptDiscoverState } from './adapters';
+import { adaptContinueWatchingState, adaptCoreState, adaptDiscoverState } from './adapters';
 import { createAddonNetwork } from './addonNetwork';
 import { CatalogPaging } from './catalogPaging';
 import { PendingCoreWork, trackCoreSync } from './pendingWork';
@@ -83,6 +83,8 @@ scope.init = async ({ appVersion, shellVersion }) => {
   scope.getState = (field) => {
     if (!isCoreModelName(field)) throw new Error('Kino does not read that Stremio model.');
     if (field === 'discover') return paging.snapshot(adaptDiscoverState(core.get_state(field)));
+    if (field === 'continue_watching_preview')
+      return adaptContinueWatchingState(core.get_state(field), core.decode_stream);
     if (field === 'ctx') {
       const context = adaptCoreState(field, core.get_state(field));
       return {

--- a/apps/desktop/src/core/resume.ts
+++ b/apps/desktop/src/core/resume.ts
@@ -1,0 +1,66 @@
+import type { PlaybackSelection } from './actions';
+import { classifySource, sourceKey } from './sources';
+import type { CoreTransport } from './transport';
+import type { ContinueWatchingItem, MetaDetailsState } from './types';
+
+export interface ResumeRequest {
+  checking: boolean;
+  item: ContinueWatchingItem;
+  transport: CoreTransport | null;
+}
+
+// Only a fresh response from the remembered add-on can authorize this shortcut.
+// Display labels may change, but the media identity and request headers may not.
+export function checkResumeSource(
+  item: ContinueWatchingItem,
+  state: MetaDetailsState | null,
+  loading: boolean,
+  error: string | null,
+): 'pending' | 'unavailable' | PlaybackSelection {
+  const remembered = item.rememberedSource;
+  if (!remembered || error) return 'unavailable';
+  if (loading || !state || state.metaItem?.content.type === 'Loading') return 'pending';
+  const resource = state.metaItem;
+  if (resource?.content.type !== 'Ready' || !resource.addon.transportUrl) return 'unavailable';
+  const meta = resource.content.content;
+  const videoId = item.videoId ?? (item.type === 'series' ? null : item.id);
+  const video = meta.videos.find((candidate) => candidate.id === videoId) ?? null;
+  if (
+    !videoId ||
+    meta.id !== item.id ||
+    meta.type !== item.type ||
+    (item.type === 'series' && !video) ||
+    (video?.id ?? meta.id) !== videoId ||
+    state.selected?.metaPath.id !== item.id ||
+    state.selected.metaPath.type !== item.type ||
+    state.selected.streamPath?.id !== videoId ||
+    state.selected.streamPath.type !== item.type
+  )
+    return 'unavailable';
+
+  const support = classifySource(remembered.stream.source);
+  if (support !== 'direct' && support !== 'torrent') return 'unavailable';
+  const selection = { meta, video };
+  const key = sourceKey(remembered.stream, remembered.transportUrl, selection);
+  const resources = state.streams.filter(
+    (entry) => entry.addon.transportUrl === remembered.transportUrl,
+  );
+  for (const entry of resources) {
+    if (entry.content.type !== 'Ready') continue;
+    const stream = entry.content.content.find(
+      (candidate) => sourceKey(candidate, remembered.transportUrl, selection) === key,
+    );
+    if (stream) {
+      const index = video ? meta.videos.indexOf(video) : -1;
+      return {
+        ...selection,
+        metaTransportUrl: resource.addon.transportUrl,
+        nextVideo: index >= 0 ? (meta.videos[index + 1] ?? null) : null,
+        resumeMode: 'resume',
+        stream,
+        streamTransportUrl: remembered.transportUrl,
+      };
+    }
+  }
+  return resources.some((entry) => entry.content.type === 'Loading') ? 'pending' : 'unavailable';
+}

--- a/apps/desktop/src/core/types.ts
+++ b/apps/desktop/src/core/types.ts
@@ -200,6 +200,7 @@ export interface ContinueWatchingItem {
   poster: string | null;
   posterShape: PosterShape;
   progress: number;
+  rememberedSource: { stream: CoreSource; transportUrl: string } | null;
   type: string;
   videoId: string | null;
 }

--- a/apps/desktop/src/locales/en-US.ts
+++ b/apps/desktop/src/locales/en-US.ts
@@ -33,6 +33,8 @@ export const enUS = {
     title: 'Home',
     continueWatching: 'Continue Watching',
     continueEmpty: 'Nothing to resume yet.',
+    resume: 'Resume',
+    resumeTitle: (name: string) => `Resume ${name}`,
     dismiss: 'Remove from Continue Watching',
     dismissing: (name: string) => `Removing ${name} from Continue Watching…`,
     dismissed: (name: string) => `${name} was removed from Continue Watching.`,
@@ -221,6 +223,8 @@ export const enUS = {
     cancel: 'Cancel',
   },
   details: {
+    checkingResume: 'Checking the previous source…',
+    resumeUnavailable: 'The previous source is unavailable or changed. Choose a source to resume.',
     loading: 'Loading title details…',
     error: 'Title details could not be loaded.',
     episodes: 'Episodes',

--- a/apps/desktop/src/screens/HomeScreen.tsx
+++ b/apps/desktop/src/screens/HomeScreen.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react';
 
-import { X } from '@phosphor-icons/react';
+import { Play, X } from '@phosphor-icons/react';
 
 import styles from '../App.module.css';
 import { ActionFeedback } from '../components/ActionFeedback';
@@ -11,7 +11,7 @@ import { MediaCard } from '../components/MediaCard';
 import { loadBoardAction, rewindLibraryItemAction } from '../core/actions';
 import { useCore } from '../core/context';
 import { savedTitlePreview } from '../core/preview';
-import type { CoreMetaPreview } from '../core/types';
+import type { ContinueWatchingItem, CoreMetaPreview } from '../core/types';
 import { useCoreModel } from '../core/useCoreModel';
 import { t as enUS } from '../locales';
 
@@ -35,8 +35,10 @@ function RowSkeleton() {
 
 export function HomeScreen({
   onOpen,
+  onResume,
 }: {
   onOpen: (item: CoreMetaPreview, videoId?: string | null) => void;
+  onResume?: (item: ContinueWatchingItem) => void;
 }) {
   const core = useCore();
   const dismissal = useActionFeedback(core.transport);
@@ -120,6 +122,17 @@ export function HomeScreen({
                       <span style={{ width: `${Math.max(0, Math.min(100, item.progress))}%` }} />
                     </span>
                   </span>
+                </button>
+                <button
+                  aria-label={enUS.home.resumeTitle(item.name)}
+                  className={styles.continueResume}
+                  onClick={() =>
+                    onResume ? onResume(item) : onOpen(savedTitlePreview(item), item.videoId)
+                  }
+                  type="button"
+                >
+                  <Play aria-hidden size={14} weight="fill" />
+                  {enUS.home.resume}
                 </button>
                 <button
                   aria-label={`${enUS.home.dismiss} ${item.name}`}

--- a/apps/desktop/src/screens/MetaDetailsScreen.tsx
+++ b/apps/desktop/src/screens/MetaDetailsScreen.tsx
@@ -16,6 +16,7 @@ import {
   type PlaybackSelection,
 } from '../core/actions';
 import { useCore } from '../core/context';
+import { checkResumeSource, type ResumeRequest } from '../core/resume';
 import {
   classifySource,
   externalWebUrl,
@@ -48,12 +49,18 @@ export function MetaDetailsScreen({
   item,
   onBack,
   onPlay,
+  resumeRequest = null,
+  onCancelResume,
+  onResumeUnavailable,
 }: {
   failedSources: ReadonlyMap<string, string>;
   initialVideoId?: string | null;
   item: CoreMetaPreview;
   onBack: () => void;
   onPlay: (selection: PlaybackSelection) => void;
+  resumeRequest?: ResumeRequest | null;
+  onCancelResume?: () => void;
+  onResumeUnavailable?: () => void;
 }) {
   const { transport } = useCore();
   const libraryAction = useActionFeedback(transport);
@@ -68,6 +75,27 @@ export function MetaDetailsScreen({
     loadMetaDetailsAction(item, videoId),
     `${item.type}:${item.id}:${videoId ?? 'guess'}`,
   );
+  const checkedResume = useRef<ResumeRequest | null>(null);
+  const checkingResume = Boolean(resumeRequest?.checking);
+  useEffect(() => {
+    if (!resumeRequest?.checking || checkedResume.current === resumeRequest) return;
+    const decision =
+      resumeRequest.transport === transport
+        ? checkResumeSource(resumeRequest.item, result.state, result.loading, result.error)
+        : 'unavailable';
+    if (decision === 'pending') return;
+    checkedResume.current = resumeRequest;
+    if (decision === 'unavailable') onResumeUnavailable?.();
+    else onPlay(decision);
+  }, [
+    onPlay,
+    onResumeUnavailable,
+    result.error,
+    result.loading,
+    result.state,
+    resumeRequest,
+    transport,
+  ]);
   const resource = result.state?.metaItem;
   const loadedMeta =
     resource?.content.type === 'Ready' &&
@@ -208,6 +236,7 @@ export function MetaDetailsScreen({
       (item.type !== 'series' && !savedProgress.videoId));
 
   const chooseVideo = (id: string) => {
+    onCancelResume?.();
     setStartOver(false);
     setVideoId(id);
   };
@@ -240,6 +269,11 @@ export function MetaDetailsScreen({
 
   const sourceSection = (
     <section aria-labelledby="sources-heading" className={styles.detailSection}>
+      {resumeRequest ? (
+        <p className={styles.inlineEmpty} role="status">
+          {checkingResume ? enUS.details.checkingResume : enUS.details.resumeUnavailable}
+        </p>
+      ) : null}
       <ResourceFailures
         names={failures}
         error={result.error ? enUS.details.error : null}
@@ -254,6 +288,7 @@ export function MetaDetailsScreen({
         <div className={styles.resumeChoice} role="group" aria-label={enUS.details.playbackStart}>
           <button
             aria-pressed={!startOver}
+            disabled={checkingResume}
             className={!startOver ? styles.seasonActive : styles.seasonButton}
             onClick={() => setStartOver(false)}
             type="button"
@@ -262,6 +297,7 @@ export function MetaDetailsScreen({
           </button>
           <button
             aria-pressed={startOver}
+            disabled={checkingResume}
             className={startOver ? styles.seasonActive : styles.seasonButton}
             onClick={() => setStartOver(true)}
             type="button"
@@ -305,7 +341,7 @@ export function MetaDetailsScreen({
             <div className={styles.sourceRow} key={`${choice.transportUrl}:${index}`}>
               <button
                 className={styles.sourceButton}
-                disabled={!selectable || !sourcesCurrent || !choice.current}
+                disabled={checkingResume || !selectable || !sourcesCurrent || !choice.current}
                 onClick={() => {
                   if (!sourcesCurrent || !choice.current) return;
                   if (external) {
@@ -499,7 +535,10 @@ export function MetaDetailsScreen({
         <SourcePickerDialog
           returnFocus={selectedEpisodeRef}
           title={activeVideo?.title || display.name}
-          onClose={() => setSourcePickerOpen(false)}
+          onClose={() => {
+            onCancelResume?.();
+            setSourcePickerOpen(false);
+          }}
         >
           {sourceSection}
         </SourcePickerDialog>

--- a/scripts/check-core-streams.mjs
+++ b/scripts/check-core-streams.mjs
@@ -2,9 +2,15 @@
 
 import assert from 'node:assert/strict';
 
-import { adaptCoreState } from '../apps/desktop/src/core/adapters.ts';
+import { adaptContinueWatchingState, adaptCoreState } from '../apps/desktop/src/core/adapters.ts';
+import { loadPlayerAction, playerAction } from '../apps/desktop/src/core/actions.ts';
 import { torrentCreateRequest } from '../apps/desktop/src/player/torrent.ts';
-import { initializeCore, resolveCoreStream } from './test-support/core-stream.mjs';
+import {
+  fixturePreview,
+  fixtureSource,
+  initializeCore,
+  resolveCoreStream,
+} from './test-support/core-stream.mjs';
 
 const core = await initializeCore();
 const tracker = 'https://tracker.invalid/announce';
@@ -32,4 +38,54 @@ assert.deepEqual(
 );
 assert.equal(request.body.guessFileIdx, false);
 console.log('Pinned Core torrent resolution preserves trackers in the engine request.');
+
+for (const stream of [
+  fixtureSource({
+    url: 'https://media.invalid/remembered.mp4',
+    behaviorHints: {
+      proxyHeaders: { request: { Referer: 'https://media.invalid/' } },
+    },
+  }),
+  fixtureSource({
+    infoHash: '0123456789abcdef0123456789abcdef01234567',
+    fileIdx: 2,
+    sources: ['tracker:https://tracker.invalid/announce'],
+  }),
+]) {
+  core.dispatch(
+    loadPlayerAction({
+      meta: fixturePreview,
+      metaTransportUrl: 'https://metadata.invalid/manifest.json',
+      streamTransportUrl: 'https://streams.invalid/manifest.json',
+      stream,
+      video: null,
+      nextVideo: null,
+    }),
+    'player',
+    '',
+  );
+  await new Promise((resolve) => setImmediate(resolve));
+  core.dispatch(playerAction('VideoParamsChanged', { videoParams: null }), 'player', '');
+  core.dispatch(
+    playerAction('TimeChanged', { time: 30000, duration: 120000, device: 'kino' }),
+    'player',
+    '',
+  );
+  core.dispatch(playerAction('PausedChanged', { paused: true }), 'player', '');
+  await new Promise((resolve) => setImmediate(resolve));
+  core.dispatch({ action: 'Unload' }, 'player', '');
+  await new Promise((resolve) => setImmediate(resolve));
+  const item = adaptContinueWatchingState(
+    core.get_state('continue_watching_preview'),
+    core.decode_stream,
+  ).items[0];
+  assert.equal(item.progress, 25);
+  assert.deepEqual(item.rememberedSource, {
+    stream,
+    transportUrl: 'https://streams.invalid/manifest.json',
+  });
+}
+console.log(
+  'Pinned Core Continue Watching links preserve the last source, headers, add-on, and progress.',
+);
 process.exit(0);


### PR DESCRIPTION
Continue Watching now has an explicit Resume action. Core decodes its remembered player link, and Kino checks the saved source against the current response from the same add-on before starting playback. Changed or unavailable sources open selection for the saved episode with resume mode preserved. Closing selection or switching profiles cancels the shortcut; playback failure returns to selection without retrying automatically.

Validation: `pnpm check` passed with 229 tests, pinned Core WASM checks for remembered direct/torrent sources and request headers, and a production build. Focused tests cover changed URLs, headers, torrent files, add-on identity, cancellation, profile changes, and playback failure. Native UI reviewed at 100% and 200%, including pending checks and changed-source fallback.

Closes #81.
