### PR TITLE
Cover Continue Watching resume with a spinner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           // Inputs to the native build, its tests, and its startup probes. A
           // change anywhere else, including the Android workflow and its
           // scripts, leaves the macOS job skipped.
-          const nativePaths = /^(\.github\/workflows\/ci\.yml$|apps\/(macos-shell|stream-engine)\/|apps\/desktop\/src\/native\/|scripts\/(build-engine\.sh|build-macos\.sh|check-engine-|check-macos-|package-macos\.mjs$)|third_party\/|package\.json$|pnpm-lock\.yaml$|\.node-version$)/;
+          const nativePaths = /^(\.github\/workflows\/ci\.yml$|apps\/(macos-shell|stream-engine)\/|apps\/desktop\/src\/(native\/|test\/(browser\/|resumeState\.ts$|coreState\.ts$))|scripts\/(build-engine\.sh|build-macos\.sh|check-engine-|check-macos-|test-support\/webengine\.mjs$|package-macos\.mjs$)|third_party\/|package\.json$|pnpm-lock\.yaml$|\.node-version$)/;
           // Inputs to the packaged bundle and the notices it carries. On a pull
           // request the packaging step runs only for these; every push to main
           // packages regardless, so a release artifact is never first built at
@@ -174,6 +174,7 @@ jobs:
           pnpm macos:check-cache-clear
           pnpm macos:check-scale
           pnpm macos:check-focus
+          pnpm macos:check-resume
           pnpm macos:check-fullscreen
           pnpm macos:check-volume
           pnpm macos:check-audio

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ The player saves volume locally between launches. Its slider and Up/Down shortcu
 
 Desktop navigation moves focus to the page or heading without drawing an outline. Keyboard controls and Skip to content retain their visible focus indicators. `pnpm macos:check-focus` exercises the production bundle in Qt WebEngine through launch, navigation, Tab, and Skip to content.
 
+Continue Watching covers the desktop with a spinner while the remembered add-on answers, then starts the previous source if it still matches. Escape reveals manual selection and cancels the pending resume. `pnpm macos:check-resume` compiles the production presentation with delayed Core snapshots and checks movie and series coverage from the first frame, keyboard focus, cancellation, profile changes, and playback preparation before unrelated add-ons finish.
+
 The fullscreen button and F toggle the current window state. Escape exits fullscreen after closing any open subtitle menu. The native bridge follows Qt window visibility, including changes through macOS window controls. Run `pnpm macos:check-fullscreen` to verify the actual WebChannel property and change notifications through repeated entry and exit.
 
 Validate the playback contract against generated legal fixtures — codecs, HDR ranges, audio formats, subtitles, chapters, and failure paths — with:

--- a/apps/desktop/src/App.module.css
+++ b/apps/desktop/src/App.module.css
@@ -122,6 +122,50 @@
   inset: 0;
 }
 
+.resumeCover {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  max-height: none;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: var(--kino-bg);
+  outline: none;
+}
+
+.resumeCover[open] {
+  display: grid;
+  place-items: center;
+}
+
+.resumeCover::backdrop {
+  background: var(--kino-bg);
+}
+
+.resumeSpinner {
+  width: 32px;
+  height: 32px;
+  border: 2px solid var(--kino-border);
+  border-top-color: var(--kino-text-strong);
+  border-radius: 50%;
+  animation: resumeSpin 750ms linear infinite;
+}
+
+@keyframes resumeSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .resumeSpinner {
+    animation: none;
+  }
+}
+
 .content:focus-visible,
 .content h1:focus-visible {
   outline: 2px solid var(--kino-accent);

--- a/apps/desktop/src/App.resume.test.tsx
+++ b/apps/desktop/src/App.resume.test.tsx
@@ -6,27 +6,10 @@ import type { PlaybackSelection } from './core/actions';
 import { CoreContext } from './core/context';
 import { checkResumeSource } from './core/resume';
 import type { CoreTransport } from './core/transport';
-import type { ContinueWatchingItem, CoreRuntimeEvent, MetaDetailsState } from './core/types';
-import { hints, metaItem, profile, torrentSource, urlSource, video } from './test/coreState';
+import type { CoreRuntimeEvent } from './core/types';
+import { hints, profile, torrentSource, urlSource } from './test/coreState';
+import { addon, details, episode, item, remembered } from './test/resumeState';
 
-const episode = video({ id: 'show:2:5', title: 'Saved episode', season: 2, episode: 5 });
-const meta = metaItem({
-  id: 'show',
-  type: 'series',
-  name: 'Saved series',
-  videos: [video({ id: 'show:1:1', title: 'First episode', season: 1, episode: 1 }), episode],
-});
-const addon = {
-  manifest: { id: 'test', logo: null, name: 'Test add-on' },
-  transportUrl: 'https://addon.invalid/manifest.json',
-};
-const remembered = urlSource('https://media.invalid/saved.mp4', { name: 'Previous source' });
-const item: ContinueWatchingItem = {
-  ...meta,
-  progress: 25,
-  videoId: episode.id,
-  rememberedSource: { stream: remembered, transportUrl: addon.transportUrl },
-};
 const played = vi.hoisted(() => vi.fn());
 vi.mock('./screens/PlayerScreen', () => ({
   PlayerScreen: ({
@@ -48,20 +31,6 @@ beforeEach(() => {
   window.localStorage.clear();
   Element.prototype.scrollIntoView = vi.fn();
 });
-
-function details(): MetaDetailsState {
-  return {
-    libraryItem: { id: meta.id, videoId: episode.id, timeOffset: 30000 },
-    title: null,
-    selected: {
-      metaPath: { resource: 'meta', type: 'series', id: meta.id, extra: [] },
-      streamPath: { resource: 'stream', type: 'series', id: episode.id, extra: [] },
-      guessStream: false,
-    },
-    metaItem: { addon, content: { type: 'Ready', content: meta } },
-    streams: [{ addon, content: { type: 'Ready', content: [remembered] } }],
-  };
-}
 
 function mount() {
   let state = details();
@@ -115,9 +84,14 @@ function mount() {
 it('waits for the remembered add-on and resumes once, returning to selection after failure', async () => {
   const fixture = mount();
   fireEvent.click(await screen.findByRole('button', { name: 'Resume Saved series' }));
-  expect(await screen.findByText('Checking the previous source…')).toBeInTheDocument();
+  expect(screen.getByRole('dialog', { name: 'Loading playback' }).textContent).toBe('');
   expect(played).not.toHaveBeenCalled();
-  await fixture.ready();
+  const ready = details();
+  ready.streams.push({
+    addon: { ...addon, transportUrl: 'https://slow.invalid/manifest.json' },
+    content: { type: 'Loading' },
+  });
+  await fixture.ready(ready);
   await screen.findByRole('button', { name: 'Fail playback' });
   expect(played).toHaveBeenLastCalledWith(
     expect.objectContaining({
@@ -161,16 +135,16 @@ it.each(['close', 'profile'])(
   async (cancel) => {
     const fixture = mount();
     fireEvent.click(await screen.findByRole('button', { name: 'Resume Saved series' }));
-    await screen.findByText('Checking the previous source…');
+    await screen.findByRole('dialog', { name: 'Loading playback' });
     if (cancel === 'close')
       fireEvent(
-        screen.getByRole('dialog', { name: 'Saved episode' }),
+        screen.getByRole('dialog', { name: 'Loading playback' }),
         new Event('cancel', { bubbles: true, cancelable: true }),
       );
     else fixture.changeProfile();
     await fixture.ready();
     await waitFor(() =>
-      expect(screen.queryByText('Checking the previous source…')).not.toBeInTheDocument(),
+      expect(screen.queryByRole('dialog', { name: 'Loading playback' })).not.toBeInTheDocument(),
     );
     expect(played).not.toHaveBeenCalled();
   },

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -181,7 +181,7 @@ export function App() {
   const view = playback
     ? 'player'
     : screen === 'detail'
-      ? `detail:${detail?.type}:${detail?.id}`
+      ? `detail:${detail?.type}:${detail?.id}${resumeRequest ? ':resume' : ''}`
       : screen;
   useLayoutEffect(() => {
     const previous = previousView.current;

--- a/apps/desktop/src/components/ResumeCover.tsx
+++ b/apps/desktop/src/components/ResumeCover.tsx
@@ -1,0 +1,31 @@
+import { useLayoutEffect, useRef } from 'react';
+
+import styles from '../App.module.css';
+import { t } from '../locales';
+
+export function ResumeCover({ onCancel }: { onCancel: () => void }) {
+  const dialog = useRef<HTMLDialogElement>(null);
+  useLayoutEffect(() => {
+    const element = dialog.current;
+    // Enter the top layer before paint, making browsing inert immediately.
+    element?.showModal();
+    return () => element?.close();
+  }, []);
+  return (
+    <dialog
+      aria-label={t.details.loadingPlayback}
+      aria-busy="true"
+      className={styles.resumeCover}
+      ref={dialog}
+      onKeyDown={(event) => {
+        if (event.key === 'Tab') event.preventDefault();
+      }}
+      onCancel={(event) => {
+        event.preventDefault();
+        onCancel();
+      }}
+    >
+      <span aria-hidden="true" className={styles.resumeSpinner} />
+    </dialog>
+  );
+}

--- a/apps/desktop/src/locales/en-US.ts
+++ b/apps/desktop/src/locales/en-US.ts
@@ -257,7 +257,7 @@ export const enUS = {
   details: {
     season: (number: number) => `Season ${number}`,
     episode: (number: number | null) => (number === null ? 'Episode' : `Episode ${number}`),
-    checkingResume: 'Checking the previous source…',
+    loadingPlayback: 'Loading playback',
     loading: 'Loading title details…',
     error: 'Title details could not be loaded.',
     episodes: 'Episodes',

--- a/apps/desktop/src/screens/MetaDetailsScreen.tsx
+++ b/apps/desktop/src/screens/MetaDetailsScreen.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import styles from '../App.module.css';
 import { SourcePickerDialog } from '../components/SourcePickerDialog';
+import { ResumeCover } from '../components/ResumeCover';
 import { ActionFeedback } from '../components/ActionFeedback';
 import { useActionFeedback } from '../components/useActionFeedback';
 import { ResourceFailures } from '../components/ResourceFailures';
@@ -259,11 +260,6 @@ export function MetaDetailsScreen({
 
   const sourceSection = (
     <section aria-labelledby="sources-heading" className={styles.detailSection}>
-      {checkingResume ? (
-        <p className={styles.inlineEmpty} role="status">
-          {enUS.details.checkingResume}
-        </p>
-      ) : null}
       <ResourceFailures
         names={failures}
         error={result.error ? enUS.details.error : null}
@@ -308,7 +304,7 @@ export function MetaDetailsScreen({
           return (
             <SourceRow
               addonName={choice.addonName}
-              disabled={checkingResume || !selectable || !sourcesCurrent || !choice.current}
+              disabled={!selectable || !sourcesCurrent || !choice.current}
               external={external}
               failed={playable && failed}
               fields={fields}
@@ -461,7 +457,7 @@ export function MetaDetailsScreen({
 
         {item.type !== 'series' ? sourceSection : null}
       </div>
-      {item.type === 'series' && sourcePickerOpen ? (
+      {item.type === 'series' && sourcePickerOpen && !checkingResume ? (
         <SourcePickerDialog
           returnFocus={selectedEpisodeRef}
           title={activeVideo?.title || display.name}
@@ -476,6 +472,7 @@ export function MetaDetailsScreen({
       {currentExternal ? (
         <ExternalSourceDialog url={currentExternal.url} onClose={() => setExternalChoice(null)} />
       ) : null}
+      {checkingResume ? <ResumeCover onCancel={() => onCancelResume?.()} /> : null}
     </div>
   );
 }

--- a/apps/desktop/src/test/browser/resume.html
+++ b/apps/desktop/src/test/browser/resume.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Kino resume check</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./resume.tsx"></script>
+  </body>
+</html>

--- a/apps/desktop/src/test/browser/resume.tsx
+++ b/apps/desktop/src/test/browser/resume.tsx
@@ -1,0 +1,98 @@
+import { createRoot } from 'react-dom/client';
+import '@fontsource-variable/geist';
+import '../../global.css';
+
+import { App } from '../../App';
+import { CoreContext } from '../../core/context';
+import type { CoreTransport } from '../../core/transport';
+import type { CoreRuntimeEvent, MetaDetailsState } from '../../core/types';
+import { metaItem, profile } from '../coreState';
+import { addon, details, item, remembered } from '../resumeState';
+
+// Compile the production presentation against delayed Core snapshots. A null
+// player model holds the player at preparation without contacting a media URL.
+const movie = new URLSearchParams(location.search).get('kind') === 'movie';
+const saved = movie
+  ? { ...item, ...metaItem({ id: 'movie', name: 'Saved movie' }), videoId: 'movie' }
+  : item;
+const initial = details();
+if (movie) {
+  initial.metaItem = { addon, content: { type: 'Ready', content: metaItem(saved) } };
+  initial.libraryItem = { id: saved.id, videoId: saved.id, timeOffset: 30000 };
+  initial.selected = {
+    guessStream: false,
+    metaPath: { resource: 'meta', type: 'movie', id: saved.id, extra: [] },
+    streamPath: { resource: 'stream', type: 'movie', id: saved.id, extra: [] },
+  };
+}
+let state: MetaDetailsState = {
+  ...initial,
+  streams: [{ addon, content: { type: 'Loading' } }],
+};
+let playerLoads = 0;
+const listeners = new Set<(event: CoreRuntimeEvent) => void>();
+const transport: CoreTransport = {
+  init: async () => {},
+  destroy: async () => {},
+  flush: async () => {},
+  prepareClose: async () => {},
+  onBeforeDestroy: () => () => {},
+  dispatch: async (action, model) => {
+    if (model === 'player' && action.action === 'Load') playerLoads++;
+  },
+  getState: (async (model: string) => {
+    if (model === 'ctx') return profile();
+    if (model === 'continue_watching_preview') return { items: [saved] };
+    if (model === 'board') return { catalogs: [] };
+    if (model === 'player') return null;
+    return state;
+  }) as CoreTransport['getState'],
+  subscribe: (listener) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+};
+const root = createRoot(document.getElementById('root')!);
+const render = (target = transport) =>
+  root.render(
+    <CoreContext.Provider
+      value={{
+        error: null,
+        status: 'ready',
+        session: 'guest',
+        transport: target,
+        selectSession: () => {},
+      }}
+    >
+      <App />
+    </CoreContext.Provider>,
+  );
+
+const probe = {
+  get playerLoads() {
+    return playerLoads;
+  },
+  ready(found = true) {
+    state = {
+      ...initial,
+      streams: [
+        { addon, content: { type: 'Ready', content: found ? [remembered] : [] } },
+        {
+          addon: { ...addon, transportUrl: 'https://slow.invalid/manifest.json' },
+          content: { type: 'Loading' },
+        },
+      ],
+    };
+    listeners.forEach((listener) => listener({ name: 'NewState', args: ['meta_details'] }));
+  },
+  changeProfile() {
+    render({ ...transport });
+  },
+};
+declare global {
+  interface Window {
+    kinoResumeProbe: typeof probe;
+  }
+}
+window.kinoResumeProbe = probe;
+render();

--- a/apps/desktop/src/test/resumeState.ts
+++ b/apps/desktop/src/test/resumeState.ts
@@ -1,0 +1,34 @@
+import type { ContinueWatchingItem, MetaDetailsState } from '../core/types';
+import { metaItem, urlSource, video } from './coreState';
+
+export const episode = video({ id: 'show:2:5', title: 'Saved episode', season: 2, episode: 5 });
+export const meta = metaItem({
+  id: 'show',
+  type: 'series',
+  name: 'Saved series',
+  videos: [video({ id: 'show:1:1', title: 'First episode', season: 1, episode: 1 }), episode],
+});
+export const addon = {
+  manifest: { id: 'test', logo: null, name: 'Test add-on' },
+  transportUrl: 'https://addon.invalid/manifest.json',
+};
+export const remembered = urlSource('https://media.invalid/saved.mp4', { name: 'Previous source' });
+export const item: ContinueWatchingItem = {
+  ...meta,
+  progress: 25,
+  videoId: episode.id,
+  rememberedSource: { stream: remembered, transportUrl: addon.transportUrl },
+};
+export function details(): MetaDetailsState {
+  return {
+    libraryItem: { id: meta.id, videoId: episode.id, timeOffset: 30000 },
+    title: null,
+    selected: {
+      metaPath: { resource: 'meta', type: 'series', id: meta.id, extra: [] },
+      streamPath: { resource: 'stream', type: 'series', id: episode.id, extra: [] },
+      guessStream: false,
+    },
+    metaItem: { addon, content: { type: 'Ready', content: meta } },
+    streams: [{ addon, content: { type: 'Ready', content: [remembered] } }],
+  };
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "macos:check-engine-retry": "node scripts/check-macos-engine-retry.mjs",
     "macos:check-scale": "node scripts/check-macos-scale.mjs",
     "macos:check-focus": "node scripts/check-macos-focus.mjs",
+    "macos:check-resume": "node scripts/check-macos-resume.mjs",
     "macos:check-fullscreen": "node scripts/check-macos-fullscreen.mjs",
     "macos:check-audio": "node scripts/check-macos-audio.mjs",
     "macos:check-volume": "node scripts/check-macos-volume.mjs",

--- a/scripts/check-macos-focus.mjs
+++ b/scripts/check-macos-focus.mjs
@@ -1,118 +1,9 @@
 import assert from 'node:assert/strict';
-import { spawn } from 'node:child_process';
-import { once } from 'node:events';
-import { readFile } from 'node:fs/promises';
-import { createServer } from 'node:http';
-import { extname, resolve, sep } from 'node:path';
-import { setTimeout as delay } from 'node:timers/promises';
+import { resolve } from 'node:path';
+import { withWebEngine } from './test-support/webengine.mjs';
 
-const ui = resolve('apps/desktop/dist');
-const server = createServer(async (request, response) => {
-  const path = resolve(ui, '.' + new URL(request.url, 'http://localhost').pathname);
-  if (path !== ui && !path.startsWith(ui + sep)) return response.writeHead(403).end();
-  try {
-    const file = path === ui ? resolve(ui, 'index.html') : path;
-    let body = await readFile(file);
-    if (extname(file) === '.html') {
-      // Isolate browsing from the user's native account and external catalogs.
-      // The production App, navigation effects, and styles still run unchanged.
-      body = body
-        .toString()
-        .replace(
-          '<head>',
-          '<head><script>window.qt = undefined; window.Worker = undefined;</script>',
-        );
-    }
-    const types = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css' };
-    response.writeHead(200, { 'Content-Type': types[extname(file)] ?? 'application/octet-stream' });
-    response.end(body);
-  } catch {
-    response.writeHead(404).end();
-  }
-});
-let child;
-let socket;
-let commandId = 0;
-const pending = new Map();
-async function until(read, description) {
-  const deadline = Date.now() + 15000;
-  while (Date.now() < deadline) {
-    const value = await read();
-    if (value) return value;
-    await delay(50);
-  }
-  throw new Error('Timed out waiting for ' + description);
-}
-function command(method, params = {}) {
-  const id = ++commandId;
-  return new Promise((resolveResult, reject) => {
-    const timer = setTimeout(() => {
-      pending.delete(id);
-      reject(new Error(method + ' timed out'));
-    }, 5000);
-    pending.set(id, (message) => {
-      clearTimeout(timer);
-      if (message.error) reject(new Error(message.error.message));
-      else resolveResult(message.result);
-    });
-    socket.send(JSON.stringify({ id, method, params }));
-  });
-}
-async function evaluate(expression) {
-  const result = await command('Runtime.evaluate', { expression, returnByValue: true });
-  assert.equal(result.exceptionDetails, undefined, 'Browser evaluation failed');
-  return result.result.value;
-}
-async function key(key, code, virtualKey, modifiers = 0) {
-  for (const type of ['keyDown', 'keyUp'])
-    await command('Input.dispatchKeyEvent', {
-      type,
-      key,
-      code,
-      windowsVirtualKeyCode: virtualKey,
-      text: type === 'keyDown' && key === 'Enter' ? '\r' : undefined,
-      modifiers,
-    });
-}
 const focus = `(() => { const el = document.activeElement; return { tag: el.tagName, label: el.textContent.trim(), outline: getComputedStyle(el).outlineStyle }; })()`;
-try {
-  server.listen(0, '127.0.0.1');
-  await once(server, 'listening');
-  const origin = `http://127.0.0.1:${server.address().port}`;
-  const portServer = createServer();
-  portServer.listen(0, '127.0.0.1');
-  await once(portServer, 'listening');
-  const debugPort = portServer.address().port;
-  await new Promise((done) => portServer.close(done));
-  child = spawn(
-    resolve(process.env.KINO_APP_BINARY ?? 'build/macos/Kino.app/Contents/MacOS/Kino'),
-    [],
-    {
-      env: {
-        ...process.env,
-        KINO_UI_URL: origin,
-        QTWEBENGINE_REMOTE_DEBUGGING: `127.0.0.1:${debugPort}`,
-      },
-      stdio: ['ignore', 'ignore', 'pipe'],
-    },
-  );
-  child.stderr.resume();
-  const page = await until(async () => {
-    try {
-      return (await (await fetch(`http://127.0.0.1:${debugPort}/json`)).json()).find((page) =>
-        page.url.startsWith(origin),
-      );
-    } catch {
-      return null;
-    }
-  }, 'WebEngine debugging');
-  socket = new WebSocket(page.webSocketDebuggerUrl);
-  await once(socket, 'open');
-  socket.addEventListener('message', ({ data }) => {
-    const message = JSON.parse(data);
-    pending.get(message.id)?.(message);
-    pending.delete(message.id);
-  });
+await withWebEngine(resolve('apps/desktop/dist'), '/', async ({ evaluate, key, until }) => {
   await until(() => evaluate(`document.activeElement?.tagName === 'MAIN'`), 'Home focus');
   assert.equal(
     (await evaluate(focus)).outline,
@@ -162,13 +53,4 @@ try {
   console.log(
     'Qt WebEngine: launch and navigation focus have no outline; Tab and Skip to content retain visible focus.',
   );
-} finally {
-  socket?.close();
-  if (child && child.exitCode === null && child.signalCode === null) {
-    const exited = once(child, 'exit');
-    child.kill('SIGKILL');
-    await exited;
-  }
-  server.closeAllConnections();
-  await new Promise((done) => server.close(done));
-}
+});

--- a/scripts/check-macos-resume.mjs
+++ b/scripts/check-macos-resume.mjs
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { withWebEngine } from './test-support/webengine.mjs';
+
+const { build } = await import(createRequire(resolve('apps/desktop/package.json')).resolve('vite'));
+const ui = resolve('build/desktop-resume');
+await build({
+  root: resolve('apps/desktop'),
+  configFile: resolve('apps/desktop/vite.config.ts'),
+  logLevel: 'warn',
+  build: {
+    outDir: ui,
+    emptyOutDir: true,
+    rollupOptions: { input: resolve('apps/desktop/src/test/browser/resume.html') },
+  },
+});
+for (const kind of ['movie', 'series']) {
+  const entry = `/src/test/browser/resume.html?kind=${kind}`;
+  await withWebEngine(ui, entry, async ({ evaluate, key, command, until, origin }) => {
+    async function open() {
+      await until(
+        () =>
+          evaluate(
+            `document.querySelector('button[aria-label^="Resume Saved"]')?.closest('main')?.hidden === false && window.kinoResumeProbe.playerLoads === 0`,
+          ),
+        'Continue Watching',
+      );
+      await evaluate(`
+        window.coverFrames = [];
+        window.recordCover = true;
+        function frame() {
+          if (!window.recordCover) return;
+          const dialog = document.querySelector('dialog[aria-label="Loading playback"]');
+          const style = dialog && getComputedStyle(dialog);
+          const rect = dialog?.getBoundingClientRect();
+          window.coverFrames.push(Boolean(dialog?.matches(':modal') && dialog.textContent.trim() === '' &&
+            style.backgroundColor.startsWith('rgb(') && style.opacity === '1' &&
+            rect.x === 0 && rect.y === 0 && rect.width >= innerWidth && rect.height >= innerHeight));
+          requestAnimationFrame(frame);
+        }
+        requestAnimationFrame(frame);
+        document.querySelector('button[aria-label^="Resume Saved"]').click();
+      `);
+      await until(() => evaluate('window.coverFrames.length >= 3'), 'covered frames');
+      assert.ok(
+        (await evaluate('window.coverFrames')).every(Boolean),
+        'Every frame after the click must have an opaque spinner-only cover',
+      );
+      await key('Tab', 'Tab', 9);
+      assert.equal(
+        await evaluate(
+          `Boolean(document.activeElement.closest('dialog[aria-label="Loading playback"]'))`,
+        ),
+        true,
+        'Tab must not reach browsing behind the cover',
+      );
+      await evaluate('window.recordCover = false');
+    }
+    await open();
+    const screenshot = await command('Page.captureScreenshot', { format: 'png' });
+    await writeFile(resolve(ui, `resume-${kind}.png`), Buffer.from(screenshot.data, 'base64'));
+    await command('Emulation.setEmulatedMedia', {
+      features: [{ name: 'prefers-reduced-motion', value: 'reduce' }],
+    });
+    assert.equal(
+      await evaluate(
+        `getComputedStyle(document.querySelector('dialog[aria-label="Loading playback"] span')).animationName`,
+      ),
+      'none',
+      'Reduced motion must stop the spinner animation',
+    );
+    await command('Emulation.setEmulatedMedia', { features: [] });
+    await key('Escape', 'Escape', 27);
+    await until(
+      () => evaluate(`!document.querySelector('dialog[aria-label="Loading playback"]')`),
+      'Escape cancellation',
+    );
+    const target =
+      kind === 'movie'
+        ? `document.querySelector('main:not([hidden]) h1')`
+        : `document.querySelector('button[aria-label="Close source picker"]')`;
+    assert.equal(
+      await evaluate(`document.activeElement === ${target}`),
+      true,
+      'Escape must restore the normal manual-selection focus',
+    );
+    await evaluate('window.kinoResumeProbe.ready()');
+    await until(
+      () =>
+        evaluate(
+          `Boolean(Array.from(document.querySelectorAll('button')).find(el => el.textContent.includes('Previous source') && !el.disabled))`,
+        ),
+      'manual sources',
+    );
+    assert.equal(
+      await evaluate('window.kinoResumeProbe.playerLoads'),
+      0,
+      'Late results must not resume after Escape',
+    );
+
+    await command('Page.navigate', { url: origin + entry });
+    await open();
+    await evaluate('window.kinoResumeProbe.ready()');
+    await until(
+      () => evaluate('window.kinoResumeProbe.playerLoads === 1'),
+      'remembered add-on playback',
+    );
+    assert.equal(
+      await evaluate(`Boolean(document.querySelector('dialog[aria-label="Loading playback"]'))`),
+      false,
+    );
+
+    await command('Page.navigate', { url: origin + entry });
+    await open();
+    await evaluate('window.kinoResumeProbe.changeProfile()');
+    await until(
+      () => evaluate(`!document.querySelector('dialog[aria-label="Loading playback"]')`),
+      'profile cancellation',
+    );
+    await evaluate('window.kinoResumeProbe.ready()');
+    assert.equal(await evaluate('window.kinoResumeProbe.playerLoads'), 0);
+
+    await command('Page.navigate', { url: origin + entry });
+    await open();
+    await evaluate('window.kinoResumeProbe.ready(false)');
+    await until(
+      () => evaluate(`!document.querySelector('dialog[aria-label="Loading playback"]')`),
+      'unavailable remembered source',
+    );
+    assert.equal(await evaluate('window.kinoResumeProbe.playerLoads'), 0);
+    assert.equal(await evaluate(`document.activeElement === ${target}`), true);
+  });
+}
+console.log(
+  'Qt WebEngine: movie and series resume cover every frame, preserve Escape focus, reject late/profile results, and start before unrelated add-ons finish.',
+);

--- a/scripts/test-support/webengine.mjs
+++ b/scripts/test-support/webengine.mjs
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { readFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { extname, resolve, sep } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+export async function withWebEngine(ui, entry, check) {
+  const server = createServer(async (request, response) => {
+    const path = resolve(ui, '.' + new URL(request.url, 'http://localhost').pathname);
+    if (path !== ui && !path.startsWith(ui + sep)) return response.writeHead(403).end();
+    try {
+      const file = path === ui ? resolve(ui, 'index.html') : path;
+      let body = await readFile(file);
+      if (extname(file) === '.html') {
+        // Isolate browsing from the user's native account and external catalogs.
+        // The production App, navigation effects, and styles still run unchanged.
+        body = body
+          .toString()
+          .replace(
+            '<head>',
+            '<head><script>window.qt = undefined; window.Worker = undefined;</script>',
+          );
+      }
+      const types = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css' };
+      response.writeHead(200, {
+        'Content-Type': types[extname(file)] ?? 'application/octet-stream',
+      });
+      response.end(body);
+    } catch {
+      response.writeHead(404).end();
+    }
+  });
+  let child;
+  let socket;
+  let commandId = 0;
+  const pending = new Map();
+  async function until(read, description) {
+    const deadline = Date.now() + 15000;
+    while (Date.now() < deadline) {
+      const value = await read();
+      if (value) return value;
+      await delay(50);
+    }
+    throw new Error('Timed out waiting for ' + description);
+  }
+  function command(method, params = {}) {
+    const id = ++commandId;
+    return new Promise((resolveResult, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(method + ' timed out'));
+      }, 5000);
+      pending.set(id, (message) => {
+        clearTimeout(timer);
+        if (message.error) reject(new Error(message.error.message));
+        else resolveResult(message.result);
+      });
+      socket.send(JSON.stringify({ id, method, params }));
+    });
+  }
+  async function evaluate(expression) {
+    const result = await command('Runtime.evaluate', { expression, returnByValue: true });
+    assert.equal(result.exceptionDetails, undefined, 'Browser evaluation failed');
+    return result.result.value;
+  }
+  async function key(key, code, virtualKey, modifiers = 0) {
+    for (const type of ['keyDown', 'keyUp'])
+      await command('Input.dispatchKeyEvent', {
+        type,
+        key,
+        code,
+        windowsVirtualKeyCode: virtualKey,
+        text: type === 'keyDown' && key === 'Enter' ? '\r' : undefined,
+        modifiers,
+      });
+  }
+  try {
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+    const origin = `http://127.0.0.1:${server.address().port}`;
+    const portServer = createServer();
+    portServer.listen(0, '127.0.0.1');
+    await once(portServer, 'listening');
+    const debugPort = portServer.address().port;
+    await new Promise((done) => portServer.close(done));
+    child = spawn(
+      resolve(process.env.KINO_APP_BINARY ?? 'build/macos/Kino.app/Contents/MacOS/Kino'),
+      [],
+      {
+        env: {
+          ...process.env,
+          KINO_UI_URL: origin + entry,
+          QTWEBENGINE_REMOTE_DEBUGGING: `127.0.0.1:${debugPort}`,
+        },
+        stdio: ['ignore', 'ignore', 'pipe'],
+      },
+    );
+    child.stderr.resume();
+    const page = await until(async () => {
+      try {
+        return (await (await fetch(`http://127.0.0.1:${debugPort}/json`)).json()).find((page) =>
+          page.url.startsWith(origin),
+        );
+      } catch {
+        return null;
+      }
+    }, 'WebEngine debugging');
+    socket = new WebSocket(page.webSocketDebuggerUrl);
+    await once(socket, 'open');
+    socket.addEventListener('message', ({ data }) => {
+      const message = JSON.parse(data);
+      pending.get(message.id)?.(message);
+      pending.delete(message.id);
+    });
+    await check({ evaluate, key, command, until, origin });
+  } finally {
+    socket?.close();
+    if (child && child.exitCode === null && child.signalCode === null) {
+      const exited = once(child, 'exit');
+      child.kill('SIGKILL');
+      await exited;
+    }
+    server.closeAllConnections();
+    await new Promise((done) => server.close(done));
+  }
+}


### PR DESCRIPTION
Continue Watching now shows an opaque, spinner-only cover while Kino resolves the remembered source. The modal opens before paint, keeps focus inside it, and lets Escape return to the normal detail or source-selection view. The old inline resume message and resume-specific disabled source buttons are removed.

A Qt WebEngine gate drives the actual React presentation with delayed Core snapshots. It checks movie and series first-frame coverage, cancellation and focus restoration, reduced motion, profile changes, unavailable-source fallback, and player preparation as soon as the remembered add-on responds while another add-on remains pending. Shared browser fixtures and the gate helper trigger native CI when changed.

Validation: `pnpm check` passed (245 tests across 44 files plus integration gates); macOS build, focus, resume, and launch gates passed. Independent Standards and Spec reviews completed; the missing CI fixture paths identified in review were added and verified. README documents the behavior and the gate's scope; product and playback contracts remain true.

Closes #157.
