### PR TITLE
Require an exact runtime before trusting community intro markers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           // Inputs to the native build, its tests, and its startup probes. A
           // change anywhere else, including the Android workflow and its
           // scripts, leaves the macOS job skipped.
-          const nativePaths = /^(\.github\/workflows\/ci\.yml$|apps\/(macos-shell|stream-engine)\/|apps\/desktop\/src\/(native\/|player\/|screens\/(PlayerScreen|MetaDetailsScreen|EpisodeSourcesScreen)\.tsx$|App\.(tsx|module\.css)$|core\/(actions|seasons)\.ts$|locales\/|components\/AudioTrackPicker\.tsx$|test\/(browser\/|resumeState\.ts$|coreState\.ts$))|scripts\/(build-engine\.sh|build-macos\.sh|check-engine-|check-macos-|test-support\/|package-macos\.mjs$)|third_party\/|package\.json$|pnpm-lock\.yaml$|\.node-version$)/;
+          const nativePaths = /^(\.github\/workflows\/ci\.yml$|apps\/(macos-shell|stream-engine)\/|apps\/desktop\/src\/(native\/|player\/|intro\/|screens\/(PlayerScreen|MetaDetailsScreen|EpisodeSourcesScreen)\.tsx$|App\.(tsx|module\.css)$|core\/(actions|seasons)\.ts$|locales\/|components\/AudioTrackPicker\.tsx$|test\/(browser\/|resumeState\.ts$|coreState\.ts$))|scripts\/(build-engine\.sh|build-macos\.sh|check-engine-|check-macos-|check-intro-community\.mjs$|test-support\/|package-macos\.mjs$)|third_party\/|package\.json$|pnpm-lock\.yaml$|\.node-version$)/;
           // Inputs to the packaged bundle and the notices it carries. On a pull
           // request the packaging step runs only for these; every push to main
           // packages regardless, so a release artifact is never first built at
@@ -175,6 +175,7 @@ jobs:
           pnpm macos:check-scale
           pnpm macos:check-focus
           pnpm macos:check-resume
+          pnpm macos:check-intro
           pnpm macos:check-seasons
           pnpm macos:check-fullscreen
           pnpm macos:check-volume

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ KINO_LIFETIME_MEDIA="$PWD/build/fixtures/h264-sdr-aac.mp4" \
 
 Direct media uses the add-on's original HTTPS URL and required request headers in libmpv, independent of any Stremio Service URL saved in the account. TLS certificate verification is required. The native header check drives the production WebChannel and player through a protected media request, external subtitles, and a second source. It verifies literal header values, prevents headers from carrying into subtitles or later sources, rejects header injection and untrusted certificates, and checks diagnostic output for synthetic credentials. It uses `openssl` for the untrusted certificate and generates a short H.264 fixture with `ffmpeg`, or uses `KINO_PLAYBACK_FIXTURE` when provided.
 
+Community intro markers require an exact known runtime. `pnpm intro:check` exercises the bundled client against HTTP fixtures, and `pnpm macos:check-intro` repeats the match and cancellation checks in Qt WebEngine.
+
 ### Streaming engine
 
 Torrent sources play through a pinned build of the open [stream-server](https://github.com/stremio-native/stream-server) engine, which the shell starts on demand and binds to loopback. It is optional: without it Kino runs normally and reports torrent sources as unavailable. Build and bundle it with:

--- a/apps/desktop/src/intro/markers.ts
+++ b/apps/desktop/src/intro/markers.ts
@@ -1,4 +1,4 @@
-import { createIntroDbClient, type NormalizedSegmentTimestamp } from 'theintrodb';
+import { buildMediaQuery, parseMediaResponse, type NormalizedSegmentTimestamp } from 'theintrodb';
 
 export interface Chapter {
   endMs: number;
@@ -22,7 +22,6 @@ export interface IntroMarker {
   startMs: number;
 }
 
-const introDb = createIntroDbClient();
 const INTRO_LABEL = /^(intro|introduction|opening|opening credits|op)$/i;
 
 function validBounds(startMs: number, endMs: number, durationMs: number) {
@@ -66,9 +65,7 @@ export function markerFromCommunity(
   candidates: NormalizedSegmentTimestamp[],
   durationMs: number,
 ): IntroMarker | null {
-  // The public API returns one already-weighted segment per type with no
-  // confidence or submission fields, so trust rests on the bounds checks and
-  // on the duration matching the service performs against `duration_ms`.
+  // Runtime selection is checked before these normalized segment bounds.
   const candidate = candidates.find(
     (segment) => segment.endMs !== null && validBounds(segment.startMs, segment.endMs, durationMs),
   );
@@ -77,20 +74,84 @@ export function markerFromCommunity(
     : { source: 'theintrodb', startMs: candidate.startMs, endMs: candidate.endMs };
 }
 
+const MAX_RESPONSE_BYTES = 64 * 1024;
+const MAX_VERSIONS = 512;
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+async function readMedia(query: URLSearchParams, signal: AbortSignal): Promise<unknown> {
+  const response = await fetch(`https://api.theintrodb.org/v3/media?${query}`, {
+    signal,
+    credentials: 'omit',
+    redirect: 'error',
+    referrerPolicy: 'no-referrer',
+    headers: { Accept: 'application/json' },
+  });
+  if (!response.ok || !response.body) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new Error('Intro lookup unavailable');
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder('utf-8', { fatal: true });
+  let length = 0;
+  let text = '';
+  try {
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      length += chunk.value.byteLength;
+      if (length > MAX_RESPONSE_BYTES) throw new Error('Intro response too large');
+      text += decoder.decode(chunk.value, { stream: true });
+    }
+    return JSON.parse(text + decoder.decode()) as unknown;
+  } finally {
+    await reader.cancel().catch(() => undefined);
+    reader.releaseLock();
+  }
+}
+
 export async function lookupCommunityIntro(
   identity: IntroIdentity,
   signal?: AbortSignal,
 ): Promise<IntroMarker | null> {
   if (!identity.tmdbId && !identity.imdbId) return null;
-  const media = await introDb.getMedia(
-    {
-      durationMs: identity.durationMs,
-      ...(identity.episode === undefined ? {} : { episode: identity.episode }),
-      ...(identity.imdbId === undefined ? {} : { imdbId: identity.imdbId }),
-      ...(identity.season === undefined ? {} : { season: identity.season }),
-      ...(identity.tmdbId === undefined ? {} : { tmdbId: identity.tmdbId }),
-    },
-    { signal },
-  );
-  return markerFromCommunity(media.intro, identity.durationMs);
+  if (!Number.isSafeInteger(identity.durationMs) || identity.durationMs <= 0) return null;
+  const requestSignal = AbortSignal.any([...(signal ? [signal] : []), AbortSignal.timeout(5000)]);
+  try {
+    const query = buildMediaQuery(identity);
+    query.set('list_versions', 'true');
+    const versions = await readMedia(query, requestSignal);
+    if (!record(versions) || !Array.isArray(versions.versions)) return null;
+    const matchesIdentity = (media: ReturnType<typeof parseMediaResponse>) =>
+      media.type === (identity.season === undefined ? 'movie' : 'tv') &&
+      media.season === identity.season &&
+      media.episode === identity.episode &&
+      (identity.tmdbId === undefined || media.tmdbId === identity.tmdbId);
+    const listed = parseMediaResponse(versions);
+    if (!matchesIdentity(listed) || versions.versions.length > MAX_VERSIONS) return null;
+    const runtimes = versions.versions.map((version: unknown) =>
+      record(version) ? version.duration_ms : undefined,
+    );
+    if (
+      runtimes.some(
+        (runtime) => typeof runtime !== 'number' || !Number.isSafeInteger(runtime) || runtime < 0,
+      )
+    )
+      return null;
+    // The service deliberately falls back to another release when no runtime
+    // matches. Its version list lets Kino reject that fallback before reading
+    // markers. The zero-runtime bucket is unknown and never qualifies.
+    if (runtimes.filter((runtime) => runtime === identity.durationMs).length !== 1) return null;
+    query.delete('list_versions');
+    query.set('merge_unknown', 'false');
+    const media = parseMediaResponse(await readMedia(query, requestSignal));
+    if (!matchesIdentity(media) || media.tmdbId !== listed.tmdbId) return null;
+    requestSignal.throwIfAborted();
+    return markerFromCommunity(media.intro, identity.durationMs);
+  } catch {
+    if (signal?.aborted) throw new DOMException('Intro lookup canceled', 'AbortError');
+    return null;
+  }
 }

--- a/apps/desktop/src/screens/PlayerScreen.tsx
+++ b/apps/desktop/src/screens/PlayerScreen.tsx
@@ -174,7 +174,11 @@ export function PlayerScreen({
     toggle: toggleFullscreen,
   } = useFullscreen(containerRef, nativePlayer);
   const [chapterCues, setChapterCues] = useState<ChapterCue[]>([]);
-  const [communityMarker, setCommunityMarker] = useState<IntroMarker | null>(null);
+  const [communityLookup, setCommunityLookup] = useState<{
+    selection: PlaybackSelection;
+    duration: number;
+    marker: IntroMarker | null;
+  } | null>(null);
   const [automaticSkipComplete, setAutomaticSkipComplete] = useState(false);
   const [automaticNotice, setAutomaticNotice] = useState(false);
   const [audioTracks, setAudioTracks] = useState<AudioTrack[]>([]);
@@ -257,6 +261,10 @@ export function PlayerScreen({
     () => markerFromChapterCues(chapterCues, duration),
     [chapterCues, duration],
   );
+  const communityMarker =
+    communityLookup?.selection === selection && communityLookup.duration === duration
+      ? communityLookup.marker
+      : null;
   const marker = chapterMarker ?? communityMarker;
   const nearEnd =
     Number.isFinite(duration) &&
@@ -804,7 +812,8 @@ export function PlayerScreen({
     const controller = new AbortController();
     void lookupCommunityIntro(introIdentity(selection, duration), controller.signal)
       .then((communityMarker) => {
-        setCommunityMarker(communityMarker);
+        if (controller.signal.aborted) return;
+        setCommunityLookup({ selection, duration, marker: communityMarker });
         console.info(
           communityMarker
             ? '[kino:intro] trusted community marker'

--- a/docs/PLAYBACK.md
+++ b/docs/PLAYBACK.md
@@ -88,6 +88,10 @@ Marker resolution uses this order:
 
 The button exists only while the playhead is inside a trusted marker. Manual activation seeks to the marker end and shows no notice. Automatic skipping is off by default, triggers no more than once per segment in a playback session, and shows an “Intro skipped” notice with Undo. Undo seeks to the marker start and suppresses another automatic skip for that segment during the session.
 
+The community client first checks the available versions for one exact positive runtime, then requests that runtime with unknown-runtime submissions excluded. It checks media identity in both responses. Missing or ambiguous matches, invalid responses, redirects, canceled requests, and responses above 64 KiB produce no marker. A five-second deadline covers both requests. The service does not return a stable version ID or echo the selected runtime, so this selection check cannot detect a release change between the two responses.
+
+`pnpm intro:check`, included in `pnpm check`, bundles the production client and exercises it against HTTP fixtures. `pnpm macos:check-intro` also runs the bundle in Qt WebEngine, including a canceled response body.
+
 The timeline highlights a trusted intro range. Seeking into that range restores the manual button; seeking outside it removes the button immediately.
 
 ## Platform gates

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -45,7 +45,7 @@ Skip Intro is built in and enabled by default. Kino first uses explicit opening-
 
 Manual skipping seeks to the marker's end without showing a notice. Automatic intro skipping is a separate setting that is disabled by default. When enabled, an automatic skip shows a brief “Intro skipped” notice with Undo. Undo returns to the intro start and suppresses automatic skipping for that segment during the current playback session.
 
-Kino favors a missing button over skipping dialogue. Version one does not run local audio fingerprinting and does not provide any surface for submitting or correcting intro timestamps.
+Kino requests community markers only after the service lists the exact positive runtime. Unknown or unmatched runtimes leave the button hidden. Kino favors a missing button over skipping dialogue. Version one does not run local audio fingerprinting and does not provide any surface for submitting or correcting intro timestamps.
 
 ## Privacy and diagnostics
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "pnpm --filter @kino/desktop build",
-    "check": "pnpm format:check && pnpm lint && pnpm typecheck && pnpm test && pnpm core:check-contract && pnpm core:check-seasons && pnpm core:check-streams && pnpm core:check-pagination && pnpm core:check-subtitles && pnpm core:check-shutdown && pnpm core:check-addon-transports && pnpm engine:check-vendor && pnpm notices:check && pnpm build",
+    "check": "pnpm format:check && pnpm lint && pnpm typecheck && pnpm test && pnpm core:check-contract && pnpm core:check-seasons && pnpm core:check-streams && pnpm core:check-pagination && pnpm core:check-subtitles && pnpm core:check-shutdown && pnpm intro:check && pnpm core:check-addon-transports && pnpm engine:check-vendor && pnpm notices:check && pnpm build",
     "core:capture-fixtures": "node scripts/capture-core-fixtures.mjs",
     "core:check-seasons": "node scripts/check-core-seasons.mjs",
     "core:check-contract": "node scripts/check-core-contract.mjs",
@@ -53,7 +53,9 @@
     "notices:check": "node scripts/check-license-notices.mjs",
     "android:build": "python3 scripts/build-android.py",
     "android:run": "python3 scripts/run-android.py",
-    "android:check": "python3 scripts/check-android.py"
+    "android:check": "python3 scripts/check-android.py",
+    "intro:check": "node scripts/check-intro-community.mjs",
+    "macos:check-intro": "node scripts/check-intro-community.mjs --macos"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",

--- a/scripts/check-intro-community.mjs
+++ b/scripts/check-intro-community.mjs
@@ -1,0 +1,235 @@
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { createServer } from 'node:http';
+import { writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const { build } = await import(createRequire(resolve('apps/desktop/package.json')).resolve('vite'));
+const output = resolve('build/intro-community');
+await build({
+  configFile: false,
+  logLevel: 'warn',
+  build: {
+    outDir: output,
+    emptyOutDir: true,
+    lib: {
+      entry: resolve('apps/desktop/src/intro/markers.ts'),
+      formats: ['es'],
+      fileName: () => 'markers.js',
+    },
+  },
+});
+const { lookupCommunityIntro } = await import(pathToFileURL(resolve(output, 'markers.js')));
+const identity = { tmdbId: 1396, season: 1, episode: 1, durationMs: 3501000 };
+const media = { tmdb_id: 1396, type: 'tv', season: 1, episode: 1 };
+const marker = { source: 'theintrodb', startMs: 10000, endMs: 22000 };
+const listed = { ...media, versions: [{ duration_ms: 0 }, { duration_ms: identity.durationMs }] };
+const selected = { ...media, intro: [{ start_ms: 10000, end_ms: 22000 }] };
+const networkFetch = globalThis.fetch;
+let bodies = [];
+let requests = [];
+let hold;
+let bodyStarted;
+let delayedTimer;
+const server = createServer((request, response) => {
+  response.setHeader('Access-Control-Allow-Origin', '*');
+  requests.push(new URL(request.url, 'http://fixture.invalid').searchParams);
+  assert.equal(request.method, 'GET');
+  assert.equal(request.headers.authorization, undefined);
+  assert.equal(request.headers.cookie, undefined);
+  assert.equal(request.headers.referer, undefined);
+  const body = bodies.shift();
+  if (body === 'held') {
+    response.writeHead(200, { 'Content-Type': 'application/json' });
+    response.write('{');
+    hold = response;
+    bodyStarted.resolve();
+  } else if (body === 'delayed-list') {
+    response.writeHead(200, { 'Content-Type': 'application/json' });
+    response.flushHeaders();
+    delayedTimer = setTimeout(() => response.end(JSON.stringify(listed)), 2000);
+  } else if (body === 'redirect') {
+    response.writeHead(302, { Location: '/forbidden' }).end();
+  } else {
+    response.writeHead(200, { 'Content-Type': 'application/json' });
+    response.end(typeof body === 'string' ? body : JSON.stringify(body));
+  }
+});
+try {
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  globalThis.fetch = (url, options) => {
+    const original = new URL(url);
+    assert.equal(original.origin + original.pathname, 'https://api.theintrodb.org/v3/media');
+    assert.equal(options.credentials, 'omit');
+    assert.equal(options.referrerPolicy, 'no-referrer');
+    assert.equal(options.redirect, 'error');
+    assert.deepEqual(Object.keys(options.headers), ['Accept']);
+    return networkFetch(`http://127.0.0.1:${server.address().port}/${original.search}`, options);
+  };
+  async function lookup(first = listed, second = selected, input = identity) {
+    requests = [];
+    bodies = [first, second];
+    return lookupCommunityIntro(input);
+  }
+  assert.deepEqual(await lookup(), marker);
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0].get('list_versions'), 'true');
+  assert.equal(requests[1].get('list_versions'), null);
+  assert.equal(requests[1].get('duration_ms'), String(identity.durationMs));
+  assert.equal(requests[1].get('merge_unknown'), 'false');
+  assert.deepEqual([...requests[1].keys()].sort(), [
+    'duration_ms',
+    'episode',
+    'merge_unknown',
+    'season',
+    'tmdb_id',
+  ]);
+
+  for (const durationMs of [0, 1000000, identity.durationMs + 1, NaN, 1.5]) {
+    assert.equal(await lookup(listed, selected, { ...identity, durationMs }), null);
+    assert.ok(
+      requests.length <= 1,
+      'An unmatched runtime never asks the service for fallback markers',
+    );
+  }
+  for (const versions of [
+    undefined,
+    [{ duration_ms: 0 }],
+    [{ duration_ms: '3501000' }],
+    [{ duration_ms: identity.durationMs }, { duration_ms: identity.durationMs }],
+    Array.from({ length: 513 }, () => ({ duration_ms: 1 })),
+  ]) {
+    assert.equal(await lookup({ ...media, versions }), null);
+    assert.equal(requests.length, 1);
+  }
+  for (const invalid of [{ tmdb_id: 9 }, { type: 'movie' }, { season: 2 }, { episode: 2 }]) {
+    assert.equal(await lookup({ ...listed, ...invalid }), null);
+    assert.equal(requests.length, 1);
+    assert.equal(await lookup(listed, { ...selected, ...invalid }), null);
+  }
+  assert.deepEqual(
+    await lookup(listed, selected, {
+      imdbId: 'tt0903747',
+      season: 1,
+      episode: 1,
+      durationMs: identity.durationMs,
+    }),
+    marker,
+  );
+  assert.equal(
+    await lookup(
+      listed,
+      { ...selected, tmdb_id: 9 },
+      { imdbId: 'tt0903747', season: 1, episode: 1, durationMs: identity.durationMs },
+    ),
+    null,
+  );
+  for (const intro of [
+    [{ start_ms: 1, end_ms: null }],
+    [{ start_ms: -1, end_ms: 12000 }],
+    [{ start_ms: 10000, end_ms: 11000 }],
+    [{ start_ms: 0, end_ms: identity.durationMs + 1 }],
+  ]) {
+    assert.equal(await lookup(listed, { ...media, intro }), null);
+  }
+  assert.equal(await lookup('not json'), null);
+  assert.equal(await lookup('x'.repeat(65537)), null);
+  assert.equal(await lookup('redirect'), null);
+  assert.equal(requests.length, 1, 'Marker requests do not follow redirects');
+
+  requests = [];
+  bodies = [listed, 'held'];
+  bodyStarted = Promise.withResolvers();
+  const controller = new AbortController();
+  const canceled = lookupCommunityIntro(identity, controller.signal);
+  const rejection = assert.rejects(canceled, { name: 'AbortError' });
+  await bodyStarted.promise;
+  controller.abort();
+  await rejection;
+  hold.end('}');
+  requests = [];
+  bodies = ['delayed-list', 'held'];
+  bodyStarted = Promise.withResolvers();
+  const started = Date.now();
+  const deadline = lookupCommunityIntro(identity);
+  await bodyStarted.promise;
+  const bodyClosed = once(hold, 'close');
+  assert.equal(await deadline, null);
+  assert.equal(requests.length, 2);
+  const elapsed = Date.now() - started;
+  assert.ok(
+    elapsed >= 4500 && elapsed < 6500,
+    'One five-second budget covers the delayed version list and held marker body',
+  );
+  await bodyClosed;
+  assert.equal(hold.writableEnded, false, 'The timeout cancels the unfinished response body');
+  console.log(`Both intro requests exhausted their shared deadline after ${elapsed} ms.`);
+  console.log(
+    'Bundled intro client rejected mismatched runtimes, invalid identity, ambiguous versions, unsafe bounds, oversized responses, redirects, and canceled response bodies.',
+  );
+  if (process.argv.includes('--macos')) {
+    globalThis.fetch = networkFetch;
+    const { withWebEngine } = await import('./test-support/webengine.mjs');
+    await writeFile(
+      resolve(output, 'index.html'),
+      `<!doctype html><html><head></head><body><script type="module">
+      import { lookupCommunityIntro } from './markers.js';
+      const networkFetch = window.fetch.bind(window);
+      window.fetch = (url, options) => {
+        const original = new URL(url);
+        if (original.origin + original.pathname !== 'https://api.theintrodb.org/v3/media') throw new Error('Unexpected intro destination');
+        return networkFetch('http://127.0.0.1:${server.address().port}/' + original.search, options);
+      };
+      window.kinoIntroProbe = { lookup: lookupCommunityIntro };
+    </script></body></html>`,
+    );
+    await withWebEngine(output, '/', async ({ command, evaluate, until }) => {
+      await until(() => evaluate('Boolean(window.kinoIntroProbe)'), 'bundled intro client');
+      async function browserLookup() {
+        const result = await command('Runtime.evaluate', {
+          expression: `window.kinoIntroProbe.lookup(${JSON.stringify(identity)})`,
+          awaitPromise: true,
+          returnByValue: true,
+        });
+        assert.equal(result.exceptionDetails, undefined);
+        return result.result.value;
+      }
+      requests = [];
+      bodies = [listed, selected];
+      assert.deepEqual(await browserLookup(), marker);
+      assert.equal(requests.length, 2);
+      bodies = [{ ...media, versions: [{ duration_ms: identity.durationMs + 1 }] }];
+      requests = [];
+      assert.equal(await browserLookup(), null);
+      assert.equal(requests.length, 1);
+      bodies = [listed, 'held'];
+      bodyStarted = Promise.withResolvers();
+      await evaluate(`
+        window.kinoIntroProbe.controller = new AbortController();
+        window.kinoIntroProbe.pending = window.kinoIntroProbe.lookup(${JSON.stringify(identity)}, window.kinoIntroProbe.controller.signal)
+          .then(() => 'resolved', error => error.name);
+      `);
+      await bodyStarted.promise;
+      await evaluate('window.kinoIntroProbe.controller.abort()');
+      const canceled = await command('Runtime.evaluate', {
+        expression: 'window.kinoIntroProbe.pending',
+        awaitPromise: true,
+        returnByValue: true,
+      });
+      assert.equal(canceled.result.value, 'AbortError');
+      hold.end('}');
+      console.log(
+        'Qt WebEngine accepted only the exact runtime and canceled the held marker response.',
+      );
+    });
+  }
+} finally {
+  clearTimeout(delayedTimer);
+  hold?.destroy();
+  globalThis.fetch = networkFetch;
+  server.closeAllConnections();
+  await new Promise((done) => server.close(done));
+}


### PR DESCRIPTION
TheIntroDB can return markers for a popular release when the requested runtime does not match. The desktop client previously trusted that fallback, so a duration-valid intro could still belong to another cut.

The client now requires one exact positive runtime in the version list before requesting markers, excludes unknown-runtime submissions, and validates media identity in both responses. Both requests share a five-second deadline and a 64 KiB response limit. Requests omit credentials and referrers, reject redirects, and cancel unfinished bodies. A result remains tied to its playback selection and duration.

This corrects the existing desktop behavior before implementing the same trust rule for the TV work in #160. That issue remains open. The public API does not echo a stable version ID or selected runtime, so the documented check cannot detect a release change between the two responses.

Validation:

- `pnpm check`: 245 tests, the real Core gates, formatting, lint, typecheck, and production build passed. The new bundled HTTP gate covers exact and mismatched runtimes, unknown and duplicate versions, identity changes, invalid bounds, response limits, redirects, cancellation, and the shared deadline. The delayed two-request case ended after 5,002 ms.
- `pnpm macos:check-intro`: the production client bundle passed exact-match, mismatch, and held-body cancellation checks in Qt WebEngine. Native CI now runs this gate and selects the job for intro-only changes.
- `pnpm macos:build` and `pnpm macos:check-launch`: the local app bundle rebuilt and stayed healthy through launch.
- Both review axes are clear after adding the CI input paths and deadline gate.

Document audit: updated README, PRODUCT, and PLAYBACK. ADR 0004's strict matching decision remains unchanged. CONTEXT and ANDROID-TV remain accurate; this chunk does not add the TV player controls.
