### PR TITLE
Render subtitles outlined without a background box

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -38,7 +38,17 @@ jobs:
           distribution: temurin
           java-version: '21'
       - name: Install the pinned Android toolchain
-        run: sdkmanager 'platforms;android-36' 'build-tools;35.0.0' 'ndk;29.0.14206865'
+        # The runner image ships the SDK under ANDROID_HOME but leaves the
+        # command-line tools off PATH, so resolve sdkmanager before using it.
+        run: |
+          tools="$ANDROID_HOME/cmdline-tools/latest/bin"
+          if [ ! -x "$tools/sdkmanager" ]; then
+            tools="$(dirname "$(find "$ANDROID_HOME/cmdline-tools" -name sdkmanager -type f | sort -V | tail -1)")"
+          fi
+          test -x "$tools/sdkmanager"
+          yes | "$tools/sdkmanager" --licenses > /dev/null
+          "$tools/sdkmanager" 'platforms;android-36' 'build-tools;35.0.0' 'ndk;29.0.14206865'
+          echo "$tools" >> "$GITHUB_PATH"
       - name: Build Core, compile instrumentation, and lint
         run: python3 scripts/build-android.py :app:assembleDebug :app:assembleDebugAndroidTest :app:lintDebug
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/apps/android-tv/app/src/androidTest/java/app/kino/tv/CaptionStyleTest.kt
+++ b/apps/android-tv/app/src/androidTest/java/app/kino/tv/CaptionStyleTest.kt
@@ -1,0 +1,54 @@
+@file:androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+
+package app.kino.tv
+
+import android.graphics.Color
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.BackgroundColorSpan
+import android.text.style.StyleSpan
+import androidx.media3.common.text.Cue
+import androidx.media3.ui.CaptionStyleCompat
+import org.junit.Assert.*
+import org.junit.Test
+
+/** Captions must reach the screen outlined, with nothing filled behind them. */
+class CaptionStyleTest {
+    @Test
+    fun styleFillsNothingAndOutlinesGlyphs() {
+        assertEquals(Color.TRANSPARENT, outlinedCaptionStyle.backgroundColor)
+        assertEquals(Color.TRANSPARENT, outlinedCaptionStyle.windowColor)
+        assertEquals(CaptionStyleCompat.EDGE_TYPE_OUTLINE, outlinedCaptionStyle.edgeType)
+        assertEquals(Color.BLACK, outlinedCaptionStyle.edgeColor)
+        assertEquals(Color.WHITE, outlinedCaptionStyle.foregroundColor)
+    }
+
+    @Test
+    fun authoredFillsAreRemovedAndTextStylingSurvives() {
+        val text = SpannableString("Kino boxed caption")
+        text.setSpan(BackgroundColorSpan(Color.BLACK), 0, text.length, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
+        text.setSpan(StyleSpan(android.graphics.Typeface.ITALIC), 0, 4, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
+        val cue = Cue.Builder().setText(text).setWindowColor(Color.BLACK).build()
+
+        val cleaned = withoutCaptionFills(cue)
+
+        assertFalse("A window colour paints a rectangle", cleaned.windowColorSet)
+        val cleanedText = cleaned.text as Spanned
+        assertEquals("Kino boxed caption", cleanedText.toString())
+        assertEquals(
+            0,
+            cleanedText.getSpans(0, cleanedText.length, BackgroundColorSpan::class.java).size,
+        )
+        assertEquals(
+            "Italics and other text styling must survive",
+            1,
+            cleanedText.getSpans(0, cleanedText.length, StyleSpan::class.java).size,
+        )
+    }
+
+    @Test
+    fun plainCuesAreLeftAlone() {
+        val cue = Cue.Builder().setText("Kino fixture subtitles").build()
+        assertSame(cue, withoutCaptionFills(cue))
+    }
+}

--- a/apps/android-tv/app/src/main/java/app/kino/tv/TvPlayer.kt
+++ b/apps/android-tv/app/src/main/java/app/kino/tv/TvPlayer.kt
@@ -3,7 +3,11 @@
 package app.kino.tv
 
 import android.content.Context
+import android.graphics.Color
 import android.os.Handler
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.BackgroundColorSpan
 import android.util.Log
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
@@ -17,6 +21,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.media3.common.*
+import androidx.media3.common.text.Cue
+import androidx.media3.common.text.CueGroup
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
@@ -29,6 +35,7 @@ import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.video.MediaCodecVideoRenderer
 import androidx.media3.exoplayer.video.VideoRendererEventListener
 import androidx.media3.session.MediaSession
+import androidx.media3.ui.CaptionStyleCompat
 import androidx.media3.ui.PlayerView
 import kotlinx.coroutines.delay
 
@@ -122,6 +129,52 @@ class HardwareRenderers(context: Context) : DefaultRenderersFactory(context) {
     }
 }
 
+/**
+ * White glyphs with a black outline and nothing filled behind them. Media3
+ * otherwise takes the device caption style, whose default paints a black
+ * rectangle behind every line.
+ */
+val outlinedCaptionStyle =
+    CaptionStyleCompat(
+        Color.WHITE,
+        Color.TRANSPARENT,
+        Color.TRANSPARENT,
+        CaptionStyleCompat.EDGE_TYPE_OUTLINE,
+        Color.BLACK,
+        null,
+    )
+
+/**
+ * Removes the fills a cue asks for itself. Media3's SSA parser turns an
+ * authored `BorderStyle: 3` into a background span, and WebVTT cues can set a
+ * window colour; both draw the rectangle the caption style already refuses.
+ * Italics, bold, text colour, alignment, and line breaks are left alone.
+ */
+fun withoutCaptionFills(cue: Cue): Cue {
+    val text = cue.text
+    val fills =
+        (text as? Spanned)?.getSpans(0, text.length, BackgroundColorSpan::class.java) ?: emptyArray()
+    if (!cue.windowColorSet && fills.isEmpty()) return cue
+    val builder = cue.buildUpon().clearWindowColor()
+    if (fills.isNotEmpty()) {
+        val stripped = SpannableString(text)
+        for (fill in fills) stripped.removeSpan(fill)
+        builder.setText(stripped)
+    }
+    return builder.build()
+}
+
+/** Applies [withoutCaptionFills] to the cues the player view renders. */
+class OutlinedCaptions(player: Player) : ForwardingSimpleBasePlayer(player) {
+    override fun getState(): SimpleBasePlayer.State {
+        val state = super.getState()
+        val group = state.currentCues
+        if (group.cues.isEmpty()) return state
+        val cues = CueGroup(group.cues.map(::withoutCaptionFills), group.presentationTimeUs)
+        return state.buildUpon().setCurrentCues(cues).build()
+    }
+}
+
 fun createTvPlayer(
     context: Context,
     renderers: HardwareRenderers,
@@ -190,6 +243,7 @@ fun FullscreenPlayer(
             )
         }
     val session = remember(player) { MediaSession.Builder(context, player).build() }
+    val captioned = remember(player) { OutlinedCaptions(player) }
     var view by remember { mutableStateOf<PlayerView?>(null) }
     val currentExit by rememberUpdatedState(onExit)
     val currentFailure by rememberUpdatedState(onFailure)
@@ -295,6 +349,9 @@ fun FullscreenPlayer(
                 core.stopPlayer()
             }
             lifecycle.removeObserver(observer)
+            // Drop the cue wrapper's listeners before the player it forwards to
+            // goes away; releasing it here would release that player twice.
+            view?.player = null
             session.release()
             player.removeListener(listener)
             player.release()
@@ -304,7 +361,13 @@ fun FullscreenPlayer(
     AndroidView(
         factory = {
             PlayerView(it).apply {
-                this.player = player
+                this.player = captioned
+                subtitleView?.apply {
+                    // Keep italics and the other authored text styling; only the
+                    // fills are dropped, by the style and by OutlinedCaptions.
+                    setApplyEmbeddedStyles(true)
+                    setStyle(outlinedCaptionStyle)
+                }
                 setShowSubtitleButton(true)
                 setShowNextButton(false)
                 setShowPreviousButton(false)

--- a/apps/macos-shell/CMakeLists.txt
+++ b/apps/macos-shell/CMakeLists.txt
@@ -21,7 +21,9 @@ find_package(
     WebChannel
     WebEngineQuick
 )
-pkg_check_modules(MPV REQUIRED IMPORTED_TARGET mpv)
+# libmpv 2.4 (mpv 0.40) renamed the subtitle outline options Kino pins for
+# its caption style. An older library would reject them at startup.
+pkg_check_modules(MPV REQUIRED IMPORTED_TARGET mpv>=2.4)
 find_library(FOUNDATION_FRAMEWORK Foundation REQUIRED)
 find_library(IOKIT_FRAMEWORK IOKit REQUIRED)
 find_library(MEDIAPLAYER_FRAMEWORK MediaPlayer REQUIRED)

--- a/apps/macos-shell/src/mpvitem.cpp
+++ b/apps/macos-shell/src/mpvitem.cpp
@@ -240,6 +240,22 @@ QQuickFramebufferObject::Renderer *MpvItem::createRenderer() const {
     return new MpvRenderer(context_);
 }
 
+QVariantMap MpvItem::subtitleStyle() const {
+    static const char *const names[] = {
+        "sub-ass-override", "sub-ass-style-overrides", "sub-back-color",
+        "sub-blur",         "sub-border-style",        "sub-color",
+        "sub-outline-color", "sub-outline-size",       "sub-shadow-offset",
+    };
+    QVariantMap style;
+    for (const char *name : names) {
+        char *value = mpv_get_property_string(handle_, name);
+        if (!value) continue;
+        style.insert(QString::fromUtf8(name), QString::fromUtf8(value).trimmed());
+        mpv_free(value);
+    }
+    return style;
+}
+
 QString MpvItem::version() const {
     char *value = mpv_get_property_string(handle_, "mpv-version");
     if (!value) return QStringLiteral("Unavailable");
@@ -275,6 +291,26 @@ void MpvItem::initialize() {
         {"title", "Kino"},
         {"sid", "no"},
         {"sub-auto", "no"},
+        // Text subtitles render as outlined glyphs over the video. Pin every
+        // field the box could come back from: Kino's own style, a libmpv
+        // default, and the authored ASS/SSA styles libass would otherwise
+        // honour. "sub-shadow-color" is an alias for "sub-back-color", so a
+        // transparent back colour also removes the drop shadow.
+        {"sub-border-style", "outline-and-shadow"},
+        {"sub-color", "#FFFFFFFF"},
+        {"sub-outline-color", "#FF000000"},
+        {"sub-outline-size", "3"},
+        {"sub-back-color", "#00000000"},
+        {"sub-shadow-offset", "0"},
+        {"sub-blur", "0"},
+        // "scale" keeps authored positions, fonts, italics, and text colours.
+        // The style overrides replace only the fields that draw a box:
+        // BorderStyle 3 becomes an outline, and the box/shadow colour and the
+        // outline colour become transparent black and opaque black. ASS colours
+        // are &HAABBGGRR with 00 opaque, so &HFF000000& is fully transparent.
+        {"sub-ass-override", "scale"},
+        {"sub-ass-style-overrides",
+         "BorderStyle=1,Outline=3,Shadow=0,OutlineColour=&H00000000&,BackColour=&HFF000000&"},
     };
 
     for (const Option &option : options) {

--- a/apps/macos-shell/src/mpvitem.h
+++ b/apps/macos-shell/src/mpvitem.h
@@ -23,6 +23,7 @@ public:
     ~MpvItem() override;
 
     bool active() const;
+    QVariantMap subtitleStyle() const;
     QString version() const;
     Renderer *createRenderer() const override;
 

--- a/apps/macos-shell/src/playbackprobe.cpp
+++ b/apps/macos-shell/src/playbackprobe.cpp
@@ -68,8 +68,15 @@ void PlaybackProbe::onPlayerEvent(const QString &name, const QVariantMap &payloa
             subtitleTracks_.append(QJsonObject{
                 {QStringLiteral("codec"), track.value(QStringLiteral("codec")).toString()},
                 {QStringLiteral("external"), track.value(QStringLiteral("external")).toBool()},
+                {QStringLiteral("id"), track.value(QStringLiteral("id")).toLongLong()},
                 {QStringLiteral("lang"), track.value(QStringLiteral("lang")).toString()},
             });
+        }
+        // Selecting a track makes libass build the renderer, so the reported
+        // caption style reflects a session that actually drew subtitles.
+        if (!items.isEmpty() && !subtitleSelected_) {
+            subtitleSelected_ = true;
+            player_->setSubtitleTrack(items.first().toMap().value(QStringLiteral("id")).toInt());
         }
     } else if (name == QLatin1String("ready")) {
         if (!subtitlesPath_.isEmpty() && !subtitlesAdded_) {
@@ -96,11 +103,19 @@ void PlaybackProbe::finish(const QString &outcome, const QString &errorCode) {
     }
     finished_ = true;
     timeout_.stop();
+    // Read the caption style from the live player before it stops, so the
+    // fixture gate sees what libmpv actually held during playback.
+    QJsonObject subtitleStyle;
+    const QVariantMap style = player_->subtitleStyle();
+    for (auto field = style.cbegin(); field != style.cend(); ++field) {
+        subtitleStyle.insert(field.key(), field.value().toString());
+    }
     player_->stop();
 
     QJsonObject result{
         {QStringLiteral("chapters"), chapterCount_},
         {QStringLiteral("outcome"), outcome},
+        {QStringLiteral("subtitleStyle"), subtitleStyle},
         {QStringLiteral("subtitleTracks"), subtitleTracks_},
         {QStringLiteral("timeMs"), timeMs_},
     };

--- a/apps/macos-shell/src/playbackprobe.h
+++ b/apps/macos-shell/src/playbackprobe.h
@@ -28,6 +28,7 @@ private:
     bool finished_ = false;
     bool hardwareDecoding_ = false;
     bool subtitlesAdded_ = false;
+    bool subtitleSelected_ = false;
     qlonglong chapterCount_ = 0;
     qlonglong timeMs_ = 0;
     MpvItem *player_;

--- a/apps/macos-shell/tests/mpvitem_test.cpp
+++ b/apps/macos-shell/tests/mpvitem_test.cpp
@@ -45,6 +45,49 @@ private slots:
         QCOMPARE(events.first().at(1).toMap().value("percent").toDouble(), 37.5);
     }
 
+    // The caption style must come from Kino, not from a libmpv default that
+    // could change, and it must survive a load, a track switch, and an
+    // external subtitle. Every value is read back from the live player.
+    static void verifyOutlinedSubtitles(const MpvItem &player, const char *stage) {
+        const QVariantMap style = player.subtitleStyle();
+        auto value = [&](const char *name) { return style.value(QLatin1String(name)).toString(); };
+        QVERIFY2(!style.isEmpty(), stage);
+        // Fully transparent alpha. libmpv also draws the shadow in this colour.
+        QCOMPARE(value("sub-back-color"), QStringLiteral("#00000000"));
+        QCOMPARE(value("sub-shadow-offset"), QStringLiteral("0.000000"));
+        QCOMPARE(value("sub-border-style"), QStringLiteral("outline-and-shadow"));
+        QCOMPARE(value("sub-color"), QStringLiteral("#FFFFFFFF"));
+        QCOMPARE(value("sub-outline-color"), QStringLiteral("#FF000000"));
+        QCOMPARE(value("sub-blur"), QStringLiteral("0.000000"));
+        QVERIFY2(value("sub-outline-size").toDouble() > 0, stage);
+        // Authored ASS/SSA styling keeps its positions, fonts, and italics.
+        QCOMPARE(value("sub-ass-override"), QStringLiteral("scale"));
+        const QString overrides = value("sub-ass-style-overrides");
+        // BorderStyle 3 draws an opaque box; 1 draws the requested outline.
+        QVERIFY2(overrides.contains(QStringLiteral("BorderStyle=1")), stage);
+        // ASS colours are &HAABBGGRR, so 00 is opaque and FF is transparent.
+        QVERIFY2(overrides.contains(QStringLiteral("BackColour=&HFF000000&")), stage);
+        QVERIFY2(overrides.contains(QStringLiteral("OutlineColour=&H00000000&")), stage);
+        QVERIFY2(overrides.contains(QStringLiteral("Shadow=0")), stage);
+    }
+
+    void subtitlesRenderOutlinedWithoutABox() {
+        MpvItem player;
+        verifyOutlinedSubtitles(player, "after initialization");
+
+        player.load(QStringLiteral("https://media.invalid/fixture.mkv"), false);
+        verifyOutlinedSubtitles(player, "after loading a source");
+
+        player.setSubtitleTrack(2);
+        player.setSubtitleScale(1.5);
+        player.setSubtitlePosition(90);
+        verifyOutlinedSubtitles(player, "after switching tracks");
+
+        player.addSubtitles(QStringLiteral("https://media.invalid/fixture.srt"),
+                            QStringLiteral("English"), QStringLiteral("en"));
+        verifyOutlinedSubtitles(player, "after adding external subtitles");
+    }
+
     void subtitleVariantMetadata_data() {
         QTest::addColumn<bool>("flag");
         QTest::newRow("variant") << true;

--- a/docs/PLAYBACK.md
+++ b/docs/PLAYBACK.md
@@ -51,7 +51,11 @@ Audio preferences start with the Stremio profile language and may be overridden 
 
 ## Subtitles
 
-Kino supports embedded and external SRT, WebVTT, ASS, SSA, and PGS subtitles. ASS and SSA styling and positioning are retained where the player permits. The player exposes track selection, delay, size, and vertical position. Subtitle language begins with the Stremio preference, while enabled state and device overrides are remembered locally.
+Kino supports embedded and external SRT, WebVTT, ASS, SSA, and PGS subtitles. The player exposes track selection, delay, size, and vertical position. Subtitle language begins with the Stremio preference, while enabled state and device overrides are remembered locally.
+
+Text subtitles render as white glyphs with a black outline over the video. Nothing is filled behind them: no caption background, no window, and no drop shadow, whether the fill comes from Kino, a player default, or the device's own caption settings. ASS and SSA keep their positions, fonts, sizes, text colours, and italics, but an authored opaque box does not survive. On desktop, libmpv pins the caption colours and replaces `BorderStyle: 3` and the box and shadow colours through style overrides. On TV, Media3 renders with an explicit outline style, and Kino strips window colours and background spans from each cue before the player view draws it.
+
+PGS and other bitmap subtitles are images. Any background they contain is part of those pixels, so no text style setting removes it, and Kino does not claim otherwise.
 
 ## Controls and lifecycle
 

--- a/scripts/check-macos-playback.mjs
+++ b/scripts/check-macos-playback.mjs
@@ -69,6 +69,21 @@ Style: Default,Arial,28,&H00FFFFFF,2
 Format: Layer, Start, End, Style, Text
 Dialogue: 0,0:00:00.50,0:00:04.00,Default,Kino styled subtitles
 `;
+// BorderStyle 3 is the authored opaque box the caption style has to replace
+// with an outline. BackColour paints that box, so it must not survive either.
+const boxedAssText = `[Script Info]
+ScriptType: v4.00+
+PlayResX: 640
+PlayResY: 360
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, OutlineColour, BackColour, Italic, BorderStyle, Outline, Shadow, Alignment
+Style: Boxed,Arial,28,&H00FFFFFF,&H00000000,&H00000000,1,3,3,2,2
+
+[Events]
+Format: Layer, Start, End, Style, Text
+Dialogue: 0,0:00:00.50,0:00:04.00,Boxed,Kino boxed caption
+`;
 const vttText = `WEBVTT
 
 00:00.500 --> 00:04.000
@@ -109,6 +124,7 @@ function generateFixtures() {
   mkdirSync(fixturesDir, { recursive: true });
   const subsSrt = writeFixture('embedded.srt', srtText);
   const subsAss = writeFixture('embedded.ass', assText);
+  const subsBoxedAss = writeFixture('authored-box.ass', boxedAssText);
   const chaptersMeta = writeFixture('chapters.ffmeta', chapterMetadata);
 
   const h264 = encode('h264-sdr-aac.mp4', [
@@ -283,6 +299,30 @@ function generateFixtures() {
     '-c:s',
     'copy',
   ]);
+  encode('subs-authored-box.mkv', [
+    ...videoSource,
+    ...audioSource,
+    '-i',
+    subsBoxedAss,
+    '-map',
+    '0:v',
+    '-map',
+    '1:a',
+    '-map',
+    '2:s',
+    '-c:v',
+    'libx264',
+    '-preset',
+    'veryfast',
+    '-pix_fmt',
+    'yuv420p',
+    '-c:a',
+    'aac',
+    '-ac',
+    '2',
+    '-c:s',
+    'copy',
+  ]);
   encode('chapters-intro.mkv', [
     ...videoSource,
     ...audioSource,
@@ -329,19 +369,24 @@ const fixtures = [
   { file: 'h264-pcm.mkv', expect: { outcome: 'played' } },
   {
     file: 'subs-embedded.mkv',
-    expect: { outcome: 'played', subtitleCodecs: ['subrip', 'ass'] },
+    expect: { outcome: 'played', subtitleCodecs: ['subrip', 'ass'], outlinedSubtitles: true },
+  },
+  {
+    file: 'subs-authored-box.mkv',
+    note: 'authored ASS opaque box must render as an outline',
+    expect: { outcome: 'played', subtitleCodecs: ['ass'], outlinedSubtitles: true },
   },
   {
     file: 'h264-sdr-aac.mp4',
     label: 'external-srt',
     subtitles: 'external.srt',
-    expect: { outcome: 'played', externalSubtitle: true },
+    expect: { outcome: 'played', externalSubtitle: true, outlinedSubtitles: true },
   },
   {
     file: 'h264-sdr-aac.mp4',
     label: 'external-vtt',
     subtitles: 'external.vtt',
-    expect: { outcome: 'played', externalSubtitle: true },
+    expect: { outcome: 'played', externalSubtitle: true, outlinedSubtitles: true },
   },
   { file: 'chapters-intro.mkv', expect: { outcome: 'played', minChapters: 2 } },
   { file: 'corrupt.mp4', expect: { outcome: 'failed' } },
@@ -361,6 +406,49 @@ function runProbe(fixture) {
     return { failure: `no probe verdict (${detail})`, stderr: run.stderr };
   }
   return { result: JSON.parse(line.slice('KINO_PROBE_RESULT '.length)) };
+}
+
+// Text subtitles carry a black glyph outline and no filled background. The
+// style is read back from the live player, so a libmpv default change or an
+// authored ASS box would both fail here. Bitmap tracks such as PGS keep any
+// background baked into their images; no text style can remove those pixels.
+function outlinedSubtitleProblems(style) {
+  if (!style) return ['no caption style reported'];
+  const problems = [];
+  const transparent = (name) => {
+    const value = style[name] ?? '';
+    if (!/^#00[0-9a-f]{6}$/i.test(value))
+      problems.push(`${name} is ${value || 'unset'}, expected a fully transparent colour`);
+  };
+  const equals = (name, expected) => {
+    if (style[name] !== expected)
+      problems.push(`${name} is ${style[name] ?? 'unset'}, expected ${expected}`);
+  };
+  transparent('sub-back-color');
+  equals('sub-border-style', 'outline-and-shadow');
+  equals('sub-color', '#FFFFFFFF');
+  equals('sub-outline-color', '#FF000000');
+  if (!(Number(style['sub-outline-size']) > 0)) {
+    problems.push(
+      `sub-outline-size is ${style['sub-outline-size'] ?? 'unset'}, expected a visible outline`,
+    );
+  }
+  if (Number(style['sub-shadow-offset']) !== 0) {
+    problems.push(`sub-shadow-offset is ${style['sub-shadow-offset'] ?? 'unset'}, expected 0`);
+  }
+  // Authored ASS/SSA styling keeps its positions, fonts, and italics; only the
+  // fields that draw a box are replaced.
+  equals('sub-ass-override', 'scale');
+  const overrides = style['sub-ass-style-overrides'] ?? '';
+  for (const field of [
+    'BorderStyle=1',
+    'Shadow=0',
+    'OutlineColour=&H00000000&',
+    'BackColour=&HFF000000&',
+  ]) {
+    if (!overrides.includes(field)) problems.push(`sub-ass-style-overrides is missing ${field}`);
+  }
+  return problems;
 }
 
 function assertExpectations(fixture, result) {
@@ -386,6 +474,7 @@ function assertExpectations(fixture, result) {
   if (expect.externalSubtitle && !(result.subtitleTracks ?? []).some((track) => track.external)) {
     problems.push('no external subtitle track appeared');
   }
+  if (expect.outlinedSubtitles) problems.push(...outlinedSubtitleProblems(result.subtitleStyle));
   return problems;
 }
 


### PR DESCRIPTION
Closes #145.

Captions arrived inside a filled rectangle on both clients. The fill had three separate sources, so removing any one of them would have left the others.

## Desktop (libmpv)

`MpvItem::initialize` now pins the caption colours instead of inheriting defaults that have already changed once: `sub-back-color` defaults to a 69% opaque black in current mpv and doubles as the shadow colour.

Authored ASS and SSA styling still wins for positions, fonts, sizes, text colours, and italics (`sub-ass-override=scale`). Only the fields that draw a box are replaced, through `sub-ass-style-overrides`: `BorderStyle` 3 becomes an outline, and the box/shadow and outline colours become transparent and opaque black.

CMake now requires `libmpv >= 2.4`, the release that renamed `--sub-border-*` to `--sub-outline-*`. An older library fails at configure time with a clear message instead of throwing "mpv rejected a required option" at startup.

## Android TV (Media3)

`PlayerView` was using the device caption style, whose default is white text on an opaque black background. It now gets an explicit `CaptionStyleCompat` with `EDGE_TYPE_OUTLINE` and transparent background and window colours.

Embedded styling stays on, so italics and the rest survive. A `ForwardingSimpleBasePlayer` strips window colours and `BackgroundColorSpan`s from each cue before the view draws it, because Media3's SSA parser turns an authored `BorderStyle: 3` into exactly such a span.

## Verification

- Rendering an ASS fixture with `BorderStyle: 3` through mpv drops the longest contiguous run of dark pixels behind the text from **280px** (a solid bar the width of the caption) to **31px** (the glyph outlines). White pixel count is unchanged at ~1.4k, so the text itself renders identically.
- `pnpm macos:check-playback` passes all 16 fixtures locally, including a new `subs-authored-box.mkv`. The probe now selects a subtitle track and reports the style read back from the live player, so the gate checks what libmpv actually held during playback rather than what the source code wrote.
- `ctest` passes 8/8, including a new `mpvitem_test` case that re-reads the style after a load, a track switch, and an external subtitle.
- New `CaptionStyleTest` covers the cue sanitizer: fills removed, italics kept, plain cues returned untouched.
- `pnpm check` passes.

## Bitmap subtitles

Unchanged, and `docs/PLAYBACK.md` now says why: a background in a PGS image is part of those pixels, so no text style setting removes it.

## Not verified here

The TV changes compile in CI but have not run on the Shield. `pnpm android:check` needs the physical device.