### PR TITLE
Fix desktop outline on automatic page focus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
           pnpm macos:check-engine
           pnpm macos:check-cache-clear
           pnpm macos:check-scale
+          pnpm macos:check-focus
           pnpm macos:check-fullscreen
           pnpm macos:check-volume
           pnpm macos:check-audio

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Settings can copy a diagnostic summary with application, macOS, Qt, Core, player
 
 The player saves volume locally between launches. Its slider and Up/Down shortcuts adjust 0-100% volume; M toggles mute, and raising volume unmutes playback. Focused sliders keep their native keyboard step. Run `pnpm macos:check-volume` to verify the production WebChannel method and libmpv volume notifications, including bounds.
 
+Desktop navigation moves focus to the page or heading without drawing an outline. Keyboard controls and Skip to content retain their visible focus indicators. `pnpm macos:check-focus` exercises the production bundle in Qt WebEngine through launch, navigation, Tab, and Skip to content.
+
 The fullscreen button and F toggle the current window state. Escape exits fullscreen after closing any open subtitle menu. The native bridge follows Qt window visibility, including changes through macOS window controls. Run `pnpm macos:check-fullscreen` to verify the actual WebChannel property and change notifications through repeated entry and exit.
 
 Validate the playback contract against generated legal fixtures — codecs, HDR ranges, audio formats, subtitles, chapters, and failure paths — with:

--- a/apps/desktop/src/App.module.css
+++ b/apps/desktop/src/App.module.css
@@ -128,6 +128,11 @@
   outline-offset: -2px;
 }
 
+.content.navigationFocus:focus,
+.content h1.navigationFocus:focus {
+  outline: none;
+}
+
 .page {
   width: min(100%, 1500px);
   min-height: 100%;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -210,6 +210,12 @@ export function App() {
     const target =
       heading && !heading.classList.contains(styles.visuallyHidden ?? '') ? heading : main;
     target.tabIndex = -1;
+    // WebEngine treats cold-launch focus as keyboard focus. Suppress only this
+    // navigation focus, then restore the indicator when the target loses focus.
+    target.classList.add(styles.navigationFocus!);
+    target.addEventListener('blur', () => target.classList.remove(styles.navigationFocus!), {
+      once: true,
+    });
     target.focus({ preventScroll: true });
   }, [entry, playback, screen, view]);
 
@@ -253,7 +259,9 @@ export function App() {
           href="#main-content"
           onClick={(event) => {
             event.preventDefault();
-            (screen === 'detail' ? detailMain.current : browseMain.current)?.focus();
+            const main = screen === 'detail' ? detailMain.current : browseMain.current;
+            main?.classList.remove(styles.navigationFocus!);
+            main?.focus();
           }}
         >
           {enUS.navigation.skipToContent}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "macos:check-cache-clear": "node scripts/check-macos-cache-clear.mjs",
     "macos:check-engine-retry": "node scripts/check-macos-engine-retry.mjs",
     "macos:check-scale": "node scripts/check-macos-scale.mjs",
+    "macos:check-focus": "node scripts/check-macos-focus.mjs",
     "macos:check-fullscreen": "node scripts/check-macos-fullscreen.mjs",
     "macos:check-audio": "node scripts/check-macos-audio.mjs",
     "macos:check-volume": "node scripts/check-macos-volume.mjs",

--- a/scripts/check-macos-focus.mjs
+++ b/scripts/check-macos-focus.mjs
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { readFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { extname, resolve, sep } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const ui = resolve('apps/desktop/dist');
+const server = createServer(async (request, response) => {
+  const path = resolve(ui, '.' + new URL(request.url, 'http://localhost').pathname);
+  if (path !== ui && !path.startsWith(ui + sep)) return response.writeHead(403).end();
+  try {
+    const file = path === ui ? resolve(ui, 'index.html') : path;
+    let body = await readFile(file);
+    if (extname(file) === '.html') {
+      // Isolate browsing from the user's native account and external catalogs.
+      // The production App, navigation effects, and styles still run unchanged.
+      body = body
+        .toString()
+        .replace(
+          '<head>',
+          '<head><script>window.qt = undefined; window.Worker = undefined;</script>',
+        );
+    }
+    const types = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css' };
+    response.writeHead(200, { 'Content-Type': types[extname(file)] ?? 'application/octet-stream' });
+    response.end(body);
+  } catch {
+    response.writeHead(404).end();
+  }
+});
+let child;
+let socket;
+let commandId = 0;
+const pending = new Map();
+async function until(read, description) {
+  const deadline = Date.now() + 15000;
+  while (Date.now() < deadline) {
+    const value = await read();
+    if (value) return value;
+    await delay(50);
+  }
+  throw new Error('Timed out waiting for ' + description);
+}
+function command(method, params = {}) {
+  const id = ++commandId;
+  return new Promise((resolveResult, reject) => {
+    const timer = setTimeout(() => {
+      pending.delete(id);
+      reject(new Error(method + ' timed out'));
+    }, 5000);
+    pending.set(id, (message) => {
+      clearTimeout(timer);
+      if (message.error) reject(new Error(message.error.message));
+      else resolveResult(message.result);
+    });
+    socket.send(JSON.stringify({ id, method, params }));
+  });
+}
+async function evaluate(expression) {
+  const result = await command('Runtime.evaluate', { expression, returnByValue: true });
+  assert.equal(result.exceptionDetails, undefined, 'Browser evaluation failed');
+  return result.result.value;
+}
+async function key(key, code, virtualKey, modifiers = 0) {
+  for (const type of ['keyDown', 'keyUp'])
+    await command('Input.dispatchKeyEvent', {
+      type,
+      key,
+      code,
+      windowsVirtualKeyCode: virtualKey,
+      text: type === 'keyDown' && key === 'Enter' ? '\r' : undefined,
+      modifiers,
+    });
+}
+const focus = `(() => { const el = document.activeElement; return { tag: el.tagName, label: el.textContent.trim(), outline: getComputedStyle(el).outlineStyle }; })()`;
+try {
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const origin = `http://127.0.0.1:${server.address().port}`;
+  const portServer = createServer();
+  portServer.listen(0, '127.0.0.1');
+  await once(portServer, 'listening');
+  const debugPort = portServer.address().port;
+  await new Promise((done) => portServer.close(done));
+  child = spawn(
+    resolve(process.env.KINO_APP_BINARY ?? 'build/macos/Kino.app/Contents/MacOS/Kino'),
+    [],
+    {
+      env: {
+        ...process.env,
+        KINO_UI_URL: origin,
+        QTWEBENGINE_REMOTE_DEBUGGING: `127.0.0.1:${debugPort}`,
+      },
+      stdio: ['ignore', 'ignore', 'pipe'],
+    },
+  );
+  child.stderr.resume();
+  const page = await until(async () => {
+    try {
+      return (await (await fetch(`http://127.0.0.1:${debugPort}/json`)).json()).find((page) =>
+        page.url.startsWith(origin),
+      );
+    } catch {
+      return null;
+    }
+  }, 'WebEngine debugging');
+  socket = new WebSocket(page.webSocketDebuggerUrl);
+  await once(socket, 'open');
+  socket.addEventListener('message', ({ data }) => {
+    const message = JSON.parse(data);
+    pending.get(message.id)?.(message);
+    pending.delete(message.id);
+  });
+  await until(() => evaluate(`document.activeElement?.tagName === 'MAIN'`), 'Home focus');
+  assert.equal(
+    (await evaluate(focus)).outline,
+    'none',
+    'Cold launch must not outline the content region',
+  );
+  await evaluate(`document.querySelector('button[aria-label="Settings"]').focus()`);
+  await key('Enter', 'Enter', 13);
+  await until(() => evaluate(`document.activeElement?.tagName === 'H1'`), 'Settings heading focus');
+  assert.equal((await evaluate(focus)).outline, 'none', 'Navigation must not outline the heading');
+  await key('Tab', 'Tab', 9);
+  assert.equal((await evaluate(focus)).outline, 'solid', 'Tab must visibly focus a control');
+  await evaluate(`document.querySelector('a[href="#main-content"]').focus()`);
+  await key('Enter', 'Enter', 13);
+  assert.equal((await evaluate(focus)).tag, 'MAIN');
+  assert.equal(
+    (await evaluate(focus)).outline,
+    'solid',
+    'Skip to content must visibly focus the region',
+  );
+  await key('Tab', 'Tab', 9);
+  assert.equal(
+    (await evaluate(focus)).outline,
+    'solid',
+    'Controls retain visible focus after skipping',
+  );
+  // A deliberate keyboard entry must regain the ring after the automatic focus ends.
+  await evaluate(
+    `document.querySelector('main').tabIndex = 0; document.querySelector('a[href="#main-content"]').focus()`,
+  );
+  await key('Enter', 'Enter', 13);
+  await key('Tab', 'Tab', 9);
+  await key('Tab', 'Tab', 9, 8);
+  assert.equal((await evaluate(focus)).tag, 'MAIN');
+  assert.equal(
+    (await evaluate(focus)).outline,
+    'solid',
+    'Tabbing back into the region must retain its ring',
+  );
+  console.log(
+    'Qt WebEngine: launch and navigation focus have no outline; Tab and Skip to content retain visible focus.',
+  );
+} finally {
+  socket?.close();
+  if (child && child.exitCode === null && child.signalCode === null) {
+    const exited = once(child, 'exit');
+    child.kill('SIGKILL');
+    await exited;
+  }
+  server.closeAllConnections();
+  await new Promise((done) => server.close(done));
+}


### PR DESCRIPTION
Cold launch and page navigation focus the main region or heading for accessibility. Qt WebEngine treats that programmatic focus as keyboard focus and painted an outline around the page. Suppress the outline for that automatic focus until blur; keep visible indicators for controls, Skip to content, and subsequent keyboard entry.

Adds a production-bundle Qt WebEngine gate to native CI. It failed on the original cold-launch outline and now passes launch, page navigation, Tab, and Skip to content checks.

Validation: `pnpm check` passed (249 tests and all integration gates), `pnpm macos:check-focus` passed, and the rebuilt macOS app passed `pnpm macos:check-launch`. Existing SourcePickerDialog lint warning remains. Android is unaffected.

Documentation: updated README with the behavior and gate; PRODUCT.md accessibility requirements and CONTEXT.md remain accurate. No ADR changes are needed.

Closes #156.
