### PR TITLE
fix: show a loading screen while Continue Watching resumes on TV

### DIFF
--- a/apps/android-tv/app/build.gradle.kts
+++ b/apps/android-tv/app/build.gradle.kts
@@ -73,7 +73,21 @@ android {
     }
 }
 
-tasks.named("preBuild") { dependsOn(generateDesignTokens) }
+// A gradle-only build with that directory missing would still succeed and
+// ship an APK without the surround decoders, and every AC-3, E-AC-3, DTS, and
+// TrueHD source would then fail on the Shield as an unplayable audio format.
+val requireFfmpegRenderer by
+    tasks.registering {
+        val library = file("../../../build/android-ffmpeg/jniLibs/arm64-v8a/libffmpegJNI.so")
+        doLast {
+            check(library.exists()) {
+                "Missing $library. Run `pnpm android:build`, which builds Media3's FFmpeg audio " +
+                    "renderer before Gradle; a Gradle-only build would omit the surround decoders."
+            }
+        }
+    }
+
+tasks.named("preBuild") { dependsOn(generateDesignTokens, requireFfmpegRenderer) }
 
 dependencies {
     implementation(files("../../../build/android-core/classes.jar"))

--- a/apps/android-tv/app/build.gradle.kts
+++ b/apps/android-tv/app/build.gradle.kts
@@ -84,6 +84,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.4")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.9.4")
     implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.animation:animation")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.tv:tv-material:1.0.1")
     implementation("io.coil-kt.coil3:coil-compose:3.3.0")

--- a/apps/android-tv/app/src/main/java/app/kino/tv/TvScreens.kt
+++ b/apps/android-tv/app/src/main/java/app/kino/tv/TvScreens.kt
@@ -4,6 +4,15 @@ package app.kino.tv
 
 import android.content.Context
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -34,8 +43,12 @@ import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -116,21 +129,28 @@ fun KinoApp(
             core.search(query.trim())
         }
     }
+    // The remembered stream lives in one add-on's response, so playback starts
+    // as soon as that add-on answers rather than after the slowest one. The
+    // overlay only lifts onto the source list once every add-on has replied
+    // without it, or the title itself failed to load.
     LaunchedEffect(resumePending, state.details) {
-        if (resumePending && !state.details.loading && !state.details.sourcesLoading) {
-            resumePending = false
-            val previous = state.details.lastUsedStream
-            val source =
-                state.details.sources.firstOrNull {
-                    it.playable &&
-                        previous != null &&
-                        it.stream.source == previous.source &&
-                        it.stream.behaviorHints.proxyHeaders == previous.behaviorHints.proxyHeaders
-                }
-            if (source != null) {
+        if (!resumePending) return@LaunchedEffect
+        val details = state.details
+        val previous = details.lastUsedStream
+        val source =
+            details.sources.firstOrNull {
+                it.playable &&
+                    previous != null &&
+                    it.stream.source == previous.source &&
+                    it.stream.behaviorHints.proxyHeaders == previous.behaviorHints.proxyHeaders
+            }
+        when {
+            source != null -> {
+                resumePending = false
                 core.startPlayer(source)
                 playing = source
             }
+            details.failed || (!details.loading && !details.sourcesLoading) -> resumePending = false
         }
     }
     val closeDetails = {
@@ -206,6 +226,7 @@ fun KinoApp(
                                     videoId,
                                     state.details,
                                     playbackError,
+                                    resuming = resumePending,
                                     onBack = closeDetails,
                                     onEpisode = {
                                         resumePending = false
@@ -248,6 +269,7 @@ fun KinoApp(
                         }
                     }
             }
+            if (playing == null) ResumeOverlay(resumePending) { resumePending = false }
         }
     }
 }
@@ -483,6 +505,7 @@ private fun DetailScreen(
     videoId: String?,
     details: Details,
     error: Int?,
+    resuming: Boolean,
     onBack: () -> Unit,
     onEpisode: (String) -> Unit,
     onRetry: () -> Unit,
@@ -564,7 +587,7 @@ private fun DetailScreen(
                     )
                 }
             }
-            LaunchedEffect(Unit) { focus.requestFocus() }
+            LaunchedEffect(resuming) { if (!resuming) focus.requestFocus() }
         }
         if (media.preview != null || meta != null)
             item {
@@ -662,6 +685,55 @@ private fun DetailScreen(
                 SourceRow(source, details.meta?.runtime, onSelect = { onSource(source) })
             }
         }
+    }
+}
+
+/**
+ * A plain loading screen between Home and the player while Core confirms the
+ * remembered source. The poster the user just chose says what is loading, so
+ * it carries no text. It covers the rail as well as the details page, holds
+ * focus, and swallows every key but Back, so nothing beneath can be activated
+ * a moment before playback takes over; Back reveals the details page for a
+ * manual choice. The caller drops it from composition when the player mounts,
+ * so its focus never competes with the surface.
+ */
+@Composable
+private fun ResumeOverlay(visible: Boolean, onCancel: () -> Unit) {
+    val focus = remember { FocusRequester() }
+    BackHandler(visible, onCancel)
+    // No entrance fade: the page must never show through before the spinner.
+    AnimatedVisibility(visible, enter = EnterTransition.None, exit = fadeOut(tween(250))) {
+        Box(
+            Modifier.fillMaxSize()
+                .background(Background)
+                .focusRequester(focus)
+                .focusable()
+                .onPreviewKeyEvent { it.key != Key.Back },
+            contentAlignment = Alignment.Center,
+        ) {
+            Spinner()
+        }
+        LaunchedEffect(Unit) { focus.requestFocus() }
+    }
+}
+
+@Composable
+private fun Spinner() {
+    val angle by
+        rememberInfiniteTransition(label = "spinner")
+            .animateFloat(
+                0f,
+                360f,
+                infiniteRepeatable(tween(1000, easing = LinearEasing)),
+                label = "angle",
+            )
+    val track = KinoColors.TextStrong.copy(alpha = .16f)
+    Canvas(Modifier.size(30.dp)) {
+        val stroke = Stroke(3.dp.toPx(), cap = StrokeCap.Round)
+        val inset = stroke.width / 2
+        val bounds = Size(size.width - stroke.width, size.height - stroke.width)
+        drawArc(track, 0f, 360f, false, Offset(inset, inset), bounds, style = stroke)
+        drawArc(KinoColors.TextStrong, angle, 80f, false, Offset(inset, inset), bounds, style = stroke)
     }
 }
 

--- a/docs/ANDROID-TV.md
+++ b/docs/ANDROID-TV.md
@@ -30,7 +30,7 @@ The build also requires `rustup`, Python 3, and Git. It installs Rust 1.93.1 wit
 
 The development-signed APK and its checksum are written to `build/android/Kino-TV.apk` and `build/android/Kino-TV.apk.sha256`. The app appears as **Kino** in the TV launcher. Select **Settings → Sign in** to link Stremio using a phone. This does not copy the Mac's credentials or profile to the TV.
 
-After the first native build, Kotlin-only iteration can use:
+After the first native build, Kotlin-only iteration can use the commands below. Gradle refuses to build until `pnpm android:build` has produced the FFmpeg audio renderer under `build/android-ffmpeg`, since an APK without it fails every surround source on the Shield.
 
 ```sh
 cd apps/android-tv

--- a/docs/ANDROID-TV.md
+++ b/docs/ANDROID-TV.md
@@ -2,7 +2,7 @@
 
 Kino has a native Kotlin and Compose TV app in `apps/android-tv`. The first build targets ARM64 devices running Android 9 or newer and is tested on an NVIDIA Shield.
 
-This is the first runnable TV version. It includes Stremio device-link sign-in, guest browsing, Home, Search, Library, movie and episode details, explicit source selection, and fullscreen Media3 playback. Continue Watching uses poster cards with titles below, a centered play icon, and saved progress. A remembered source resumes only if it is still returned by its add-on; otherwise its source list opens without an unavailable-source notice.
+This is the first runnable TV version. It includes Stremio device-link sign-in, guest browsing, Home, Search, Library, movie and episode details, explicit source selection, and fullscreen Media3 playback. Continue Watching uses poster cards with titles below, a centered play icon, and saved progress. Opening a Continue Watching item shows a loading screen until the remembered source comes back from its add-on, then plays it; Back during that wait reveals the details page for a manual choice. If every add-on answers without that source, the loading screen gives way to the source list without an unavailable-source notice.
 
 ## Interface
 

--- a/scripts/build-android.py
+++ b/scripts/build-android.py
@@ -195,11 +195,19 @@ def main():
                         sanitized.writestr(name, classes.read(name))
 
     compiler = str(llvm / "aarch64-linux-android26-clang")
-    env.update({"RUSTUP_TOOLCHAIN": TOOLCHAIN, "CARGO_TARGET_DIR": str(BUILD / "android-core-target"),
+    # Cargo resolves `rustc` through PATH, and `rustup run` does not put the
+    # toolchain ahead of it. With Homebrew's Rust at /opt/homebrew/bin before
+    # ~/.cargo/bin, Cargo compiled with a rustc that has no Android standard
+    # library and failed with "can't find crate for `core`". Name the pinned
+    # toolchain's own binaries so PATH order cannot swap compilers.
+    toolchain_bin = Path(subprocess.run([rustup, "which", "--toolchain", TOOLCHAIN, "rustc"],
+        capture_output=True, check=True, text=True).stdout.strip()).parent
+    env.update({"RUSTUP_TOOLCHAIN": TOOLCHAIN, "RUSTC": str(toolchain_bin / "rustc"),
+        "CARGO_TARGET_DIR": str(BUILD / "android-core-target"),
         "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER": compiler, "CC_aarch64_linux_android": compiler,
         "AR_aarch64_linux_android": str(llvm / "llvm-ar"), "RANLIB_aarch64_linux_android": str(llvm / "llvm-ranlib"),
         "ANDROID_NDK_ROOT": str(ndk)})
-    run(rustup, "run", TOOLCHAIN, "cargo", "build", "--locked", "--release", "--target", "aarch64-linux-android",
+    run(toolchain_bin / "cargo", "build", "--locked", "--release", "--target", "aarch64-linux-android",
         "--manifest-path", VENDOR / "Cargo.toml", "-p", "stremio-core-kotlin", env=env)
     build_ffmpeg_decoders(env, ndk, llvm, host)
     library = output / "jniLibs/arm64-v8a/libstremio_core_kotlin.so"


### PR DESCRIPTION
Opening a Continue Watching item on the Shield landed on an interactive details page that switched to the player once every add-on had answered, with nothing on screen saying playback was coming. This covers the screen, rail included, with a plain spinner until the remembered source is confirmed.

- Playback starts as soon as the remembered source's add-on returns it, instead of after the slowest add-on.
- Back during the wait reveals the details page for a manual choice, with its Back button focused.
- The cover holds focus and swallows every key but Back, so nothing beneath can be activated a moment before the player mounts. It leaves composition the moment the player mounts so its focus never competes with the surface.
- If every add-on answers without the source, or the title fails to load, the cover gives way to the details page as before.

Checked on the Shield with screen recordings: Home to spinner on the next frame with no details flash, spinner to playback, and Select then Back onto the details page with no decoder start. `pnpm android:check` was not run; the flow needs a signed-in profile with Continue Watching items, which the instrumentation suite does not set up. Android lint passes and the device tests compile.

`docs/ANDROID-TV.md` describes the new flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)