### PR TITLE
Say "Sign in with Stremio" on desktop

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import { App } from './App';
+import { t as enUS } from './locales';
 import { SETTINGS_STORAGE_KEY } from './settings';
 
 describe('App', () => {
@@ -72,9 +73,9 @@ describe('App', () => {
     const user = userEvent.setup();
     render(<App />);
 
-    await user.click(screen.getByRole('button', { name: 'Sign in to Stremio' }));
+    await user.click(screen.getByRole('button', { name: enUS.account.signInTitle }));
 
-    expect(screen.getByRole('dialog', { name: 'Sign in to Stremio' })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: enUS.account.signInTitle })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Create account' })).toHaveAttribute(
       'href',
       'https://www.stremio.com/register',
@@ -82,8 +83,10 @@ describe('App', () => {
 
     fireEvent(screen.getByRole('dialog'), new Event('cancel', { cancelable: true }));
 
-    expect(screen.queryByRole('dialog', { name: 'Sign in to Stremio' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('dialog', { name: enUS.account.signInTitle }),
+    ).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Home' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Sign in to Stremio' })).toHaveFocus();
+    expect(screen.getByRole('button', { name: enUS.account.signInTitle })).toHaveFocus();
   });
 });

--- a/apps/desktop/src/core/CoreProvider.recovery.test.tsx
+++ b/apps/desktop/src/core/CoreProvider.recovery.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 
 import { App } from '../App';
 import { CoreRecovery } from '../components/CoreRecovery';
+import { t as enUS } from '../locales';
 import { profile } from '../test/coreState';
 import { CoreProvider } from './CoreProvider';
 import { useCore } from './context';
@@ -138,7 +139,7 @@ it('shows account initialization failures with retry and a working guest escape'
     </CoreProvider>,
   );
   await waitFor(() => expect(control.init).toHaveBeenCalledWith('guest'));
-  fireEvent.click(screen.getByRole('button', { name: 'Sign in to Stremio' }));
+  fireEvent.click(screen.getByRole('button', { name: enUS.account.signInTitle }));
   const dialog = within(screen.getByRole('dialog'));
   expect(await dialog.findByRole('alert')).toHaveTextContent('Account storage unavailable.');
   expect(dialog.queryByRole('button', { name: 'Preparing account…' })).not.toBeInTheDocument();

--- a/apps/desktop/src/locales/en-US.ts
+++ b/apps/desktop/src/locales/en-US.ts
@@ -36,7 +36,7 @@ export const enUS = {
   },
   account: {
     title: 'Stremio account',
-    signInTitle: 'Sign in to Stremio',
+    signInTitle: 'Sign in with Stremio',
     signedIn: 'Signed in',
     signOut: 'Sign out',
     description: 'Your credentials go directly to Stremio. Kino keeps guest activity separate.',


### PR DESCRIPTION
Kino signs the account in against Stremio rather than opening Stremio, and the TV welcome copy already said "with". This makes the desktop wording match.

The string labels both the sidebar button and the sign-in dialog, so both change together.

Two tests asserted the literal old string. They now read it from the locale, which is what `HomeScreen.coreFailure.test.tsx` already does, so the next wording change does not break them.

`pnpm format:check`, `pnpm lint`, `pnpm typecheck` and the desktop suite pass. Confirmed in the running client: the sidebar button and the dialog heading both read "Sign in with Stremio".