### PR TITLE
Speed up CI validation

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -49,8 +49,55 @@ jobs:
           yes | "$tools/sdkmanager" --licenses > /dev/null
           "$tools/sdkmanager" 'platforms;android-36' 'build-tools;35.0.0' 'ndk;29.0.14206865'
           echo "$tools" >> "$GITHUB_PATH"
+      # The pinned Core, its Cargo dependencies, and the Gradle caches are all
+      # keyed by their own inputs, so an unchanged Core is restored instead of
+      # rebuilt from source on every run.
+      - name: Restore the vendored Core and its Cargo dependencies
+        id: core-cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            build/android-core-target
+            build/vendor/stremio-core-kotlin
+            build/vendor/stremio-core-kotlin.stamp
+            build/stremio-core-kotlin-1.15.0.tar.gz
+          key: android-core-${{ runner.os }}-${{ hashFiles('scripts/build-android.py', 'apps/android-tv/core/Cargo.lock', 'apps/android-tv/core/patches/**') }}
+          restore-keys: android-core-${{ runner.os }}-
+      - name: Restore Gradle caches
+        id: gradle-cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: android-gradle-${{ runner.os }}-${{ hashFiles('apps/android-tv/**/*.gradle.kts', 'apps/android-tv/gradle.properties', 'apps/android-tv/gradle/wrapper/gradle-wrapper.properties', 'apps/android-tv/app/gradle.lockfile') }}
+          restore-keys: android-gradle-${{ runner.os }}-
+
       - name: Build Core, compile instrumentation, and lint
         run: python3 scripts/build-android.py :app:assembleDebug :app:assembleDebugAndroidTest :app:lintDebug
+
+      - name: Save the vendored Core and its Cargo dependencies
+        if: steps.core-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            build/android-core-target
+            build/vendor/stremio-core-kotlin
+            build/vendor/stremio-core-kotlin.stamp
+            build/stremio-core-kotlin-1.15.0.tar.gz
+          key: ${{ steps.core-cache.outputs.cache-primary-key }}
+      - name: Save Gradle caches
+        if: steps.gradle-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ steps.gradle-cache.outputs.cache-primary-key }}
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: Kino-TV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       native: ${{ steps.paths.outputs.native }}
+      packaging: ${{ steps.paths.outputs.packaging }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -37,8 +38,21 @@ jobs:
           const files = !base || /^0+$/.test(base)
             ? ['.github/workflows/ci.yml']
             : execFileSync('git', ['diff', '--name-only', '-z', base, head], { encoding: 'utf8' }).split('\0');
-          const native = files.some((file) => /^(\.github\/|apps\/(macos-shell|stream-engine)\/|apps\/desktop\/src\/native\/|scripts\/|third_party\/|package\.json$|pnpm-lock\.yaml$|\.node-version$)/.test(file));
-          appendFileSync(process.env.GITHUB_OUTPUT, `native=${native}\n`);
+          // Inputs to the native build, its tests, and its startup probes. A
+          // change anywhere else, including the Android workflow and its
+          // scripts, leaves the macOS job skipped.
+          const nativePaths = /^(\.github\/workflows\/ci\.yml$|apps\/(macos-shell|stream-engine)\/|apps\/desktop\/src\/native\/|scripts\/(build-engine\.sh|build-macos\.sh|check-engine-|check-macos-|package-macos\.mjs$)|third_party\/|package\.json$|pnpm-lock\.yaml$|\.node-version$)/;
+          // Inputs to the packaged bundle and the notices it carries. On a pull
+          // request the packaging step runs only for these; every push to main
+          // packages regardless, so a release artifact is never first built at
+          // tag time. The notice index itself is checked on every pull request
+          // by "pnpm notices:check" in the web job.
+          const packagingPaths = /^(\.github\/workflows\/ci\.yml$|apps\/macos-shell\/CMakeLists\.txt$|scripts\/(package-macos\.mjs|check-license-notices\.mjs)$|third_party\/|pnpm-lock\.yaml$)/;
+          const packaging = files.some((file) => packagingPaths.test(file));
+          // Packaging runs inside the native job, so anything that packaging
+          // depends on has to bring that job along with it.
+          const native = packaging || files.some((file) => nativePaths.test(file));
+          appendFileSync(process.env.GITHUB_OUTPUT, `native=${native}\npackaging=${packaging}\n`);
           JS
 
   web:
@@ -72,12 +86,19 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 45
     env:
-      CARGO_BUILD_JOBS: '2'
       CARGO_TARGET_DIR: ${{ github.workspace }}/build/engine-target
-      CMAKE_BUILD_PARALLEL_LEVEL: '2'
       HOMEBREW_NO_AUTO_UPDATE: '1'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Match build parallelism to the runner
+        # Both builds were pinned to two jobs. Track the runner instead, capped
+        # so a wider machine cannot run the linker out of memory.
+        run: |
+          cores="$(sysctl -n hw.ncpu)"
+          jobs=$(( cores > 4 ? 4 : cores ))
+          echo "Runner reports $cores cores; building with $jobs jobs"
+          echo "CARGO_BUILD_JOBS=$jobs" >> "$GITHUB_ENV"
+          echo "CMAKE_BUILD_PARALLEL_LEVEL=$jobs" >> "$GITHUB_ENV"
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -118,8 +139,10 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             build/engine-target
-          key: cargo-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.key }}-${{ hashFiles('apps/stream-engine/Cargo.lock', 'apps/stream-engine/engine.lock', 'apps/stream-engine/patches/**') }}
-          restore-keys: cargo-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.key }}-
+            build/vendor/stream-server
+            build/vendor/stream-server.stamp
+          key: cargo-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.key }}-${{ hashFiles('apps/stream-engine/Cargo.lock', 'apps/stream-engine/engine.lock', 'apps/stream-engine/patches/**') }}
+          restore-keys: cargo-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.key }}-
       - name: Reconstruct vendor patches and build the locked engine
         run: pnpm engine:build
       - name: Test the locked engine and embedded profile
@@ -136,6 +159,8 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             build/engine-target
+            build/vendor/stream-server
+            build/vendor/stream-server.stamp
           key: ${{ steps.engine-cache.outputs.cache-primary-key }}
 
       - name: Compile and bundle the native shell
@@ -153,7 +178,11 @@ jobs:
           pnpm macos:check-audio
           pnpm macos:check-web-console
 
+      # Packaging is a release-artifact check, not a correctness check, and it
+      # is the slowest step in this job. Pull requests run it only when the
+      # bundle or its notices change; every push to main runs it.
       - name: Package and verify bundled dependency notices
+        if: github.event_name == 'push' || needs.changes.outputs.packaging == 'true'
         timeout-minutes: 15
         run: pnpm macos:package --no-dmg
 

--- a/scripts/build-android.py
+++ b/scripts/build-android.py
@@ -44,16 +44,37 @@ def main():
     rustup = shutil.which("rustup") or str(Path.home() / ".cargo/bin/rustup")
     run(rustup, "toolchain", "install", TOOLCHAIN, "--profile", "minimal", "--target", "aarch64-linux-android")
     BUILD.mkdir(exist_ok=True)
-    if not (VENDOR / ".git").exists():
-        run("git", "clone", "--no-checkout", "https://github.com/Stremio/stremio-core-kotlin.git", VENDOR)
-    run("git", "-C", VENDOR, "fetch", "--depth", "1", "origin", REVISION)
-    # This exact generated checkout is disposable; all Kino patches live in apps/android-tv/core.
-    run("git", "-C", VENDOR, "checkout", "--force", REVISION)
-    run("git", "-C", VENDOR, "clean", "-ffdqx")
     patches = sorted((APP / "core/patches").glob("*.patch"))
-    for patch in patches:
-        run("git", "-C", VENDOR, "apply", patch)
-    shutil.copyfile(APP / "core/Cargo.lock", VENDOR / "Cargo.lock")
+    lock = APP / "core/Cargo.lock"
+    stamp = VENDOR.with_suffix(".stamp")
+    # Reconstructing the checkout rewrites every vendored file, and Cargo
+    # fingerprints on mtime, so an unchanged tree rebuilt the whole core every
+    # run. The state covers the revision, the patches, the lock file, the
+    # checked-out commit, and the working tree, so a patch edit, a hand edit, a
+    # stray file, and a failed attempt all reconstruct.
+    def vendor_state():
+        parts = [REVISION.encode(), *(patch.read_bytes() for patch in patches), lock.read_bytes()]
+        for command in (["rev-parse", "HEAD"], ["status", "--porcelain"], ["diff"]):
+            try:
+                parts.append(subprocess.run(["git", "-C", str(VENDOR), *command], capture_output=True, check=True).stdout)
+            except (subprocess.CalledProcessError, FileNotFoundError, NotADirectoryError):
+                return None
+        return hashlib.sha256(b"\0".join(parts)).hexdigest()
+
+    if stamp.exists() and stamp.read_text() == (vendor_state() or ""):
+        print(f"Reusing the vendored Stremio Core at {REVISION}")
+    else:
+        stamp.unlink(missing_ok=True)
+        if not (VENDOR / ".git").exists():
+            run("git", "clone", "--no-checkout", "https://github.com/Stremio/stremio-core-kotlin.git", VENDOR)
+        run("git", "-C", VENDOR, "fetch", "--depth", "1", "origin", REVISION)
+        # This exact generated checkout is disposable; all Kino patches live in apps/android-tv/core.
+        run("git", "-C", VENDOR, "checkout", "--force", REVISION)
+        run("git", "-C", VENDOR, "clean", "-ffdqx")
+        for patch in patches:
+            run("git", "-C", VENDOR, "apply", patch)
+        shutil.copyfile(lock, VENDOR / "Cargo.lock")
+        stamp.write_text(vendor_state())
 
     archive = BUILD / "stremio-core-kotlin-1.15.0.tar.gz"
     if not archive.exists():

--- a/scripts/build-engine.sh
+++ b/scripts/build-engine.sh
@@ -35,15 +35,36 @@ if ! git -C "${kino_vendor_dir}" cat-file -e "${KINO_ENGINE_REVISION}^{commit}" 
   git -C "${kino_vendor_dir}" fetch --quiet --depth 1 origin "${KINO_ENGINE_REVISION}"
 fi
 
-# This generated directory is disposable. Reconstruct it on every build so
-# patch edits, removals, and failed attempts cannot leave stale source behind.
-git -C "${kino_vendor_dir}" checkout --quiet --force "${KINO_ENGINE_REVISION}"
-git -C "${kino_vendor_dir}" clean --quiet -ffdqx
-for patch in "${kino_engine_dir}"/patches/*.patch; do
-  [[ -f "${patch}" ]] || continue
-  echo "Applying $(basename "${patch}")"
-  git -C "${kino_vendor_dir}" apply "${patch}"
-done
+# This generated directory is disposable, but reconstructing it rewrites every
+# vendored file, and Cargo's fingerprints are mtime-based, so an unchanged tree
+# still rebuilt libtorrent-sys and its dependents on every run. The stamp covers
+# the revision, the patches, the checked-out commit, and the working tree, so a
+# patch edit or removal, a hand edit, a stray file, and a failed attempt all
+# reconstruct; only a byte-identical tree is reused.
+kino_vendor_stamp="${kino_vendor_dir}.stamp"
+kino_vendor_state() {
+  {
+    printf '%s\n' "${KINO_ENGINE_REVISION}"
+    cat "${kino_engine_dir}"/patches/*.patch 2>/dev/null || true
+    git -C "${kino_vendor_dir}" rev-parse HEAD 2>/dev/null || true
+    git -C "${kino_vendor_dir}" status --porcelain 2>/dev/null || true
+    git -C "${kino_vendor_dir}" diff 2>/dev/null || true
+  } | shasum -a 256 | awk '{print $1}'
+}
+
+if [[ -f "${kino_vendor_stamp}" && "$(cat "${kino_vendor_stamp}")" == "$(kino_vendor_state)" ]]; then
+  echo "Reusing the vendored stream-server at ${KINO_ENGINE_REVISION}"
+else
+  rm -f "${kino_vendor_stamp}"
+  git -C "${kino_vendor_dir}" checkout --quiet --force "${KINO_ENGINE_REVISION}"
+  git -C "${kino_vendor_dir}" clean --quiet -ffdqx
+  for patch in "${kino_engine_dir}"/patches/*.patch; do
+    [[ -f "${patch}" ]] || continue
+    echo "Applying $(basename "${patch}")"
+    git -C "${kino_vendor_dir}" apply "${patch}"
+  done
+  kino_vendor_state > "${kino_vendor_stamp}"
+fi
 
 # Offline packaging reads locked package metadata, including inactive optional manifests.
 cargo fetch --locked --target aarch64-apple-darwin --manifest-path "${kino_engine_dir}/Cargo.toml"


### PR DESCRIPTION
Native validation took 21 minutes, and most of it was work that says nothing about whether a change is correct. Step timings from run 34009614331:

| Step | Before |
|---|---|
| Package and verify bundled notices | 519s (41%) |
| Build the locked engine | 267s (21%) |
| Install native dependencies | 143s |
| Test the locked engine and profile | 138s |
| Compile and bundle the native shell | 68s |
| Native unit tests and startup probes | 41s |

## The vendored checkout defeated the Cargo cache

`build-engine.sh` runs `git checkout --force` and `git clean -ffdqx` on the vendored tree every run. That rewrites every file, and Cargo's fingerprints are mtime-based, so a warm `build/engine-target` was discarded. Measured locally on an unchanged tree, the build still recompiled `libtorrent-sys`, `server`, `enginefs`, and the engine crate.

Both build scripts now stamp the vendored state and reuse the tree while it still matches. The stamp covers the pinned revision, the patch contents, the lock file, the checked-out commit, and the working tree (`status --porcelain` plus `diff`), so the disposability guarantee the original comment was protecting is preserved. Verified locally:

| Case | Result |
|---|---|
| Nothing changed | reuse |
| Stray untracked file | reconstruct |
| Hand edit to a tracked file | reconstruct |
| Patch edited | reconstruct |
| Patch restored | reconstruct, then steady reuse |

A no-op engine build goes from 20.9s to 0.55s locally with zero crates recompiled. The CI runner has far fewer cores and was spending 267s there on a confirmed cache hit.

Two supporting changes were needed for this to apply on CI at all: the Cargo cache now carries `build/vendor/stream-server` and its stamp, and the cache key moves to `cargo-v2-` because an exact hit on the old key would skip the save step that first stores those paths.

## Packaging moves off the pull-request path

It runs on every push to `main`, and on pull requests that touch the bundle, `CMakeLists.txt`, `third_party/`, the packaging script, or the lockfile. Pull requests still validate the notice index through `pnpm notices:check` in the web job; what they skip is rebuilding and re-signing the .app.

This is a deliberate trade: a bundling regression now lands on `main` and is caught there rather than in review. Given the separate notices check and pre-1.0 status I think that is the right side of it, but it is a trade.

## Narrower native path filter

The old filter matched all of `.github/` and all of `scripts/`, so an Android-only change booked 21 minutes of macOS runner for nothing. Verified classifications:

| File | native | packaging |
|---|---|---|
| `apps/desktop/src/screens/PlayerScreen.tsx` | no | no |
| `apps/android-tv/.../TvPlayer.kt` | no | no |
| `.github/workflows/android.yml` | no | no |
| `scripts/check-android.py` | no | no |
| `docs/PLAYBACK.md` | no | no |
| `apps/macos-shell/src/mpvitem.cpp` | yes | no |
| `apps/stream-engine/Cargo.toml` | yes | no |
| `third_party/notices/foo.txt` | yes | yes |
| `scripts/package-macos.mjs` | yes | yes |

`native` is the union with `packaging`, since the packaging step lives inside the native job.

## Android caching

The job cached nothing and rebuilt the pinned Core from source every run, 465s in a single step. It now caches the vendored Core and its stamp, the Cargo registry and target directory, the bindings archive, and the Gradle caches.

## Parallelism

Both builds were pinned to two jobs. They now follow `hw.ncpu`, capped at four so a wider runner cannot run the linker out of memory. The chosen value is printed.

## Expected effect

This PR's own run is not the fast path: it edits `ci.yml`, so it takes the full native job including packaging, and it invalidates both the brew and Cargo caches. That is intentional, since it proves packaging still works. The saving shows up on the next unrelated pull request.