### PR TITLE
Keep remote focus on the TV playback surface

### DIFF
--- a/apps/android-tv/app/src/androidTest/java/app/kino/tv/TvControlsTest.kt
+++ b/apps/android-tv/app/src/androidTest/java/app/kino/tv/TvControlsTest.kt
@@ -1,0 +1,153 @@
+@file:androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+
+package app.kino.tv
+
+import android.content.Intent
+import android.net.Uri
+import android.view.KeyEvent
+import android.view.WindowManager
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.datasource.FileDataSource
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import androidx.media3.session.MediaSession
+import androidx.media3.ui.PlayerView
+import androidx.test.platform.app.InstrumentationRegistry
+import java.io.File
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * The remote has to bring the controls back during the same playback session.
+ * [PlayerView.dispatchKeyEvent] reveals them, but only for a view holding
+ * Android focus, and hiding the controls takes their focused button away with
+ * them. On a Shield the surrounding Compose hierarchy then reclaims focus and
+ * every later press is lost, so these exercise the production [tvPlayerView]
+ * with a competing Compose focus target present.
+ */
+class TvControlsTest {
+    private val instrumentation = InstrumentationRegistry.getInstrumentation()
+    private val context = instrumentation.targetContext
+
+    @Test
+    fun theSurfaceTakesFocusSoTheRemoteReachesIt() {
+        withPlayingSurface { surface ->
+            waitUntil("the surface must hold focus once it is on screen") {
+                surface.view.hasFocus()
+            }
+        }
+    }
+
+    @Test
+    fun theRemoteRevealsControlsAfterTheyAutoHide() {
+        withPlayingSurface { surface ->
+            val player = surface.player
+            // The second cycle only passes if hiding the controls returned
+            // focus to the surface; otherwise the first reveal is the last one.
+            repeat(2) { cycle ->
+                waitUntil("controls must auto-hide on cycle $cycle") {
+                    !surface.view.isControllerFullyVisible
+                }
+                val positionBefore = onMain { player.currentPosition }
+
+                instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_DPAD_CENTER)
+
+                waitUntil("the remote must reveal the controls on cycle $cycle") {
+                    surface.view.isControllerFullyVisible
+                }
+                // Revealing must not disturb playback or throw away progress.
+                assertTrue("Playback must keep running", onMain { player.isPlaying })
+                assertTrue(
+                    "Revealing must not restart or seek playback",
+                    onMain { player.currentPosition } >= positionBefore,
+                )
+            }
+        }
+    }
+
+    private class Surface(val player: ExoPlayer, val view: PlayerView)
+
+    private fun withPlayingSurface(block: (Surface) -> Unit) {
+        val fixture = File(context.cacheDir, "controls-fixture.mp4")
+        instrumentation.context.assets.open("h264-sdr-aac.mp4").use { input ->
+            fixture.outputStream().use { input.copyTo(it) }
+        }
+        val activity =
+            instrumentation.startActivitySync(
+                Intent(context, PlaybackProbeActivity::class.java)
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            ) as PlaybackProbeActivity
+        var player: ExoPlayer? = null
+        var session: MediaSession? = null
+        var view: PlayerView? = null
+        try {
+            instrumentation.runOnMainSync {
+                activity.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                val created = createTvPlayer(activity, HardwareRenderers(activity))
+                player = created
+                // Production builds one of these beside the player.
+                session = MediaSession.Builder(activity, created).build()
+                val presented = TvPresentationPlayer(created)
+                activity.setContent {
+                    Box(Modifier.fillMaxSize()) {
+                        AndroidView(
+                            factory = { tvPlayerView(it, presented).also { built -> view = built } },
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                        // A Compose focus target beside the surface, standing in
+                        // for the hierarchy that holds focus on a real Shield.
+                        // Without one the surface is granted focus for free and
+                        // the defect cannot appear.
+                        Box(Modifier.focusable())
+                    }
+                }
+                created.setMediaSource(
+                    ProgressiveMediaSource.Factory(FileDataSource.Factory())
+                        .createMediaSource(MediaItem.fromUri(Uri.fromFile(fixture)))
+                )
+                created.prepare()
+                created.repeatMode = Player.REPEAT_MODE_ALL
+                created.play()
+            }
+            val started = player!!
+            waitUntil("the fixture must reach playback") {
+                started.playbackState == Player.STATE_READY && started.isPlaying
+            }
+            waitUntil("the surface must be composed") { view != null }
+            block(Surface(started, view!!))
+        } finally {
+            instrumentation.runOnMainSync {
+                session?.release()
+                player?.release()
+            }
+            activity.finish()
+            fixture.delete()
+        }
+    }
+
+    /** Reads a player or view value on the thread Media3 requires. */
+    private fun <T> onMain(read: () -> T): T {
+        var value: T? = null
+        instrumentation.runOnMainSync { value = read() }
+        @Suppress("UNCHECKED_CAST")
+        return value as T
+    }
+
+    /** Conditions run on the main thread, so they must not post there again. */
+    private fun waitUntil(reason: String, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + 15_000
+        while (System.currentTimeMillis() < deadline) {
+            instrumentation.waitForIdleSync()
+            if (onMain(condition)) return
+            Thread.sleep(150)
+        }
+        fail(reason)
+    }
+}

--- a/apps/android-tv/app/src/main/java/app/kino/tv/TvPlayer.kt
+++ b/apps/android-tv/app/src/main/java/app/kino/tv/TvPlayer.kt
@@ -9,6 +9,7 @@ import android.text.SpannableString
 import android.text.Spanned
 import android.text.style.BackgroundColorSpan
 import android.util.Log
+import android.view.View
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
@@ -236,6 +237,51 @@ fun createTvPlayer(
         .build()
 }
 
+/**
+ * The playback surface and its controls.
+ *
+ * The remote reveals hidden controls through [PlayerView.dispatchKeyEvent],
+ * which the view only receives while it holds Android focus. Compose owns focus
+ * inside an `AndroidView`, and a `requestFocus()` call made while the view is
+ * still detached does nothing, so focus is claimed once the view reaches a
+ * window instead.
+ */
+fun tvPlayerView(context: Context, player: Player): PlayerView =
+    PlayerView(context).apply {
+        this.player = player
+        subtitleView?.apply {
+            // Keep italics and the other authored text styling; only the fills
+            // are dropped, by the style and by the presentation.
+            setApplyEmbeddedStyles(true)
+            setStyle(outlinedCaptionStyle)
+        }
+        setShowSubtitleButton(true)
+        setShowNextButton(false)
+        setShowPreviousButton(false)
+        controllerShowTimeoutMs = 3500
+        keepScreenOn = false
+        isFocusable = true
+        addOnAttachStateChangeListener(
+            object : View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(attached: View) {
+                    // Focus is only grantable once the view has a window, and
+                    // the first layout pass has to land before it can take it.
+                    attached.post { attached.requestFocus() }
+                }
+
+                override fun onViewDetachedFromWindow(detached: View) = Unit
+            }
+        )
+        // Hiding the controls takes their focused button away with them, and
+        // Compose reclaims focus from the surrounding hierarchy. Taking it back
+        // on every hide is what keeps the next remote press revealing them.
+        setControllerVisibilityListener(
+            PlayerView.ControllerVisibilityListener { visibility ->
+                if (visibility != View.VISIBLE) post { requestFocus() }
+            }
+        )
+    }
+
 @Composable
 fun FullscreenPlayer(
     source: Source,
@@ -380,24 +426,7 @@ fun FullscreenPlayer(
         }
     }
     AndroidView(
-        factory = {
-            PlayerView(it).apply {
-                this.player = presented
-                subtitleView?.apply {
-                    // Keep italics and the other authored text styling; only the
-                    // fills are dropped, by the style and by the presentation.
-                    setApplyEmbeddedStyles(true)
-                    setStyle(outlinedCaptionStyle)
-                }
-                setShowSubtitleButton(true)
-                setShowNextButton(false)
-                setShowPreviousButton(false)
-                controllerShowTimeoutMs = 3500
-                keepScreenOn = false
-                requestFocus()
-                view = this
-            }
-        },
+        factory = { tvPlayerView(it, presented).also { created -> view = created } },
         modifier = Modifier.fillMaxSize(),
     )
 }

--- a/docs/PLAYBACK.md
+++ b/docs/PLAYBACK.md
@@ -61,7 +61,7 @@ PGS and other bitmap subtitles are images. Any background they contain is part o
 
 Desktop provides Space or K for play/pause, arrow-key seeking, M for mute, and F for fullscreen. System media keys and the operating system Now Playing surface expose play, pause, seek, and metadata. Kino prevents display and system sleep only while video is actively playing.
 
-TV playback is always fullscreen. Back first closes the active menu or hides controls; when neither is open, it stops playback, saves progress, and returns to the media details screen.
+TV playback is always fullscreen. A directional key or OK reveals hidden controls without activating anything behind them, and the playback surface keeps remote focus for the whole session, including each time the controls hide again. Back first closes the active menu or hides controls; when neither is open, it stops playback, saves progress, and returns to the media details screen.
 
 Playback always runs at the normal rate. Neither presentation offers a playback-rate control, key, or remote action, and the TV player withholds the Media3 command its control view would list a Speed row for. Audio and subtitle selection stay reachable on both.
 


### PR DESCRIPTION
Closes #144.

## Confirmed, not inferred

The issue asked for the cause rather than a longer timeout. During real playback on a Shield, Kino's view hierarchy showed:

| View | State |
|---|---|
| `AndroidComposeView` | focused |
| `PlayerView` | visible, focusable, **not focused** |
| `PlayerControlView` | `GONE` |

Pressing OK and then DOWN changed none of the three.

`PlayerView.dispatchKeyEvent` reveals hidden controls for any of nine D-pad keycodes, but only for a view holding Android focus. Compose owns focus inside an `AndroidView`, and `requestFocus()` sat in the factory lambda, where the view has no window yet and the call is a no-op. So the surface never held focus and every remote key went elsewhere.

## Two parts, because the first was not enough

Claiming focus once the view reaches a window fixed only the *first* reveal. On the device the second press was lost again: hiding the controls takes their focused button with them and Compose reclaims focus. Taking focus back whenever the controller hides is what makes every later reveal work.

Verified on the Shield across three hide/reveal cycles, with OK and with DOWN. Back still hides visible controls first and only then exits, and playback kept running throughout (`state=3`, position advancing).

## Why the regression check looks the way it does

Three earlier reproductions **passed against the broken build**, which is why this one is shaped carefully. A competing Compose focus target has to sit beside the surface; without one the surface is granted focus for free and the defect cannot appear. The check drives the production `tvPlayerView` through a real window with a real key event, and its second reveal cycle is what covers the hide path, since the first reveal succeeds even with only half the fix.

Confirmed red on the unfixed build (`the surface must hold focus once it is on screen`, `the remote must reveal the controls on cycle 0`) and green after.

## Verification

- `pnpm android:check` on the Shield: **12/12**, including the two new checks and the existing playback, presentation, and startup suites.
- `pnpm check` clean.

## Note

`tvPlayerView` is extracted from `FullscreenPlayer` so the check exercises the real construction rather than a copy of it.